### PR TITLE
Handle not having input frames in refill_callback_input.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -722,6 +722,11 @@ refill_callback_input(cubeb_stream * stm)
     return rv;
   }
 
+  // This can happen at the very beginning of the stream.
+  if (!stm->linear_input_buffer.length()) {
+    return true;
+  }
+
   long read = refill(stm,
                      stm->linear_input_buffer.data(),
                      stm->linear_input_buffer.length(),


### PR DESCRIPTION
This fixes #156.