### PR TITLE
Try to connect to JACK before PulseAudio.

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -92,11 +92,11 @@ int
 cubeb_init(cubeb ** context, char const * context_name)
 {
   int (* init[])(cubeb **, char const *) = {
-#if defined(USE_PULSE)
-    pulse_init,
-#endif
 #if defined(USE_JACK)
     jack_init,
+#endif
+#if defined(USE_PULSE)
+    pulse_init,
 #endif
 #if defined(USE_ALSA)
     alsa_init,


### PR DESCRIPTION
Some systems have a PulseAudio server running above JACK. This patch ensure that JACK will be preferably used on systems where both APIs are available. On JACK-less systems, it should have no effect.