### PR TITLE
Restore non-recursive behavior of mutex wrapper

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -30,6 +30,7 @@
 #include "cubeb_ring_array.h"
 #include "cubeb_utils.h"
 #include <algorithm>
+#include <atomic>
 
 #if !defined(kCFCoreFoundationVersionNumber10_7)
 /* From CoreFoundation CFBase.h */
@@ -186,7 +187,7 @@ struct cubeb_stream {
   int draining;
   uint64_t current_latency_frames;
   uint64_t hw_latency_frames;
-  float panning;
+  std::atomic<float> panning;
   cubeb_resampler * resampler;
 };
 
@@ -415,7 +416,8 @@ audiounit_output_callback(void * user_ptr,
   stm->frames_queued += outframes;
 
   AudioFormatFlags outaff = stm->output_desc.mFormatFlags;
-  float panning = (stm->output_desc.mChannelsPerFrame == 2) ? stm->panning : 0.0f;
+  float panning = (stm->output_desc.mChannelsPerFrame == 2) ?
+      stm->panning.load(std::memory_order_relaxed) : 0.0f;
 
   /* Post process output samples. */
   if (stm->draining) {
@@ -1603,11 +1605,7 @@ int audiounit_stream_set_panning(cubeb_stream * stm, float panning)
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 
-  {
-    auto_lock lock(stm->mutex);
-    stm->panning = panning;
-  }
-
+  stm->panning.store(panning, std::memory_order_relaxed);
   return CUBEB_OK;
 }
 

--- a/src/cubeb_utils_unix.h
+++ b/src/cubeb_utils_unix.h
@@ -20,7 +20,11 @@ public:
   {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+#ifdef DEBUG
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#else
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+#endif
 
 #ifdef DEBUG
     int r =


### PR DESCRIPTION
The `recursive` attribute has been replaced with `normal` in release or `errorcheck` in debug. The critical memory that caused the deadlock, data member `cubeb_stream::panning`, has been turned into atomic in order to ensure synchronization. Patch fixes issue #144 . 