### PR TITLE
ALSA-related fixups

### DIFF
--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -971,7 +971,7 @@ alsa_get_preferred_sample_rate(cubeb * ctx, uint32_t * rate) {
 
   /* get a pcm, disabling resampling, so we get a rate the
    * hardware/dmix/pulse/etc. supports. */
-  r = snd_pcm_open(&pcm, CUBEB_ALSA_PCM_NAME, SND_PCM_STREAM_PLAYBACK | SND_PCM_NO_AUTO_RESAMPLE, 0);
+  r = snd_pcm_open(&pcm, CUBEB_ALSA_PCM_NAME, SND_PCM_STREAM_PLAYBACK, SND_PCM_NO_AUTO_RESAMPLE);
   if (r < 0) {
     return CUBEB_ERROR;
   }


### PR DESCRIPTION
A typo in one of `snd_pcm_open()` call. According to alsa-lib source, `SND_PCM_NO_AUTO_RESAMPLE` is a bit flag, it's tested internally on `pcm->mode`. So it makes more sense to pass it as `mode` parameter, leaving `stream` only for stream type.

Suspend recovery. After suspend, ALSA could return `-ESTRPIPE` error code, which also should be handled. Fortunately, `snd_pcm_recover()` knows how to deal with it. But it doesn't always call `snd_pcm_prepare()` after that, which seems to be required on my hardware. Anyway, it shouldn't hurt to call it one more time.

Event demangling. ALSA API requires calling of `snd_pcm_poll_descriptors_revents()`. Raw `revent` values from `fds` have no meaning as-is.
