### PR TITLE
Missing update from gecko

### DIFF
--- a/src/cubeb_utils_unix.h
+++ b/src/cubeb_utils_unix.h
@@ -20,11 +20,7 @@ public:
   {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-#ifdef DEBUG
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-#else
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
-#endif
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 
 #ifdef DEBUG
     int r =


### PR DESCRIPTION
This is to update the cubeb repo with a change made directly to m-c. `owned_critical_section` is not intend to be recursive. OSX implementation is not ready for non-recursive stream mutex. The change made directly in m-c in order to fix the broken nightly behavior. A bug will be opened to address all changes required in order to restore the non-recursing behavior.