### PR TITLE
Correct gecko macros

### DIFF
--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -92,7 +92,7 @@ void state_cb(cubeb_stream *stream, void *user, cubeb_state state)
 int main(int argc, char *argv[])
 {
 #ifdef CUBEB_GECKO_BUILD
-  ScopedXPCOM xpcom("test_record");
+  ScopedXPCOM xpcom("test_duplex");
 #endif
 
   cubeb *ctx;

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -10,7 +10,7 @@
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -9,7 +9,7 @@
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
Change the version of _XOPEN_SOURCE used from 5 to 6. Version 5 caused compilation error in gecko. Also correct the xpcom scoped name of test_duplex.