### PR TITLE
resampler: change calculation for in/out frames needed

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -215,8 +215,8 @@ public:
 
   size_t output_for_input(uint32_t input_frames)
   {
-    return size_t(ceilf(input_frames / resampling_ratio)
-                  - resampling_in_buffer.length() / channels);
+    return (size_t)floorf((input_frames + samples_to_frames(resampling_in_buffer.length()))
+                         / resampling_ratio);
   }
 
   /** Returns a buffer containing exactly `output_frame_count` resampled frames.
@@ -263,8 +263,9 @@ public:
    * number of output frames will be exactly equal. */
   uint32_t input_needed_for_output(uint32_t output_frame_count)
   {
-    return uint32_t(ceilf(output_frame_count * resampling_ratio) + 1
-                    - samples_to_frames(resampling_in_buffer.length()));
+    return (uint32_t)ceilf((output_frame_count - samples_to_frames(resampling_in_buffer.length()))
+                          * resampling_ratio);
+
   }
 
   /** Returns a pointer to the input buffer, that contains empty space for at


### PR DESCRIPTION
Change the way that in or out frames needed are calculated. Since there is no m-c bug about it I copy here the try run of the fix.

https://treeherder.mozilla.org/#/jobs?repo=try&revision=6c1d253ab037