### PR TITLE
Automatically switch to new devices on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ check_include_files(AudioUnit/AudioUnit.h USE_AUDIOUNIT)
 if(USE_AUDIOUNIT)
   target_sources(cubeb PRIVATE
     src/cubeb_audiounit.cpp
-    src/cubeb_osx_run_loop.c)
+    src/cubeb_osx_run_loop.cpp)
   target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT)
   target_link_libraries(cubeb PRIVATE "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
 endif()

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -511,6 +511,22 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
   cubeb_stream * stm = (cubeb_stream*) user;
 
   LOG("Audio device changed, %d events.", address_count);
+#ifdef LOGGING_ENABLED
+  for (UInt32 i = 0; i < address_count; i++) {
+    printf("%u", i);
+    switch(addresses[i].mSelector) {
+      case kAudioHardwarePropertyDefaultOutputDevice:
+        printf(" mSelector == kAudioHardwarePropertyDefaultOutputDevice\n");
+        break;
+      case kAudioHardwarePropertyDefaultInputDevice:
+        printf(" mSelector == kAudioHardwarePropertyDefaultInputDevice\n");
+        break;
+      case kAudioDevicePropertyDataSource:
+        printf(" mSelector == kAudioHardwarePropertyDataSource\n");
+        break;
+    }
+  }
+#endif // LOGGING_ENABLED
 
   for (UInt32 i = 0; i < address_count; i++) {
     switch(addresses[i].mSelector) {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -388,6 +388,8 @@ audiounit_output_callback(void * user_ptr,
     if (stm->input_linear_buffer->length() == 0) {
       /* Do nothing, there should be enough pre-buffered data to consume. */
       LOG("Input hole. Requested more input than ouput.");
+      stm->input_linear_buffer->push_silence(stm->input_buffer_frames *
+                                            stm->input_desc.mChannelsPerFrame);
     }
     // The input buffer
     input_buffer = stm->input_linear_buffer->data();

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1469,11 +1469,9 @@ audiounit_stream_init(cubeb * context,
 }
 
 static void
-audiounit_stream_destroy(cubeb_stream * stm)
+close_audiounit_stream(cubeb_stream * stm)
 {
-  stm->shutdown = 1;
-
-  if (stm->input_unit != NULL) {
+  if (has_input(stm)) {
     AudioOutputUnitStop(stm->input_unit);
     AudioUnitUninitialize(stm->input_unit);
     AudioComponentInstanceDispose(stm->input_unit);
@@ -1481,13 +1479,21 @@ audiounit_stream_destroy(cubeb_stream * stm)
 
   audiounit_destroy_input_linear_buffer(stm);
 
-  if (stm->output_unit != NULL) {
+  if (has_output(stm)) {
     AudioOutputUnitStop(stm->output_unit);
     AudioUnitUninitialize(stm->output_unit);
     AudioComponentInstanceDispose(stm->output_unit);
   }
 
   cubeb_resampler_destroy(stm->resampler);
+}
+
+static void
+audiounit_stream_destroy(cubeb_stream * stm)
+{
+  stm->shutdown = 1;
+
+  close_audiounit_stream(stm);
 
 #if !TARGET_OS_IPHONE
   int r = audiounit_uninstall_device_changed_callback(stm);

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1179,7 +1179,7 @@ setup_audiounit_stream(cubeb_stream * stm)
   UInt32 size;
 
   if (has_input(stm)) {
-    r = audiounit_create_unit(&input_unit, true,
+    r = audiounit_create_unit(&stm->input_unit, true,
                               &stm->input_stream_params,
                               stm->input_device);
     if (r != CUBEB_OK) {
@@ -1189,7 +1189,7 @@ setup_audiounit_stream(cubeb_stream * stm)
   }
 
   if (has_output(stm)) {
-    r = audiounit_create_unit(&output_unit, false,
+    r = audiounit_create_unit(&stm->output_unit, false,
                               &stm->output_stream_params,
                               stm->output_device);
     if (r != CUBEB_OK) {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1508,7 +1508,7 @@ audiounit_stream_init(cubeb * context,
   stm->latency_frames = audiounit_clamp_latency(stm, latency_frames);
   assert(latency_frames > 0);
 
-  stm->switching = false;
+  stm->switching_device = false;
 
   {
     // It's not critical to lock here, because no other thread has been started

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -350,15 +350,15 @@ audiounit_input_callback(void * user_ptr,
 
   /* Input only. Call the user callback through resampler.
      Resampler will deliver input buffer in the correct rate. */
-  frames = input_frames;
   assert(input_frames <= stm->input_linear_buffer->length() / stm->input_desc.mChannelsPerFrame);
+  long total_input_frames = stm->input_linear_buffer->length() / stm->input_desc.mChannelsPerFrame;
   outframes = cubeb_resampler_fill(stm->resampler,
                                    stm->input_linear_buffer->data(),
-                                   &frames,
+                                   &total_input_frames,
                                    NULL,
                                    0);
   // Reset input buffer
-  stm->input_linear_buffer->pop(nullptr, frames * stm->input_desc.mChannelsPerFrame);
+  stm->input_linear_buffer->clear();
 
   if (outframes < 0 || outframes != input_frames) {
     stm->shutdown = true;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -575,16 +575,15 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
   LOG("Audio device changed, %d events.", address_count);
   if (g_log_level) {
     for (UInt32 i = 0; i < address_count; i++) {
-      LOG("%u", i);
       switch(addresses[i].mSelector) {
         case kAudioHardwarePropertyDefaultOutputDevice:
-          LOG(" mSelector == kAudioHardwarePropertyDefaultOutputDevice\n");
+          LOG("%d mSelector == kAudioHardwarePropertyDefaultOutputDevice", i);
           break;
         case kAudioHardwarePropertyDefaultInputDevice:
-          LOG(" mSelector == kAudioHardwarePropertyDefaultInputDevice\n");
+          LOG("%d mSelector == kAudioHardwarePropertyDefaultInputDevice", i);
           break;
         case kAudioDevicePropertyDataSource:
-          LOG(" mSelector == kAudioHardwarePropertyDataSource\n");
+          LOG("%d mSelector == kAudioHardwarePropertyDataSource", i);
           break;
       }
     }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -97,6 +97,7 @@ public:
   {assert((float_ar && !short_ar) || (!float_ar && short_ar));}
 
   ~auto_array_wrapper() {
+    auto_lock l(lock);
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
     delete float_ar;
     delete short_ar;
@@ -104,13 +105,15 @@ public:
 
   void push(void * elements, size_t length){
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
     if (float_ar)
       return float_ar->push(static_cast<float*>(elements), length);
     return short_ar->push(static_cast<short*>(elements), length);
   }
 
-  size_t length() const {
+  size_t length() {
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
     if (float_ar)
       return float_ar->length();
     return short_ar->length();
@@ -118,6 +121,7 @@ public:
 
   void push_silence(size_t length) {
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
     if (float_ar)
       return float_ar->push_silence(length);
     return short_ar->push_silence(length);
@@ -125,21 +129,34 @@ public:
 
   bool pop(void * elements, size_t length) {
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
     if (float_ar)
       return float_ar->pop(static_cast<float*>(elements), length);
     return short_ar->pop(static_cast<short*>(elements), length);
   }
 
-  void * data() const {
+  void * data() {
     assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
     if (float_ar)
       return float_ar->data();
     return short_ar->data();
   }
 
+  void clear() {
+    assert((float_ar && !short_ar) || (!float_ar && short_ar));
+    auto_lock l(lock);
+    if (float_ar) {
+      float_ar->clear();
+    } else {
+      short_ar->clear();
+    }
+  }
+
 private:
   auto_array<float> * float_ar;
   auto_array<short> * short_ar;
+  owned_critical_section lock;
 };
 
 struct cubeb_stream {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -537,22 +537,22 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
   int rv;
 
   LOG("Audio device changed, %d events.", address_count);
-#ifdef LOGGING_ENABLED
-  for (UInt32 i = 0; i < address_count; i++) {
-    printf("%u", i);
-    switch(addresses[i].mSelector) {
-      case kAudioHardwarePropertyDefaultOutputDevice:
-        printf(" mSelector == kAudioHardwarePropertyDefaultOutputDevice\n");
-        break;
-      case kAudioHardwarePropertyDefaultInputDevice:
-        printf(" mSelector == kAudioHardwarePropertyDefaultInputDevice\n");
-        break;
-      case kAudioDevicePropertyDataSource:
-        printf(" mSelector == kAudioHardwarePropertyDataSource\n");
-        break;
+  if (g_log_level) {
+    for (UInt32 i = 0; i < address_count; i++) {
+      LOG("%u", i);
+      switch(addresses[i].mSelector) {
+        case kAudioHardwarePropertyDefaultOutputDevice:
+          LOG(" mSelector == kAudioHardwarePropertyDefaultOutputDevice\n");
+          break;
+        case kAudioHardwarePropertyDefaultInputDevice:
+          LOG(" mSelector == kAudioHardwarePropertyDefaultInputDevice\n");
+          break;
+        case kAudioDevicePropertyDataSource:
+          LOG(" mSelector == kAudioHardwarePropertyDataSource\n");
+          break;
+      }
     }
   }
-#endif // LOGGING_ENABLED
 
   for (UInt32 i = 0; i < address_count; i++) {
     switch(addresses[i].mSelector) {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -185,16 +185,16 @@ struct cubeb_stream {
    * input callback iteration */
   auto_array_wrapper * input_linear_buffer;
   /* Frames on input buffer */
-  uint32_t input_buffer_frames;
+  std::atomic<uint32_t> input_buffer_frames;
   /* Frame counters */
   uint64_t frames_played;
   uint64_t frames_queued;
-  uint64_t frames_read;
+  std::atomic<int64_t> frames_read;
   std::atomic<bool> shutdown;
   std::atomic<bool> draining;
   /* Latency requested by the user. */
   uint64_t latency_frames;
-  uint64_t current_latency_frames;
+  std::atomic<uint64_t> current_latency_frames;
   uint64_t hw_latency_frames;
   std::atomic<float> panning;
   cubeb_resampler * resampler;
@@ -1229,7 +1229,7 @@ setup_audiounit_stream(cubeb_stream * stm)
 
     // Use latency to set buffer size
     stm->input_buffer_frames = stm->latency_frames;
-    LOG("Input buffer frame count %u.", stm->input_buffer_frames);
+    LOG("Input buffer frame count %u.", unsigned(stm->input_buffer_frames));
     r = AudioUnitSetProperty(stm->input_unit,
                              kAudioDevicePropertyBufferFrameSize,
                              kAudioUnitScope_Output,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1555,13 +1555,9 @@ audiounit_stream_destroy(cubeb_stream * stm)
 {
   stm->shutdown = true;
 
-  // Don't take the lock when stopping, it could be that we're switching devices
-  // and that would deadlock.
   audiounit_stream_stop_internal(stm);
 
   {
-    // At this point, the audio callbacks have returned, we can take the lock
-    // and destroy the stream.
     auto_lock lock(stm->mutex);
     close_audiounit_stream(stm);
   }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1211,7 +1211,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                             &size);
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitGetProperty/input/kAudioUnitProperty_StreamFormat", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
     stm->input_hw_rate = input_hw_desc.mSampleRate;
@@ -1220,7 +1219,6 @@ setup_audiounit_stream(cubeb_stream * stm)
     r = audio_stream_desc_init(&stm->input_desc, &stm->input_stream_params);
     if (r != CUBEB_OK) {
       LOG("Setting format description for input failed.");
-      audiounit_stream_destroy(stm);
       return r;
     }
 
@@ -1235,7 +1233,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(UInt32));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/input/kAudioDevicePropertyBufferFrameSize", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1252,7 +1249,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(AudioStreamBasicDescription));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/input/kAudioUnitProperty_StreamFormat", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1265,7 +1261,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(UInt32));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/input/kAudioUnitProperty_MaximumFramesPerSlice", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1276,7 +1271,6 @@ setup_audiounit_stream(cubeb_stream * stm)
       array_capacity = 8;
     }
     if (audiounit_init_input_linear_buffer(stm, array_capacity) != CUBEB_OK) {
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1292,7 +1286,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(aurcbs_in));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/input/kAudioOutputUnitProperty_SetInputCallback", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
     LOG("Input audiounit init successfully.");
@@ -1303,7 +1296,6 @@ setup_audiounit_stream(cubeb_stream * stm)
     r = audio_stream_desc_init(&stm->output_desc, &stm->output_stream_params);
     if (r != CUBEB_OK) {
       LOG("Could not initialize the audio stream description.");
-      audiounit_stream_destroy(stm);
       return r;
     }
 
@@ -1319,7 +1311,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              &size);
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitGetProperty/output/tkAudioUnitProperty_StreamFormat", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1331,7 +1322,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(AudioStreamBasicDescription));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/output/kAudioUnitProperty_StreamFormat", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1346,7 +1336,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              sizeof(output_buffer_frames));
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/output/kAudioDevicePropertyBufferFrameSize", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
 
@@ -1360,7 +1349,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                              &aurcbs_out,
                              sizeof(aurcbs_out));
     if (r != noErr) {
-      audiounit_stream_destroy(stm);
       PRINT_ERROR_CODE("AudioUnitSetProperty/output/kAudioUnitProperty_SetRenderCallback", r);
       return CUBEB_ERROR;
     }
@@ -1376,7 +1364,6 @@ setup_audiounit_stream(cubeb_stream * stm)
    * the requested latency to this acceptable range. */
 #if !TARGET_OS_IPHONE
   if (audiounit_get_acceptable_latency_range(&latency_range) != CUBEB_OK) {
-    audiounit_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
@@ -1393,7 +1380,6 @@ setup_audiounit_stream(cubeb_stream * stm)
   size = sizeof(default_buffer_size);
   if (AudioUnitGetProperty(stm->output_unit, kAudioDevicePropertyBufferFrameSize,
         kAudioUnitScope_Output, 0, &default_buffer_size, &size) != 0) {
-    audiounit_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
@@ -1402,7 +1388,6 @@ setup_audiounit_stream(cubeb_stream * stm)
      * effectively setting the latency of the stream. This is process-wide. */
     if (AudioUnitSetProperty(stm->output_unit, kAudioDevicePropertyBufferFrameSize,
           kAudioUnitScope_Output, 0, &buffer_size, sizeof(buffer_size)) != 0) {
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
   }
@@ -1442,7 +1427,6 @@ setup_audiounit_stream(cubeb_stream * stm)
                                           CUBEB_RESAMPLER_QUALITY_DESKTOP);
   if (!stm->resampler) {
     LOG("Could not create resampler.");
-    audiounit_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
@@ -1450,7 +1434,6 @@ setup_audiounit_stream(cubeb_stream * stm)
     r = AudioUnitInitialize(stm->input_unit);
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitInitialize/input", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
   }
@@ -1459,7 +1442,6 @@ setup_audiounit_stream(cubeb_stream * stm)
     r = AudioUnitInitialize(stm->output_unit);
     if (r != noErr) {
       PRINT_ERROR_CODE("AudioUnitInitialize/output", r);
-      audiounit_stream_destroy(stm);
       return CUBEB_ERROR;
     }
   }
@@ -1529,6 +1511,12 @@ audiounit_stream_init(cubeb * context,
     // `setup_audiounit_stream`.
     auto_lock lock(stm->mutex);
     r = setup_audiounit_stream(stm);
+  }
+
+  if (r != CUBEB_OK) {
+    LOG("Could not setup the audiounit stream.");
+    audiounit_stream_destroy(stm);
+    return r;
   }
 
   r = audiounit_install_device_changed_callback(stm);

--- a/src/cubeb_osx_run_loop.c
+++ b/src/cubeb_osx_run_loop.c
@@ -1,8 +1,0 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-*/
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-void cubeb_set_coreaudio_notification_runloop()
-{
-}

--- a/src/cubeb_osx_run_loop.cpp
+++ b/src/cubeb_osx_run_loop.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#include <cubeb/cubeb.h>
+#include "cubeb_osx_run_loop.h"
+#include "cubeb_log.h"
+#include <AudioUnit/AudioUnit.h>
+#include <CoreAudio/AudioHardware.h>
+#include <CoreAudio/HostTime.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+void cubeb_set_coreaudio_notification_runloop()
+{
+  /* This is needed so that AudioUnit listeners get called on this thread, and
+   * not the main thread. If we don't do that, they are not called, or a crash
+   * occur, depending on the OSX version. */
+  AudioObjectPropertyAddress runloop_address = {
+    kAudioHardwarePropertyRunLoop,
+    kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyElementMaster
+  };
+
+  CFRunLoopRef run_loop = nullptr;
+
+  OSStatus r;
+  r = AudioObjectSetPropertyData(kAudioObjectSystemObject,
+                                 &runloop_address,
+                                 0, NULL, sizeof(CFRunLoopRef), &run_loop);
+  if (r != noErr) {
+    LOG("Could not make global CoreAudio notifications use their own thread.");
+  }
+}

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -212,4 +212,18 @@ private:
   owned_critical_section & lock;
 };
 
+struct auto_unlock {
+  explicit auto_unlock(owned_critical_section & lock)
+    : lock(lock)
+  {
+    lock.leave();
+  }
+  ~auto_unlock()
+  {
+    lock.enter();
+  }
+private:
+  owned_critical_section & lock;
+};
+
 #endif /* CUBEB_UTILS */

--- a/src/cubeb_utils_unix.h
+++ b/src/cubeb_utils_unix.h
@@ -20,17 +20,17 @@ public:
   {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-#ifdef DEBUG
+#ifndef NDEBUG
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
 #else
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
 #endif
 
-#ifdef DEBUG
+#ifndef NDEBUG
     int r =
 #endif
     pthread_mutex_init(&mutex, &attr);
-#ifdef DEBUG
+#ifndef NDEBUG
     assert(r == 0);
 #endif
 
@@ -39,40 +39,40 @@ public:
 
   ~owned_critical_section()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     int r =
 #endif
     pthread_mutex_destroy(&mutex);
-#ifdef DEBUG
+#ifndef NDEBUG
     assert(r == 0);
 #endif
   }
 
   void enter()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     int r =
 #endif
     pthread_mutex_lock(&mutex);
-#ifdef DEBUG
+#ifndef NDEBUG
     assert(r == 0 && "Deadlock");
 #endif
   }
 
   void leave()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     int r =
 #endif
     pthread_mutex_unlock(&mutex);
-#ifdef DEBUG
+#ifndef NDEBUG
     assert(r == 0 && "Unlocking unlocked mutex");
 #endif
   }
 
   void assert_current_thread_owns()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     int r = pthread_mutex_lock(&mutex);
     assert(r == EDEADLK);
 #endif

--- a/src/cubeb_utils_win.h
+++ b/src/cubeb_utils_win.h
@@ -17,7 +17,7 @@ class owned_critical_section
 {
 public:
   owned_critical_section()
-#ifdef DEBUG
+#ifndef NDEBUG
     : owner(0)
 #endif
   {
@@ -32,7 +32,7 @@ public:
   void enter()
   {
     EnterCriticalSection(&critical_section);
-#ifdef DEBUG
+#ifndef NDEBUG
     XASSERT(owner != GetCurrentThreadId() && "recursive locking");
     owner = GetCurrentThreadId();
 #endif
@@ -40,7 +40,7 @@ public:
 
   void leave()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     /* GetCurrentThreadId cannot return 0: it is not a the valid thread id */
     owner = 0;
 #endif
@@ -51,7 +51,7 @@ public:
      is undefined otherwise. */
   void assert_current_thread_owns()
   {
-#ifdef DEBUG
+#ifndef NDEBUG
     /* This implies owner != 0, because GetCurrentThreadId cannot return 0. */
     XASSERT(owner == GetCurrentThreadId());
 #endif
@@ -59,7 +59,7 @@ public:
 
 private:
   CRITICAL_SECTION critical_section;
-#ifdef DEBUG
+#ifndef NDEBUG
   DWORD owner;
 #endif
 


### PR DESCRIPTION
It quite similar to what we do on Windows:
- Extract everything that touches the devices from `audiounit_stream_{init, destroy}`, and call them in the device change callback
- On OSX the device change callback runs on the same thread as the audio callback, so we don't have to be as careful as on windows
- `AudioOutputUnitStop` returns when the callback has returned (if it was executing). (Source: <http://lists.apple.com/archives/coreaudio-api/2005/Dec/msg00055.html>)
- We keep using the system default for playback-only stream, maybe we could change this ?
