### PR TITLE
Add travis support for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,35 +4,60 @@ sudo: required
 matrix:
   include:
     - compiler: clang
+      os: linux
     - compiler: gcc
       env: COMPILER_CXX=g++-4.8 COMPILER_CC=gcc-4.8
+      os: linux
     - compiler: gcc
       env: HOST=i686-w64-mingw32
+      os: linux
+    - compiler: clang
+      os: osx
+  exclude:
+    - os: osx
+      compiler: gcc
+    - os: linux
+      compiler: gcc
+      env:
+
 before_install:
-  - sudo apt-get update -qq
-  - if [ -z "$HOST" ]; then
-      sudo apt-get install -y libpulse-dev libasound2-dev pulseaudio doxygen;
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
+      sudo apt-get update -qq;
     fi
-  - if [ ! -z "$HOST" ]; then
-      sudo apt-get install -qq mingw-w64 g++-mingw-w64 binutils-mingw-w64;
-      wget http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-tools_3.1.0-1_amd64.deb;
-      sudo dpkg -i mingw-w64-tools_3.1.0-1_amd64.deb;
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
+      if [ -z "$HOST" ]; then
+        sudo apt-get install -y libpulse-dev libasound2-dev pulseaudio doxygen;
+      fi
+    fi
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
+      if [ ! -z "$HOST" ]; then
+        sudo apt-get install -qq mingw-w64 g++-mingw-w64 binutils-mingw-w64;
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-tools_3.1.0-1_amd64.deb;
+        sudo dpkg -i mingw-w64-tools_3.1.0-1_amd64.deb;
+      fi
     fi
 before_script:
-  - if [ ! -z "$HOST" ]; then
-      unset CC;
-      unset CXX;
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
+      if [ ! -z "$HOST" ]; then
+        unset CC;
+        unset CXX;
+      fi
     fi
-  - if [ -z "$COMPILER_CXX"]; then
-      export CC=$COMPILER_CC;
-      export CXX=$COMPILER_CXX;
+  - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
+      if [ -z "$COMPILER_CXX"]; then
+        export CC=$COMPILER_CC;
+        export CXX=$COMPILER_CXX;
+      fi
     fi
   - autoreconf -i
   - ./configure --host=$HOST
 script:
   - make
-  - if [ -z "$HOST" ]; then
-      make check;
+  - if [ -z "$HOST"  ]; then
+      if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        make check;
+        cat test/*.log;
+      fi
     fi
 addons:
   apt:

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <AudioUnit/AudioUnit.h>
 #if !TARGET_OS_IPHONE
+#include <AvailabilityMacros.h>
 #include <CoreAudio/AudioHardware.h>
 #include <CoreAudio/HostTime.h>
 #include <CoreFoundation/CoreFoundation.h>
@@ -43,7 +44,7 @@
 #define AudioComponentInstanceDispose CloseComponent
 #endif
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101000
 typedef UInt32  AudioFormatFlags;
 #endif
 


### PR DESCRIPTION
This fixes a thing in the OSX backend so it builds fine on Travis, changes a bit the .travis.yml, and disables the test on OSX.

Only five of them pass currently, and I don't know how to disable only a few test using autoconf and automake and all.

@kinetiknz, does that look reasonable?