### PR TITLE
Use the device ID to choose the device in cubeb_wasapi.cpp.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1614,9 +1614,11 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   stm->draining = false;
   if (input_stream_params) {
     stm->input_stream_params = *input_stream_params;
+    stm->input_device = input_device;
   }
   if (output_stream_params) {
     stm->output_stream_params = *output_stream_params;
+    stm->output_device = output_device;
   }
   stm->latency = latency;
   stm->volume = 1.0;


### PR DESCRIPTION
Somehow we missed this. I don't know yet how to write tests for this, I'm investigating kernel modules to insert in the machine during tests, but I haven't found a nice solution yet.