### PR TITLE
Clear callbacks before disconnecting pulse streams

### DIFF
--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -817,12 +817,14 @@ pulse_stream_destroy(cubeb_stream * stm)
     }
 
     WRAP(pa_stream_set_state_callback)(stm->output_stream, NULL, NULL);
+    WRAP(pa_stream_set_write_callback)(stm->output_stream, NULL, NULL);
     WRAP(pa_stream_disconnect)(stm->output_stream);
     WRAP(pa_stream_unref)(stm->output_stream);
   }
 
   if (stm->input_stream) {
     WRAP(pa_stream_set_state_callback)(stm->input_stream, NULL, NULL);
+    WRAP(pa_stream_set_read_callback)(stm->input_stream, NULL, NULL);
     WRAP(pa_stream_disconnect)(stm->input_stream);
     WRAP(pa_stream_unref)(stm->input_stream);
   }


### PR DESCRIPTION
Alex's patch.  Comment from Ford_Prefect in IRC:
[20:42]	Ford_Prefect	achronop: your patch is actually correct (setting the data callback to NULL)
[20:43]	Ford_Prefect	achronop: padenot: jesup: basically you're setting disconnecting the stream (which is async) and then free'ing stm -- any pending data callbacks will still come through when you unlock the threaded mainloop there, which is what could cause that problem
[20:45]	Ford_Prefect	achronop: padenot: jesup: so either you wait till you see the stream state change to PA_STREAM_TERMINATED before freeing things, or disconnect all callbacks
[20:46]	Ford_Prefect	s/setting// in the previous line

@padenot @achronop 