### PR TITLE
Fix link error on test_resampler build.

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -33,27 +33,6 @@ to_speex_quality(cubeb_resampler_quality q)
   }
 }
 
-template<typename T>
-cubeb_resampler_speex_one_way<T>::cubeb_resampler_speex_one_way(uint32_t channels,
-                                                                uint32_t source_rate,
-                                                                uint32_t target_rate,
-                                                                int quality)
-  : processor(channels)
-  , resampling_ratio(static_cast<float>(source_rate) / target_rate)
-  , additional_latency(0)
-{
-  int r;
-  speex_resampler = speex_resampler_init(channels, source_rate,
-                                         target_rate, quality, &r);
-  assert(r == RESAMPLER_ERR_SUCCESS && "resampler allocation failure");
-}
-
-template<typename T>
-cubeb_resampler_speex_one_way<T>::~cubeb_resampler_speex_one_way()
-{
-  speex_resampler_destroy(speex_resampler);
-}
-
 long noop_resampler::fill(void * input_buffer, long * input_frames_count,
                           void * output_buffer, long output_frames)
 {

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Mozilla Foundation
+ * Copyright Â© 2016 Mozilla Foundation
  *
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
@@ -31,9 +31,6 @@ namespace std
 /* This header file contains the internal C++ API of the resamplers, for testing. */
 
 int to_speex_quality(cubeb_resampler_quality q);
-
-template<typename T>
-class cubeb_resampler_speex_one_way;
 
 struct cubeb_resampler {
   virtual long fill(void * input_buffer, long * input_frames_count,
@@ -155,10 +152,22 @@ public:
   cubeb_resampler_speex_one_way(uint32_t channels,
                                 uint32_t source_rate,
                                 uint32_t target_rate,
-                                int quality);
+                                int quality)
+  : processor(channels)
+  , resampling_ratio(static_cast<float>(source_rate) / target_rate)
+  , additional_latency(0)
+  {
+    int r;
+    speex_resampler = speex_resampler_init(channels, source_rate,
+                                           target_rate, quality, &r);
+    assert(r == RESAMPLER_ERR_SUCCESS && "resampler allocation failure");
+  }
 
   /** Destructor, deallocate the resampler */
-  virtual ~cubeb_resampler_speex_one_way();
+  virtual ~cubeb_resampler_speex_one_way()
+  {
+    speex_resampler_destroy(speex_resampler);
+  }
 
   /** Sometimes, it is necessary to add latency on one way of a two-way
    * resampler so that the stream are synchronized. This must be called only on

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Mozilla Foundation
+ * Copyright Â© 2016 Mozilla Foundation
  *
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
@@ -8,9 +8,6 @@
 #define OUTSIDE_SPEEX
 #define RANDOM_PREFIX speex
 
-#include "cubeb/cubeb.h"
-#include "cubeb_utils.h"
-#include "cubeb_resampler.h"
 #include "cubeb_resampler_internal.h"
 #include <assert.h>
 #include <stdio.h>
@@ -312,9 +309,10 @@ bool array_fuzzy_equal(const auto_array<T>& lhs, const auto_array<T>& rhs, T eps
 
   for (uint32_t i = 0; i < len; i++) {
     if (abs(lhs.at(i) - rhs.at(i)) > epsi) {
-      std::cout << "not fuzzy equal at index " << i
-                << "lhs: " << lhs.at(i) <<  " rhs: " << rhs.at(i)
-                << "delta: " << abs(lhs.at(i) - rhs.at(i)) << std::endl;
+      std::cout << "not fuzzy equal at index: " << i
+                << " lhs: " << lhs.at(i) <<  " rhs: " << rhs.at(i)
+                << " delta: " << abs(lhs.at(i) - rhs.at(i))
+                << " epsilon: "<< epsi << std::endl;
       return false;
     }
   }
@@ -430,7 +428,7 @@ void test_resamplers_duplex()
         for (uint32_t source_rate_output = 0; source_rate_output < array_size(sample_rates); source_rate_output++) {
           for (uint32_t dest_rate = 0; dest_rate < array_size(sample_rates); dest_rate++) {
             for (uint32_t chunk_duration = min_chunks; chunk_duration < max_chunks; chunk_duration+=chunk_increment) {
-              printf("input chanenls:%d output_channels:%d input_rate:%d"
+              printf("input chanenls:%d output_channels:%d input_rate:%d "
                      "output_rate:%d target_rate:%d chunk_ms:%d\n",
                      input_channels, output_channels,
                      sample_rates[source_rate_input],


### PR DESCRIPTION
The PR solves link error on build of test_resampler on MAC. It also adds a few spaces for pretty printing in test_resampler. The errors has been found during the testing of audiounit full-duplex implementation. 