### PR TITLE
Allow NULL callback for deregister

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -384,7 +384,7 @@ int cubeb_stream_device_destroy(cubeb_stream * stream,
 int cubeb_stream_register_device_changed_callback(cubeb_stream * stream,
                                                   cubeb_device_changed_callback device_changed_callback)
 {
-  if (!stream || !device_changed_callback) {
+  if (!stream) {
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 

--- a/src/cubeb_audiounit.c
+++ b/src/cubeb_audiounit.c
@@ -479,8 +479,10 @@ audiounit_add_listener(cubeb_stream * stm, AudioDeviceID id, AudioObjectProperty
 }
 
 OSStatus
-audiounit_remove_listener(cubeb_stream * stm, AudioDeviceID id, AudioObjectPropertySelector selector,
-    AudioObjectPropertyScope scope, AudioObjectPropertyListenerProc listener)
+audiounit_remove_listener(cubeb_stream * stm, AudioDeviceID id,
+                          AudioObjectPropertySelector selector,
+                          AudioObjectPropertyScope scope,
+                          AudioObjectPropertyListenerProc listener)
 {
   AudioObjectPropertyAddress address = {
       selector,


### PR DESCRIPTION
Top level function does not allow to set NULL cb method. This is useful to deregister the cb. 

Nit: Also includes one small format change.

PS. This patch is not required to be imported directly to Gecko since the latter does not use this capability and the current state of the code does not need it.