### PR TITLE
Signature changes for stream init and data callback

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -261,7 +261,7 @@ typedef struct {
             and the stream will enter a shutdown state. */
 typedef long (* cubeb_data_callback)(cubeb_stream * stream,
                                      void * user_ptr,
-                                     void * input_buffer,
+                                     const void * input_buffer,
                                      void * output_buffer,
                                      long nframes);
 
@@ -337,8 +337,12 @@ void cubeb_destroy(cubeb * context);
     @param context
     @param stream
     @param stream_name
+    @param input_device_name Device for the input side of the stream. If NULL
+                             default input device is used.
     @param input_stream_params Parameters for the input side of the stream, or
                                NULL if this stream is output only.
+    @param output_device_name Device for the input side of the stream. If NULL
+                              default output device is used.
     @param output_stream_params Parameters for the output side of the stream, or
                                 NULL if this stream is input only.
     @param latency Approximate stream latency in milliseconds.  Valid range
@@ -353,7 +357,9 @@ void cubeb_destroy(cubeb * context);
 int cubeb_stream_init(cubeb * context,
                       cubeb_stream ** stream,
                       char const * stream_name,
+                      char const * input_device_name,
                       cubeb_stream_params * input_stream_params,
+                      char const * output_device_name,
                       cubeb_stream_params * output_stream_params,
                       unsigned int latency,
                       cubeb_data_callback data_callback,

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -23,7 +23,9 @@ struct cubeb_ops {
                             cubeb_device_collection ** collection);
   void (* destroy)(cubeb * context);
   int (* stream_init)(cubeb * context, cubeb_stream ** stream, char const * stream_name,
+                      char const * input_device_name,
                       cubeb_stream_params * input_stream_params,
+                      char const * output_device_name,
                       cubeb_stream_params * output_stream_params,
                       unsigned int latency,
                       cubeb_data_callback data_callback,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -241,7 +241,9 @@ cubeb_destroy(cubeb * context)
 
 int
 cubeb_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_name,
+                  char const * input_device_name,
                   cubeb_stream_params * input_stream_params,
+                  char const * output_device_name,
                   cubeb_stream_params * output_stream_params,
                   unsigned int latency,
                   cubeb_data_callback data_callback,
@@ -260,7 +262,11 @@ cubeb_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_n
   }
 
   return context->ops->stream_init(context, stream, stream_name,
-                                   input_stream_params, output_stream_params, latency,
+                                   input_device_name,
+                                   input_stream_params,
+                                   output_device_name,
+                                   output_stream_params,
+                                   latency,
                                    data_callback,
                                    state_callback,
                                    user_ptr);

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -781,7 +781,9 @@ static void alsa_stream_destroy(cubeb_stream * stm);
 
 static int
 alsa_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name,
+                 char const * input_device_name,
                  cubeb_stream_params * input_stream_params,
+                 char const * output_device_name,
                  cubeb_stream_params * output_stream_params,
                  unsigned int latency,
                  cubeb_data_callback data_callback, cubeb_state_callback state_callback,
@@ -937,7 +939,7 @@ alsa_get_max_channel_count(cubeb * ctx, uint32_t * max_channels)
 
   assert(ctx);
 
-  r = alsa_stream_init(ctx, &stm, "", NULL, &params, 100, NULL, NULL, NULL);
+  r = alsa_stream_init(ctx, &stm, "", NULL, NULL, NULL, &params, 100, NULL, NULL, NULL);
   if (r != CUBEB_OK) {
     return CUBEB_ERROR;
   }

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -278,7 +278,9 @@ audiotrack_destroy(cubeb * context)
 
 int
 audiotrack_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name,
+                       char const * input_device_name,
                        cubeb_stream_params * input_stream_params,
+                       char const * output_device_name,
                        cubeb_stream_params * output_stream_params,
                        unsigned int latency,
                        cubeb_data_callback data_callback,

--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -539,7 +539,9 @@ static void audiounit_stream_destroy(cubeb_stream * stm);
 
 static int
 audiounit_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_name,
+                      char const * input_device_name,
                       cubeb_stream_params * input_stream_params,
+                      char const * output_device_name,
                       cubeb_stream_params * output_stream_params,
                       unsigned int latency,
                       cubeb_data_callback data_callback, cubeb_state_callback state_callback,

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -465,7 +465,9 @@ static void opensl_stream_destroy(cubeb_stream * stm);
 
 static int
 opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name,
+                   char const * input_device_name,
                    cubeb_stream_params * input_stream_params,
+                   char const * output_device_name,
                    cubeb_stream_params * output_stream_params,
                    unsigned int latency,
                    cubeb_data_callback data_callback, cubeb_state_callback state_callback,

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -487,7 +487,9 @@ static void pulse_stream_destroy(cubeb_stream * stm);
 
 static int
 pulse_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_name,
+                  char const * input_device_name,
                   cubeb_stream_params * input_stream_params,
+                  char const * output_device_name,
                   cubeb_stream_params * output_stream_params,
                   unsigned int latency,
                   cubeb_data_callback data_callback, cubeb_state_callback state_callback,

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -170,10 +170,12 @@ sndio_destroy(cubeb *context)
 }
 
 static int
-sndio_stream_init(cubeb *context,
-                  cubeb_stream **stream,
-                  char const *stream_name,
+sndio_stream_init(cubeb * context,
+                  cubeb_stream ** stream,
+                  char const * stream_name,
+                  char const * input_device_name,
                   cubeb_stream_params * input_stream_params,
+                  char const * output_device_name,
                   cubeb_stream_params * output_stream_params,
                   unsigned int latency,
                   cubeb_data_callback data_callback,

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013 Mozilla Foundation
+ * Copyright ï¿½ 2013 Mozilla Foundation
  *
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
@@ -1202,7 +1202,9 @@ int setup_wasapi_stream(cubeb_stream * stm)
 int
 wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
                    char const * stream_name,
+                   char const * input_device_name,
                    cubeb_stream_params * input_stream_params,
+                   char const * output_device_name,
                    cubeb_stream_params * output_stream_params,
                    unsigned int latency, cubeb_data_callback data_callback,
                    cubeb_state_callback state_callback, void * user_ptr)

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -380,7 +380,9 @@ static void winmm_stream_destroy(cubeb_stream * stm);
 
 static int
 winmm_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_name,
+                  char const * input_device_name,
                   cubeb_stream_params * input_stream_params,
+                  char const * output_device_name,
                   cubeb_stream_params * output_stream_params,
                   unsigned int latency,
                   cubeb_data_callback data_callback,

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -73,7 +73,7 @@ void synth_run_float(synth_state* synth, float* audiobuffer, long nframes)
   }
 }
 
