### PR TITLE
audiounit: Support both signed 16bit and float stereo panning.

### DIFF
--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -159,7 +159,10 @@ audiounit_output_callback(void * user_ptr, AudioUnitRenderActionFlags * flags,
   pthread_mutex_unlock(&stm->mutex);
 
   if (stm->sample_spec.mChannelsPerFrame == 2) {
-    cubeb_pan_stereo_buffer_float((float*)buf, got, panning);
+    if (stm->sample_spec.mFormatFlags & kAudioFormatFlagIsFloat)
+      cubeb_pan_stereo_buffer_float((float*)buf, got, panning);
+    else if (stm->sample_spec.mFormatFlags & kAudioFormatFlagIsSignedInteger)
+      cubeb_pan_stereo_buffer_int((short*)buf, got, panning);
   }
 
   return noErr;


### PR DESCRIPTION
I found that running test/test_audio would crash running on OS X with audiounit backend due to the fact that stereo panning is done on float samples only.

Running under valgrind:
```
Testing: volume
Volume: 0%
Volume: 25%
Volume: 50%
Volume: 75%
Volume: 100%
Testing: panning
Panning: -1.00%
==27784== Thread 7 com.apple.audio.IOThread.client:
==27784== Invalid read of size 4
==27784==    at 0x100018D10: cubeb_pan_stereo_buffer_float (in /$SRCDIR/cubeb/src/.libs/libcubeb.0.dylib)
==27784==    by 0x10001A013: audiounit_output_callback (in /$SRCDIR/cubeb/src/.libs/libcubeb.0.dylib)
==27784==    by 0x10916E73A: AUInputElement::PullInput(unsigned int&, AudioTimeStamp const&, unsigned int, unsigned int) (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x10916DFBF: AUInputFormatConverter2::InputProc(OpaqueAudioConverter*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription**, void*) (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x10006A358: AudioConverterChain::CallInputProc(unsigned int) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10006A0DF: AudioConverterChain::FillBufferFromInputProc(unsigned int*, CABufferList*) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10006A04E: BufferedAudioConverter::GetInputBytes(unsigned int, unsigned int&, CABufferList const*&) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x100069F0F: CBRConverter::RenderOutput(CABufferList*, unsigned int, unsigned int&, AudioStreamPacketDescription*) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10005DF2C: BufferedAudioConverter::FillBuffer(unsigned int&, AudioBufferList&, AudioStreamPacketDescription*) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10005E1A8: AudioConverterChain::RenderOutput(CABufferList*, unsigned int, unsigned int&, AudioStreamPacketDescription*) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10005DF2C: BufferedAudioConverter::FillBuffer(unsigned int&, AudioBufferList&, AudioStreamPacketDescription*) (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==    by 0x10005DBB6: AudioConverterFillComplexBuffer (in /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox)
==27784==  Address 0x1065eb274 is 4 bytes after a block of size 2,048 alloc'd
==27784==    at 0x1000094AB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==27784==    by 0x10054F036: reallocf (in /usr/lib/system/libsystem_c.dylib)
==27784==    by 0x1091B72DB: AUBufferList::Allocate(CAStreamBasicDescription const&, unsigned int) (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x1091675BE: AUBase::ReallocateBuffers() (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x1091676EA: AUBase::DoInitialize() (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x10921EE45: AUMethodInitialize(void*) (in /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio)
==27784==    by 0x100019A8B: audiounit_stream_init (in /$SRCDIR/cubeb/src/.libs/libcubeb.0.dylib)
==27784==    by 0x1000017BB: run_panning_volume_test() (in test/.libs/test_audio)
==27784==    by 0x100001BA8: main (in test/.libs/test_audio)
```