### PR TITLE
Declare constructor of processor and auto_array explicit

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -67,7 +67,7 @@ private:
 /** Base class for processors. This is just used to share methods for now. */
 class processor {
 public:
-  processor(uint32_t channels)
+  explicit processor(uint32_t channels)
     : channels(channels)
   {}
 protected:

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -37,7 +37,7 @@ template<typename T>
 class auto_array
 {
 public:
-  auto_array(uint32_t capacity = 0)
+  explicit auto_array(uint32_t capacity = 0)
     : data_(capacity ? new T[capacity] : nullptr)
     , capacity_(capacity)
     , length_(0)


### PR DESCRIPTION
Clear a build error found during the Static Checking Build of OS X 10.7