### PR TITLE
Don't prebuffer when using PulseAudio.

### DIFF
--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -443,7 +443,7 @@ test_stream_position(void)
   assert(r == 0);
 
   /* XXX let start happen */
-  delay(500);
+  delay(1000);
 
   /* stream should have prefilled */
   assert(total_frames_written > 0);

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
   }
 
   cubeb_stream_start(stream);
-  delay(500);
+  delay(1000);
   cubeb_stream_stop(stream);
 
   cubeb_stream_destroy(stream);


### PR DESCRIPTION
This makes the PulseAudio backend behave like all other backends.

@achronop r?