### PR TITLE
Bump the stack size for WASAPI rendering threads.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1853,7 +1853,7 @@ int wasapi_stream_start(cubeb_stream * stm)
     return CUBEB_ERROR;
   }
 
-  stm->thread = (HANDLE) _beginthreadex(NULL, 256 * 1024, wasapi_stream_render_loop, stm, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
+  stm->thread = (HANDLE) _beginthreadex(NULL, 512 * 1024, wasapi_stream_render_loop, stm, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
   if (stm->thread == NULL) {
     LOG("could not create WASAPI render thread.\n");
     return CUBEB_ERROR;


### PR DESCRIPTION
In Gecko, `webrtc.org` code we call from the callback is using big arrays
allocated on the stack, and we're running out of stack space. Bumping it by a
factor of two should be enough.