### PR TITLE
Resampler: correct output for input frames calculation

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -215,7 +215,7 @@ public:
 
   size_t output_for_input(uint32_t input_frames)
   {
-    return ceilf(input_frames * resampling_ratio) + 1
+    return ceilf(input_frames / resampling_ratio)
            - resampling_in_buffer.length() / channels;
   }
 


### PR DESCRIPTION
Change the formula used in computation of output frames for a given input.