### PR TITLE
Audiounit device change notifications

### DIFF
--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -1730,7 +1730,7 @@ audiounit_number_of_devices(cubeb_device_type devtype)
   }
 
   AudioObjectID devices[count];
-  ret = AudioObjectGetPropertyData(kAudioObjectSystemObject, &adr, 0, NULL, &size, (void *)&devices);
+  ret = AudioObjectGetPropertyData(kAudioObjectSystemObject, &adr, 0, NULL, &size, &devices);
   if (ret != noErr) {
     return 0;
   }
@@ -1742,7 +1742,7 @@ audiounit_number_of_devices(cubeb_device_type devtype)
   uint32_t dev_count = 0;
   for(uint32_t i = 0; i < count; ++i) {
     /* For device in the given scope channel must be > 0. */
-    dev_count += !!audiounit_get_channel_count(devices[i], scope);
+    dev_count += audiounit_get_channel_count(devices[i], scope) > 0;
   }
 
   return dev_count;


### PR DESCRIPTION
This PR is the implementation of device change notifications. The idea is that every time a device is plugged or unplugged the corresponding callback will be called.

One thing to note in the implementation is that Apple framework does not differentiate if the device is input or output device. I worked around this by keeping the number of devices in the desired type and compering with the new updated number. A second thing to note is that the current implementation does not accept multiply register of the notify callback without deregister the previous one. If that is not acceptable please let me know.

Thanks!