### PR TITLE
Fix more resampler issues

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -207,12 +207,12 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
     resampled_input =
       input_processor->output(output_frames_before_processing);
   } else {
-   resampled_input = nullptr;
+    resampled_input = nullptr;
   }
 
   got = data_callback(stream, user_ptr,
-                     resampled_input, out_unprocessed,
-                     output_frames_before_processing);
+                      resampled_input, out_unprocessed,
+                      output_frames_before_processing);
 
   output_processor->written(got);
 

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -4,6 +4,7 @@
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
  */
+#include <algorithm>
 #include <cmath>
 #include <cassert>
 #include <cstring>
@@ -66,7 +67,6 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   , stream(s)
   , data_callback(cb)
   , user_ptr(ptr)
-  , draining(false)
 {
   if (input_processor && output_processor) {
     // Add some delay on the processor that has the lowest delay so that the
@@ -134,17 +134,12 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
 
   }
 
+  output_processor->written(got);
+
+
   /* Process the output. If not enough frames have been returned from the
   * callback, drain the processors. */
-  if (got != output_frames_before_processing || draining) {
-    draining = true;
-    got = output_processor->drain(output_buffer, output_frames_needed);
-  } else {
-    output_processor->output(output_buffer, output_frames_needed);
-    got = output_frames_needed;
-  }
-
-  return got;
+  return output_processor->output(output_buffer, output_frames_needed);
 }
 
 template<typename T, typename InputProcessor, typename OutputProcessor>
@@ -199,40 +194,31 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
    * get the output data, and resample it to the number of frames needed by the
    * caller. */
 
-  if (!draining) {
-     output_frames_before_processing =
-       output_processor->input_needed_for_output(output_frames_needed);
-     /* fill directly the input buffer of the output processor to save a copy */
-     out_unprocessed =
-       output_processor->input_buffer(output_frames_before_processing);
+  output_frames_before_processing =
+    output_processor->input_needed_for_output(output_frames_needed);
+   /* fill directly the input buffer of the output processor to save a copy */
+  out_unprocessed =
+    output_processor->input_buffer(output_frames_before_processing);
 
-     if (in_buffer) {
-       /* process the input, and present exactly `output_frames_needed` in the
-       * callback. */
-       input_processor->input(in_buffer, *input_frames_count);
-       resampled_input =
-         input_processor->output(output_frames_before_processing);
-     } else {
-       resampled_input = nullptr;
-     }
+  if (in_buffer) {
+    /* process the input, and present exactly `output_frames_needed` in the
+    * callback. */
+    input_processor->input(in_buffer, *input_frames_count);
+    resampled_input =
+      input_processor->output(output_frames_before_processing);
+  } else {
+   resampled_input = nullptr;
+  }
 
-     got = data_callback(stream, user_ptr,
-                         resampled_input, out_unprocessed,
-                         output_frames_before_processing);
-   }
+  got = data_callback(stream, user_ptr,
+                     resampled_input, out_unprocessed,
+                     output_frames_before_processing);
 
+  output_processor->written(got);
 
   /* Process the output. If not enough frames have been returned from the
    * callback, drain the processors. */
-  if (got != output_frames_before_processing || draining) {
-    draining = true;
-    got = output_processor->drain(out_buffer, output_frames_needed);
-  } else {
-    output_processor->output(out_buffer, output_frames_needed);
-    got = output_frames_needed;
-  }
-
-  return got;
+  return output_processor->output(out_buffer, output_frames_needed);
 }
 
 /* Resampler C API */

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -467,8 +467,8 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
   if (output_params && (output_params->rate != target_rate)) {
     output_resampler.reset(
         new cubeb_resampler_speex_one_way<T>(output_params->channels,
-                                             output_params->rate,
                                              target_rate,
+                                             output_params->rate,
                                              to_speex_quality(quality)));
     if (!output_resampler) {
       return NULL;

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Mozilla Foundation
+ * Copyright Â© 2016 Mozilla Foundation
  *
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
@@ -158,6 +158,12 @@ public:
     length_ -= length;
 
     return true;
+  }
+
+  void set_length(size_t length)
+  {
+    assert(length <= capacity_);
+    length_ = length;
   }
 
 private:

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -144,6 +144,7 @@ void test_delay_lines(uint32_t delay_frames, uint32_t channels, uint32_t chunk_m
     uint32_t to_pop = std::min<uint32_t>(input.length(), chunk_length * channels);
     float * in = delay.input_buffer(to_pop / channels);
     input.pop(in, to_pop);
+    delay.written(to_pop / channels);
     output.push_silence(to_pop);
     delay.output(output.data() + output_offset, to_pop / channels);
     output_offset += to_pop;


### PR DESCRIPTION
I had to rework the draining sequence a bit to make it more like it was, and I found an horrible bug in the setup of the output resampler. I need to investigate why it was not caught by the test, and write more tests so that it can't happen again. I'll push a commit or two to do that tomorrow.