### PR TITLE
API change for device notifications

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -480,12 +480,14 @@ int cubeb_device_info_destroy(cubeb_device_info * info);
 /** Registers a callback which is called when the system detects
     a new device or a device is removed.
     @param context
+    @param devtype device type to include
     @param callback a function called whenever the system device list changes.
            Passing NULL allow to unregister a function
     @param user_ptr pointer to user specified data which will be present in
            subsequent callbacks.
     @retval CUBEB_ERROR_NOT_SUPPORTED */
 int cubeb_register_device_collection_changed(cubeb * context,
+                                       cubeb_device_type devtype,
                                        cubeb_device_collection_changed_callback callback,
                                        void * user_ptr);
 

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -435,6 +435,7 @@ int cubeb_device_info_destroy(cubeb_device_info * info)
 }
 
 int cubeb_register_device_collection_changed(cubeb * context,
+                                             cubeb_device_type devtype,
                                              cubeb_device_collection_changed_callback callback,
                                              void * user_ptr)
 {


### PR DESCRIPTION
This pull request contains the API changes for device notification.

Currently method cubeb_register_device_collection_changed() does not has a parameter to indicate whether to notify for collection changes on sinks, sources or both. This request introduces a new method parameter of type cubeb_device_type which allow the user to choose that:

CUBEB_DEVICE_TYPE_INPUT --> for sources
CUBEB_DEVICE_TYPE_OUTPUT --> for sinks
CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT --> for both sinks and sources

This is a similar logic that applies in the cubeb_enumerate_devices() method.
Thanks!