### PR TITLE
Fix drift in WASAPI when having different output and input sample device rate

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -4,6 +4,11 @@
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
  */
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif // NOMINMAX
+
 #include <algorithm>
 #include <cmath>
 #include <cassert>

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -263,7 +263,7 @@ public:
    * number of output frames will be exactly equal. */
   uint32_t input_needed_for_output(uint32_t output_frame_count)
   {
-    return (uint32_t)ceilf((output_frame_count - samples_to_frames(resampling_out_buffer.length()))
+    return (uint32_t)roundf((output_frame_count - samples_to_frames(resampling_out_buffer.length()))
                           * resampling_ratio);
 
   }

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -687,7 +687,7 @@ refill_callback_duplex(cubeb_stream * stm)
 
   // When WASAPI has not filled the input buffer yet, send silence.
   double output_duration = double(output_frames) / stm->output_mix_params.rate;
-  double input_duration = double(input_frames) / stm->input_mix_params.rate;
+  double input_duration = double(stm->linear_input_buffer.length() / stm->input_mix_params.channels) / stm->input_mix_params.rate;
   if (input_duration < output_duration) {
     size_t padding = size_t(round((output_duration - input_duration) * stm->input_mix_params.rate));
     LOG("padding silence: out=%f in=%f pad=%u\n", output_duration, input_duration, padding);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -613,7 +613,7 @@ bool get_input_buffer(cubeb_stream * stm)
 
 /* Get an output buffer from the render_client. It has to be released before
  * exiting the callback. */
-bool get_output_buffer(cubeb_stream * stm, size_t max_frames, float *& buffer, size_t & frame_count)
+bool get_output_buffer(cubeb_stream * stm, float *& buffer, size_t & frame_count)
 {
   UINT32 padding_out;
   HRESULT hr;
@@ -635,7 +635,7 @@ bool get_output_buffer(cubeb_stream * stm, size_t max_frames, float *& buffer, s
     return true;
   }
 
-  frame_count = std::min<size_t>(max_frames, stm->output_buffer_frame_count - padding_out);
+  frame_count = stm->output_buffer_frame_count - padding_out;
   BYTE * output_buffer;
 
   hr = stm->render_client->GetBuffer(frame_count, &output_buffer);
@@ -673,7 +673,7 @@ refill_callback_duplex(cubeb_stream * stm)
     return true;
   }
 
-  rv = get_output_buffer(stm, input_frames, output_buffer, output_frames);
+  rv = get_output_buffer(stm, output_buffer, output_frames);
   if (!rv) {
     hr = stm->render_client->ReleaseBuffer(output_frames, 0);
     return rv;
@@ -745,8 +745,7 @@ refill_callback_output(cubeb_stream * stm)
 
   XASSERT(!has_input(stm) && has_output(stm));
 
-  rv = get_output_buffer(stm, std::numeric_limits<size_t>::max(),
-                         output_buffer, output_frames);
+  rv = get_output_buffer(stm, output_buffer, output_frames);
   if (!rv) {
     return rv;
   }


### PR DESCRIPTION
(Re-opening a PR since I'm apparently hitting a race on github)

This addresses the comments, and is cleaner. I removed the explicit buffer append at start, in favour of letting the emergency padding logic automatically kick in. Usually, we never append input frames, it's mainly useful when we're intentionally blocking thread because we're hitting breakpoints, or at start when the input side has not produced enough buffers yet to feed the resampler.