### PR TITLE
Remove an assert in the WASAPI backend

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1869,8 +1869,6 @@ int wasapi_stream_stop(cubeb_stream * stm)
   XASSERT(stm);
   HRESULT hr;
 
-  XASSERT(stm->output_client || stm->input_client);
-
   {
     auto_lock lock(stm->stream_reset_lock);
 


### PR DESCRIPTION
It's legal to call `cubeb_stream_stop` twice in a row.