-long data_cb_float(cubeb_stream *stream, void *user, void * inputbuffer, void *outputbuffer, long nframes)
+long data_cb_float(cubeb_stream *stream, void *user, const void * inputbuffer, void *outputbuffer, long nframes)
 {
   synth_state *synth = (synth_state *)user;
   synth_run_float(synth, (float*)outputbuffer, nframes);
@@ -92,7 +92,7 @@ void synth_run_16bit(synth_state* synth, short* audiobuffer, long nframes)
   }
 }
 
-long data_cb_short(cubeb_stream *stream, void *user, void * inputbuffer, void *outputbuffer, long nframes)
+long data_cb_short(cubeb_stream *stream, void *user, const void * inputbuffer, void *outputbuffer, long nframes)
 {
   synth_state *synth = (synth_state *)user;
   synth_run_16bit(synth, (short*)outputbuffer, nframes);
@@ -160,7 +160,7 @@ int run_test(int num_channels, int sampling_rate, int is_float)
     goto cleanup;
   }
 
-  r = cubeb_stream_init(ctx, &stream, "test tone", NULL, &params,
+  r = cubeb_stream_init(ctx, &stream, "test tone", NULL, NULL, NULL, &params,
                         100, is_float ? data_cb_float : data_cb_short, state_cb, synth);
   if (r != CUBEB_OK) {
     fprintf(stderr, "Error initializing cubeb stream: %d\n", r);
@@ -212,7 +212,7 @@ int run_panning_volume_test(int is_float)
     goto cleanup;
   }
 
-  r = cubeb_stream_init(ctx, &stream, "test tone", NULL, &params,
+  r = cubeb_stream_init(ctx, &stream, "test tone", NULL, NULL, NULL, &params,
                         100, is_float ? data_cb_float : data_cb_short, state_cb, synth);
   if (r != CUBEB_OK) {
     fprintf(stderr, "Error initializing cubeb stream: %d\n", r);

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -40,7 +40,7 @@ static uint64_t total_frames_written;
 static int delay_callback;
 
 static long
-test_data_callback(cubeb_stream * stm, void * user_ptr, void * inputbuffer, void * outputbuffer, long nframes)
+test_data_callback(cubeb_stream * stm, void * user_ptr, const void * inputbuffer, void * outputbuffer, long nframes)
 {
   assert(stm && user_ptr == &dummy && outputbuffer && nframes > 0);
   memset(outputbuffer, 0, nframes * sizeof(short));
@@ -159,7 +159,7 @@ test_init_destroy_stream(void)
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
 
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, &params, STREAM_LATENCY,
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                         test_data_callback, test_state_callback, &dummy);
   assert(r == 0 && stream);
 
@@ -188,7 +188,7 @@ test_init_destroy_multiple_streams(void)
   params.channels = STREAM_CHANNELS;
 
   for (i = 0; i < ARRAY_LENGTH(stream); ++i) {
-    r = cubeb_stream_init(ctx, &stream[i], "test", NULL, &params, STREAM_LATENCY,
+    r = cubeb_stream_init(ctx, &stream[i], "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                           test_data_callback, test_state_callback, &dummy);
     assert(r == 0);
     assert(stream[i]);
@@ -220,7 +220,7 @@ test_configure_stream(void)
   params.rate = STREAM_RATE;
   params.channels = 2; // panning
 
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, &params, STREAM_LATENCY,
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                         test_data_callback, test_state_callback, &dummy);
   assert(r == 0 && stream);
 
@@ -254,7 +254,7 @@ test_init_start_stop_destroy_multiple_streams(int early, int delay_ms)
   params.channels = STREAM_CHANNELS;
 
   for (i = 0; i < ARRAY_LENGTH(stream); ++i) {
-    r = cubeb_stream_init(ctx, &stream[i], "test", NULL, &params, STREAM_LATENCY,
+    r = cubeb_stream_init(ctx, &stream[i], "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                           test_data_callback, test_state_callback, &dummy);
     assert(r == 0);
     assert(stream[i]);
@@ -318,7 +318,7 @@ test_init_destroy_multiple_contexts_and_streams(void)
     assert(r == 0 && ctx[i]);
 
     for (j = 0; j < streams_per_ctx; ++j) {
-      r = cubeb_stream_init(ctx[i], &stream[i * streams_per_ctx + j], "test", NULL, &params, STREAM_LATENCY,
+      r = cubeb_stream_init(ctx[i], &stream[i * streams_per_ctx + j], "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                             test_data_callback, test_state_callback, &dummy);
       assert(r == 0);
       assert(stream[i * streams_per_ctx + j]);
@@ -353,7 +353,7 @@ test_basic_stream_operations(void)
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
 
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, &params, STREAM_LATENCY,
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                         test_data_callback, test_state_callback, &dummy);
   assert(r == 0 && stream);
 
@@ -402,7 +402,7 @@ test_stream_position(void)
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
 
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, &params, STREAM_LATENCY,
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                         test_data_callback, test_state_callback, &dummy);
   assert(r == 0 && stream);
 
@@ -475,7 +475,7 @@ static int do_drain;
 static int got_drain;
 
 static long
-test_drain_data_callback(cubeb_stream * stm, void * user_ptr, void * inputbuffer, void * outputbuffer, long nframes)
+test_drain_data_callback(cubeb_stream * stm, void * user_ptr, const void * inputbuffer, void * outputbuffer, long nframes)
 {
   assert(stm && user_ptr == &dummy && outputbuffer && nframes > 0);
   if (do_drain == 1) {
@@ -518,7 +518,7 @@ test_drain(void)
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
 
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, &params, STREAM_LATENCY,
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
                         test_drain_data_callback, test_drain_state_callback, &dummy);
   assert(r == 0 && stream);
 

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -34,7 +34,7 @@ struct cb_user_data {
   long position;
 };
 
-long data_cb(cubeb_stream *stream, void *user, void* inputbuffer, void *outputbuffer, long nframes)
+long data_cb(cubeb_stream *stream, void *user, const void* inputbuffer, void *outputbuffer, long nframes)
 {
   struct cb_user_data *u = (struct cb_user_data *)user;
 #if (defined(_WIN32) || defined(__WIN32__))
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
   }
   user_data->position = 0;
 
-  r = cubeb_stream_init(ctx, &stream, "Cubeb tone (mono)", NULL, &params,
+  r = cubeb_stream_init(ctx, &stream, "Cubeb tone (mono)", NULL, NULL, NULL, &params,
                         250, data_cb, state_cb, user_data);
   if (r != CUBEB_OK) {
     fprintf(stderr, "Error initializing cubeb stream\n");


### PR DESCRIPTION
Change on the signature of cubeb_stream_init to add the device input/output that will be connected. If NULL provided the default device should be chosen. 

Change on the signature for data_callback to make the input buffer const since it is not safe for some implementations to treat the buffer as non-const.