### PR TITLE
Resampler fixes

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -163,9 +163,9 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   long got = data_callback(stream, user_ptr,
                            resampled_input, nullptr, resampled_frame_count);
 
-  // Return the same percentage of initial number of input frames.
-  // Since output_frames_needed == 0 in input scenario, the only
-  // available number outside resampler is the initial number of frames.
+  /* Return the number of initial input frames or part of it.
+  * Since output_frames_needed == 0 in input scenario, the only
+  * available number outside resampler is the initial number of frames. */
   return (*input_frames_count) * (got / resampled_frame_count);
 }
 

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -160,8 +160,13 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   input_processor->input(input_buffer, *input_frames_count);
   resampled_input = input_processor->output(resampled_frame_count);
 
-  return data_callback(stream, user_ptr,
-                       resampled_input, nullptr, resampled_frame_count);
+  long got = data_callback(stream, user_ptr,
+                           resampled_input, nullptr, resampled_frame_count);
+
+  // Return the same percentage of initial number of input frames.
+  // Since output_frames_needed == 0 in input scenario, the only
+  // available number outside resampler is the initial number of frames.
+  return (*input_frames_count) * (got / resampled_frame_count);
 }
 
 

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -131,6 +131,10 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
                       nullptr, out_unprocessed,
                       output_frames_before_processing);
 
+  if (got < 0) {
+    return got;
+  }
+
   output_processor->written(got);
 
   /* Process the output. If not enough frames have been returned from the
@@ -205,6 +209,10 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   got = data_callback(stream, user_ptr,
                       resampled_input, out_unprocessed,
                       output_frames_before_processing);
+
+  if (got < 0) {
+    return got;
+  }
 
   output_processor->written(got);
 


### PR DESCRIPTION
Two small fixes for resampler found during opensl es testing. 

1. The out only or full-duplex flavors of fill method cannot return negative values of user callback. Instead of that they use the negative numbers as input arguments to unassigned values which cause overflow. Change: returns immediately when receive negative values from user callback.

2. The input only fill method is used with requested frames == 0. It's return value is the after resampling number of frames. But this number is not available on the resampler's client. The return number is used to examine for drain or error cases. Change: return the similar percentage of the processed frames transformed into initial number of input frame.