### PR TITLE
Input device change callback

### DIFF
--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -479,7 +479,7 @@ audiounit_install_device_changed_callback(cubeb_stream * stm)
      * headphone jack. */
     AudioObjectPropertyAddress alive_address = {
         kAudioDevicePropertyDataSource,
-        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyScopeOutput,
         kAudioObjectPropertyElementMaster
     };
 

--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -515,6 +515,26 @@ audiounit_install_device_changed_callback(cubeb_stream * stm)
   }
 
   if (stm->input_unit) {
+    /* This event will notify us when the data source on the input device changes. */
+    AudioDeviceID input_dev_id;
+    if (audiounit_get_input_device_id(&input_dev_id) != noErr) {
+      return CUBEB_ERROR;
+    }
+
+    AudioObjectPropertyAddress source_address = {
+        kAudioDevicePropertyDataSource,
+        kAudioObjectPropertyScopeInput,
+        kAudioObjectPropertyElementMaster
+    };
+
+    r = AudioObjectAddPropertyListener(input_dev_id,
+        &source_address,
+        &audiounit_property_listener_callback,
+        stm);
+    if (r != noErr) {
+      return CUBEB_ERROR;
+    }
+
     /* This event will notify us when the default input device changes. */
     AudioObjectPropertyAddress default_input_device_address = {
         kAudioHardwarePropertyDefaultInputDevice,


### PR DESCRIPTION
Register the listener for default input device. Also it check if input, output or both is activated in order to register for the corresponding default devices.