### PR TITLE
Simplify logging macro and clean up a bit

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -346,10 +346,8 @@ typedef void (* cubeb_device_changed_callback)(void * user_ptr);
 typedef void (* cubeb_device_collection_changed_callback)(cubeb * context,
                                                           void * user_ptr);
 
-/**
- * User supplied callback called when a message needs logging.
- * @param msg A c-string that contains the message to log. */
-typedef void (*cubeb_log_callback)(const char * msg);
+/** User supplied callback called when a message needs logging. */
+typedef void (* cubeb_log_callback)(const char * fmt, ...);
 
 /** Initialize an application context.  This will perform any library or
     application scoped initialization.
@@ -568,9 +566,7 @@ CUBEB_EXPORT int cubeb_register_device_collection_changed(cubeb * context,
 /** Set a callback to be called with a message.
     @param log_level CUBEB_LOG_VERBOSE, CUBEB_LOG_NORMAL.
     @param log_callback A function called with a message when there is
-                        something to log. Passing stdout or stderr log to
-                        this fd instead. Passing NULL allows unregistering a
-                        function.
+                        something to log. Pass NULL to unregister.
     @retval CUBEB_OK in case of success.
     @retval CUBEB_ERROR_INVALID_PARAMETER if either context or log_callback are
                                           invalid pointers, or if level is not

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -8,8 +8,6 @@
 #ifndef CUBEB_LOG
 #define CUBEB_LOG
 
-#include <stdio.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,37 +19,13 @@ extern cubeb_log_callback g_log_callback;
 }
 #endif
 
-#define LOGV(...) do {                               \
-  LOG_INTERNAL(CUBEB_LOG_VERBOSE, __VA_ARGS__);      \
-} while(0)
+#define LOGV(msg, ...) LOG_INTERNAL(CUBEB_LOG_VERBOSE, msg, ##__VA_ARGS__)
+#define LOG(msg, ...) LOG_INTERNAL(CUBEB_LOG_NORMAL, msg, ##__VA_ARGS__)
 
-#define LOG(...) do {                                \
-  LOG_INTERNAL(CUBEB_LOG_NORMAL, __VA_ARGS__);       \
-} while(0)
-
-#define LOG_INTERNAL(level, ...) do {                                \
-  if (g_log_callback && level <= g_log_level) {                      \
-    if ((FILE *)g_log_callback == stderr ||                          \
-        (FILE *)g_log_callback == stdout) {                          \
-      fprintf((FILE*)g_log_callback, "%s:%d: ", __FILE__, __LINE__); \
-      fprintf((FILE*)g_log_callback, __VA_ARGS__);                   \
-      fprintf((FILE*)g_log_callback, "\n");                          \
-    } else {                                                         \
-      const int MAX_MSG_SIZE = 256;                                  \
-      char buf[MAX_MSG_SIZE];                                        \
-      int fileandline =                                              \
-        snprintf(buf, MAX_MSG_SIZE, "%s:%d: ", __FILE__, __LINE__);  \
-      int _rv = snprintf(buf + strlen(buf),                          \
-                         MAX_MSG_SIZE - fileandline,                 \
-                         __VA_ARGS__);                               \
-      if (_rv >= MAX_MSG_SIZE) {                                     \
-        fprintf(stderr,                                              \
-                "Message truncated (size: %d, max was %d)\n",        \
-                _rv, MAX_MSG_SIZE);                                  \
-      }                                                              \
-      ((cubeb_log_callback)g_log_callback)(buf);                     \
-    }                                                                \
-  }                                                                  \
-} while(0)
+#define LOG_INTERNAL(level, fmt, ...) do {                                   \
+    if (g_log_callback && level <= g_log_level) {                            \
+      g_log_callback("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    }                                                                        \
+  } while(0)
 
 #endif // CUBEB_LOG

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -788,14 +788,14 @@ pulse_stream_init(cubeb * context,
     if (output_stream_params){
       const pa_buffer_attr * output_att;
       output_att = WRAP(pa_stream_get_buffer_attr)(stm->output_stream);
-      LOG("Output buffer attributes maxlength %u, tlength %u, prebuf %u, minreq %u, fragsize %u\n",output_att->maxlength, output_att->tlength,
+      LOG("Output buffer attributes maxlength %u, tlength %u, prebuf %u, minreq %u, fragsize %u",output_att->maxlength, output_att->tlength,
           output_att->prebuf, output_att->minreq, output_att->fragsize);
     }
 
     if (input_stream_params){
       const pa_buffer_attr * input_att;
       input_att = WRAP(pa_stream_get_buffer_attr)(stm->input_stream);
-      LOG("Input buffer attributes maxlength %u, tlength %u, prebuf %u, minreq %u, fragsize %u\n",input_att->maxlength, input_att->tlength,
+      LOG("Input buffer attributes maxlength %u, tlength %u, prebuf %u, minreq %u, fragsize %u",input_att->maxlength, input_att->tlength,
           input_att->prebuf, input_att->minreq, input_att->fragsize);
     }
   }
@@ -1271,17 +1271,17 @@ pulse_subscribe_callback(pa_context * ctx,
     if (g_log_level) {
       if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SOURCE &&
           (t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_REMOVE) {
-        LOG("Removing sink index %d\n", index);
+        LOG("Removing sink index %d", index);
       } else if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SOURCE &&
           (t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_NEW) {
-        LOG("Adding sink index %d\n", index);
+        LOG("Adding sink index %d", index);
       }
       if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SINK &&
           (t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_REMOVE) {
-        LOG("Removing source index %d\n", index);
+        LOG("Removing source index %d", index);
       } else if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) == PA_SUBSCRIPTION_EVENT_SINK &&
           (t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_NEW) {
-        LOG("Adding source index %d\n", index);
+        LOG("Adding source index %d", index);
       }
     }
 
@@ -1330,7 +1330,7 @@ pulse_register_device_collection_changed(cubeb * context,
   pa_operation * o;
   o = WRAP(pa_context_subscribe)(context->context, mask, subscribe_success, context);
   if (o == NULL) {
-    LOG("Context subscribe failed\n");
+    LOG("Context subscribe failed");
     return CUBEB_ERROR;
   }
   operation_wait(context, NULL, o);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -74,12 +74,12 @@ struct auto_com {
     if (result == RPC_E_CHANGED_MODE) {
       // This is not an error, COM was not initialized by this function, so it is
       // not necessary to uninit it.
-      LOG("COM was already initialized in STA.\n");
+      LOG("COM was already initialized in STA.");
     } else if (result == S_FALSE) {
       // This is not an error. We are allowed to call CoInitializeEx more than
       // once, as long as it is matches by an CoUninitialize call.
       // We do that in the dtor which is guaranteed to be called.
-      LOG("COM was already initialized in MTA\n");
+      LOG("COM was already initialized in MTA");
     }
     if (SUCCEEDED(result)) {
       CoUninitialize();
@@ -267,7 +267,7 @@ public:
   HRESULT STDMETHODCALLTYPE
   OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR device_id)
   {
-    LOG("Audio device default changed.\n");
+    LOG("Audio device default changed.");
 
     /* we only support a single stream type for now. */
     if (flow != eRender && role != eConsole) {
@@ -276,7 +276,7 @@ public:
 
     BOOL ok = SetEvent(reconfigure_event);
     if (!ok) {
-      LOG("SetEvent on reconfigure_event failed: %x\n", GetLastError());
+      LOG("SetEvent on reconfigure_event failed: %x", GetLastError());
     }
 
     return S_OK;
@@ -286,27 +286,27 @@ public:
      log is enabled), for debugging. */
   HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR device_id)
   {
-    LOG("Audio device added.\n");
+    LOG("Audio device added.");
     return S_OK;
   };
 
   HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR device_id)
   {
-    LOG("Audio device removed.\n");
+    LOG("Audio device removed.");
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE
   OnDeviceStateChanged(LPCWSTR device_id, DWORD new_state)
   {
-    LOG("Audio device state changed.\n");
+    LOG("Audio device state changed.");
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE
   OnPropertyValueChanged(LPCWSTR device_id, const PROPERTYKEY key)
   {
-    LOG("Audio device property value changed.\n");
+    LOG("Audio device property value changed.");
     return S_OK;
   }
 private:
@@ -488,7 +488,7 @@ refill(cubeb_stream * stm, float * input_buffer, long input_frames_count,
 
   /* Go in draining mode if we got fewer frames than requested. */
   if (out_frames < output_frames_needed) {
-    LOG("start draining.\n");
+    LOG("start draining.");
     stm->draining = true;
   }
 
@@ -521,7 +521,7 @@ bool get_input_buffer(cubeb_stream * stm)
 
   hr = stm->input_client->GetCurrentPadding(&padding_in);
   if (FAILED(hr)) {
-    LOG("Failed to get padding\n");
+    LOG("Failed to get padding");
     return false;
   }
   XASSERT(padding_in <= stm->input_buffer_frame_count);
@@ -537,7 +537,7 @@ bool get_input_buffer(cubeb_stream * stm)
   while (offset != total_available_input) {
     hr = stm->capture_client->GetNextPacketSize(&next);
     if (FAILED(hr)) {
-      LOG("cannot get next packet size: %x\n", hr);
+      LOG("cannot get next packet size: %x", hr);
       return false;
     }
     /* This can happen if the capture stream has stopped. Just return in this
@@ -553,12 +553,12 @@ bool get_input_buffer(cubeb_stream * stm)
                                         &dev_pos,
                                         NULL);
     if (FAILED(hr)) {
-      LOG("GetBuffer failed for capture: %x\n", hr);
+      LOG("GetBuffer failed for capture: %x", hr);
       return false;
     }
     XASSERT(packet_size == next);
     if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
-      LOG("insert silence: ps=%u\n", packet_size);
+      LOG("insert silence: ps=%u", packet_size);
       stm->linear_input_buffer.push_silence(packet_size * stm->input_stream_params.channels);
     } else {
       if (should_upmix(stm->input_mix_params, stm->input_stream_params)) {
@@ -609,7 +609,7 @@ bool get_output_buffer(cubeb_stream * stm, float *& buffer, size_t & frame_count
 
   hr = stm->output_client->GetCurrentPadding(&padding_out);
   if (FAILED(hr)) {
-    LOG("Failed to get padding: %x\n", hr);
+    LOG("Failed to get padding: %x", hr);
     return false;
   }
   XASSERT(padding_out <= stm->output_buffer_frame_count);
@@ -627,7 +627,7 @@ bool get_output_buffer(cubeb_stream * stm, float *& buffer, size_t & frame_count
 
   hr = stm->render_client->GetBuffer(frame_count, &output_buffer);
   if (FAILED(hr)) {
-    LOG("cannot get render buffer\n");
+    LOG("cannot get render buffer");
     return false;
   }
 
@@ -677,7 +677,7 @@ refill_callback_duplex(cubeb_stream * stm)
   double input_duration = double(stm->linear_input_buffer.length() / stm->input_stream_params.channels) / stm->input_mix_params.rate;
   if (input_duration < output_duration) {
     size_t padding = size_t(round((output_duration - input_duration) * stm->input_mix_params.rate));
-    LOG("padding silence: out=%f in=%f pad=%u\n", output_duration, input_duration, padding);
+    LOG("padding silence: out=%f in=%f pad=%u", output_duration, input_duration, padding);
     stm->linear_input_buffer.push_front_silence(padding * stm->input_stream_params.channels);
   }
 
@@ -691,7 +691,7 @@ refill_callback_duplex(cubeb_stream * stm)
 
   hr = stm->render_client->ReleaseBuffer(output_frames, 0);
   if (FAILED(hr)) {
-    LOG("failed to release buffer: %x\n", hr);
+    LOG("failed to release buffer: %x", hr);
     return false;
   }
   return true;
@@ -756,7 +756,7 @@ refill_callback_output(cubeb_stream * stm)
 
   hr = stm->render_client->ReleaseBuffer(got, 0);
   if (FAILED(hr)) {
-    LOG("failed to release buffer: %x\n", hr);
+    LOG("failed to release buffer: %x", hr);
     return false;
   }
 
@@ -780,7 +780,7 @@ wasapi_stream_render_loop(LPVOID stream)
   DWORD mmcss_task_index = 0;
   auto_com com;
   if (!com.ok()) {
-    LOG("COM initialization failed on render_loop thread.\n");
+    LOG("COM initialization failed on render_loop thread.");
     stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
     return 0;
   }
@@ -791,7 +791,7 @@ wasapi_stream_render_loop(LPVOID stream)
     stm->context->set_mm_thread_characteristics("Audio", &mmcss_task_index);
   if (!mmcss_handle) {
     /* This is not fatal, but we might glitch under heavy load. */
-    LOG("Unable to use mmcss to bump the render thread priority: %x\n", GetLastError());
+    LOG("Unable to use mmcss to bump the render thread priority: %x", GetLastError());
   }
 
 
@@ -900,7 +900,7 @@ HRESULT register_notification_client(cubeb_stream * stm)
                                 NULL, CLSCTX_INPROC_SERVER,
                                 IID_PPV_ARGS(&stm->device_enumerator));
   if (FAILED(hr)) {
-    LOG("Could not get device enumerator: %x\n", hr);
+    LOG("Could not get device enumerator: %x", hr);
     return hr;
   }
 
@@ -908,7 +908,7 @@ HRESULT register_notification_client(cubeb_stream * stm)
 
   hr = stm->device_enumerator->RegisterEndpointNotificationCallback(stm->notification_client);
   if (FAILED(hr)) {
-    LOG("Could not register endpoint notification callback: %x\n", hr);
+    LOG("Could not register endpoint notification callback: %x", hr);
     SafeRelease(stm->notification_client);
     stm->notification_client = nullptr;
     SafeRelease(stm->device_enumerator);
@@ -948,13 +948,13 @@ HRESULT get_endpoint(IMMDevice ** device, LPCWSTR devid)
                                 NULL, CLSCTX_INPROC_SERVER,
                                 IID_PPV_ARGS(&enumerator));
   if (FAILED(hr)) {
-    LOG("Could not get device enumerator: %x\n", hr);
+    LOG("Could not get device enumerator: %x", hr);
     return hr;
   }
 
   hr = enumerator->GetDevice(devid, device);
   if (FAILED(hr)) {
-    LOG("Could not get device: %x\n", hr);
+    LOG("Could not get device: %x", hr);
     SafeRelease(enumerator);
     return hr;
   }
@@ -971,12 +971,12 @@ HRESULT get_default_endpoint(IMMDevice ** device, EDataFlow direction)
                                 NULL, CLSCTX_INPROC_SERVER,
                                 IID_PPV_ARGS(&enumerator));
   if (FAILED(hr)) {
-    LOG("Could not get device enumerator: %x\n", hr);
+    LOG("Could not get device enumerator: %x", hr);
     return hr;
   }
   hr = enumerator->GetDefaultAudioEndpoint(direction, eConsole, device);
   if (FAILED(hr)) {
-    LOG("Could not get default audio endpoint: %x\n", hr);
+    LOG("Could not get default audio endpoint: %x", hr);
     SafeRelease(enumerator);
     return hr;
   }
@@ -1001,14 +1001,14 @@ current_stream_delay(cubeb_stream * stm)
   UINT64 freq;
   HRESULT hr = stm->audio_clock->GetFrequency(&freq);
   if (FAILED(hr)) {
-    LOG("GetFrequency failed: %x\n", hr);
+    LOG("GetFrequency failed: %x", hr);
     return 0;
   }
 
   UINT64 pos;
   hr = stm->audio_clock->GetPosition(&pos, NULL);
   if (FAILED(hr)) {
-    LOG("GetPosition failed: %x\n", hr);
+    LOG("GetPosition failed: %x", hr);
     return 0;
   }
 
@@ -1032,7 +1032,7 @@ stream_set_volume(cubeb_stream * stm, float volume)
   uint32_t channels;
   HRESULT hr = stm->audio_stream_volume->GetChannelCount(&channels);
   if (hr != S_OK) {
-    LOG("could not get the channel count: %x\n", hr);
+    LOG("could not get the channel count: %x", hr);
     return CUBEB_ERROR;
   }
 
@@ -1048,7 +1048,7 @@ stream_set_volume(cubeb_stream * stm, float volume)
 
   hr = stm->audio_stream_volume->SetAllVolumes(channels,  volumes);
   if (hr != S_OK) {
-    LOG("could not set the channels volume: %x\n", hr);
+    LOG("could not set the channels volume: %x", hr);
     return CUBEB_ERROR;
   }
 
@@ -1071,7 +1071,7 @@ int wasapi_init(cubeb ** context, char const * context_name)
   IMMDevice * device;
   hr = get_default_endpoint(&device, eRender);
   if (FAILED(hr)) {
-    LOG("Could not get device: %x\n", hr);
+    LOG("Could not get device: %x", hr);
     return CUBEB_ERROR;
   }
   SafeRelease(device);
@@ -1093,13 +1093,13 @@ int wasapi_init(cubeb ** context, char const * context_name)
       (revert_mm_thread_characteristics_function) GetProcAddress(
           ctx->mmcss_module, "AvRevertMmThreadCharacteristics");
     if (!(ctx->set_mm_thread_characteristics && ctx->revert_mm_thread_characteristics)) {
-      LOG("Could not load AvSetMmThreadCharacteristics or AvRevertMmThreadCharacteristics: %x\n", GetLastError());
+      LOG("Could not load AvSetMmThreadCharacteristics or AvRevertMmThreadCharacteristics: %x", GetLastError());
       FreeLibrary(ctx->mmcss_module);
     }
   } else {
     // This is not a fatal error, but we might end up glitching when
     // the system is under high load.
-    LOG("Could not load Avrt.dll\n");
+    LOG("Could not load Avrt.dll");
     ctx->set_mm_thread_characteristics = &set_mm_thread_characteristics_noop;
     ctx->revert_mm_thread_characteristics = &revert_mm_thread_characteristics_noop;
   }
@@ -1119,7 +1119,7 @@ void stop_and_join_render_thread(cubeb_stream * stm)
 
   BOOL ok = SetEvent(stm->shutdown_event);
   if (!ok) {
-    LOG("Destroy SetEvent failed: %d\n", GetLastError());
+    LOG("Destroy SetEvent failed: %d", GetLastError());
   }
 
   /* Wait five seconds for the rendering thread to return. It's supposed to
@@ -1129,10 +1129,10 @@ void stop_and_join_render_thread(cubeb_stream * stm)
     /* Something weird happened, leak the thread and continue the shutdown
      * process. */
     LOG("Destroy WaitForSingleObject on thread timed out,"
-        " leaking the thread: %d\n", GetLastError());
+        " leaking the thread: %d", GetLastError());
   }
   if (r == WAIT_FAILED) {
-    LOG("Destroy WaitForSingleObject on thread failed: %d\n", GetLastError());
+    LOG("Destroy WaitForSingleObject on thread failed: %d", GetLastError());
   }
 
   CloseHandle(stm->thread);
@@ -1214,7 +1214,7 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
   IMMDevice * device;
   hr = get_default_endpoint(&device, eRender);
   if (FAILED(hr)) {
-    LOG("Could not get default endpoint: %x\n", hr);
+    LOG("Could not get default endpoint: %x", hr);
     return CUBEB_ERROR;
   }
 
@@ -1223,7 +1223,7 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
                         NULL, (void **)&client);
   SafeRelease(device);
   if (FAILED(hr)) {
-    LOG("Could not activate device for latency: %x\n", hr);
+    LOG("Could not activate device for latency: %x", hr);
     return CUBEB_ERROR;
   }
 
@@ -1231,11 +1231,11 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
   hr = client->GetDevicePeriod(&default_period, NULL);
   if (FAILED(hr)) {
     SafeRelease(client);
-    LOG("Could not get device period: %x\n", hr);
+    LOG("Could not get device period: %x", hr);
     return CUBEB_ERROR;
   }
 
-  LOG("default device period: %lld\n", default_period);
+  LOG("default device period: %lld", default_period);
 
   /* According to the docs, the best latency we can achieve is by synchronizing
      the stream and the engine.
@@ -1342,7 +1342,7 @@ handle_channel_layout(cubeb_stream * stm,  WAVEFORMATEX ** mix_format, const cub
   if (hr == S_FALSE) {
     /* Not supported, but WASAPI gives us a suggestion. Use it, and handle the
        eventual upmix/downmix ourselves */
-    LOG("Using WASAPI suggested format: channels: %d\n", closest->nChannels);
+    LOG("Using WASAPI suggested format: channels: %d", closest->nChannels);
     WAVEFORMATEXTENSIBLE * closest_pcm = reinterpret_cast<WAVEFORMATEXTENSIBLE *>(closest);
     XASSERT(closest_pcm->SubFormat == format_pcm->SubFormat);
     CoTaskMemFree(*mix_format);
@@ -1353,9 +1353,9 @@ handle_channel_layout(cubeb_stream * stm,  WAVEFORMATEX ** mix_format, const cub
        of the code figure out the right conversion path. */
     *reinterpret_cast<WAVEFORMATEXTENSIBLE *>(*mix_format) = hw_mix_format;
   } else if (hr == S_OK) {
-    LOG("Requested format accepted by WASAPI.\n");
+    LOG("Requested format accepted by WASAPI.");
   } else {
-    LOG("IsFormatSupported unhandled error: %x\n", hr);
+    LOG("IsFormatSupported unhandled error: %x", hr);
   }
 }
 
@@ -1384,13 +1384,13 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
     id.reset(utf8_to_wstr(reinterpret_cast<char*>(devid)));
     hr = get_endpoint(&device, id.get());
     if (FAILED(hr)) {
-      LOG("Could not get %s endpoint, error: %x\n", DIRECTION_NAME, hr);
+      LOG("Could not get %s endpoint, error: %x", DIRECTION_NAME, hr);
       return CUBEB_ERROR;
     }
   } else {
     hr = get_default_endpoint(&device, direction);
     if (FAILED(hr)) {
-      LOG("Could not get default %s endpoint, error: %x\n", DIRECTION_NAME, hr);
+      LOG("Could not get default %s endpoint, error: %x", DIRECTION_NAME, hr);
       return CUBEB_ERROR;
     }
   }
@@ -1403,7 +1403,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   SafeRelease(device);
   if (FAILED(hr)) {
     LOG("Could not activate the device to get an audio"
-        " client for %s: error: %x\n", DIRECTION_NAME, hr);
+        " client for %s: error: %x", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
@@ -1412,7 +1412,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   hr = (*audio_client)->GetMixFormat(&mix_format);
   if (FAILED(hr)) {
     LOG("Could not fetch current mix format from the audio"
-        " client for %s: error: %x\n", DIRECTION_NAME, hr);
+        " client for %s: error: %x", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
@@ -1423,7 +1423,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   mix_params->format = CUBEB_SAMPLE_FLOAT32NE;
   mix_params->rate = mix_format->nSamplesPerSec;
   mix_params->channels = mix_format->nChannels;
-  LOG("Setup requested=[f=%d r=%u c=%u] mix=[f=%d r=%u c=%u]\n",
+  LOG("Setup requested=[f=%d r=%u c=%u] mix=[f=%d r=%u c=%u]",
       stream_params->format, stream_params->rate, stream_params->channels,
       mix_params->format, mix_params->rate, mix_params->channels);
 
@@ -1435,7 +1435,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
                                    mix_format,
                                    NULL);
   if (FAILED(hr)) {
-    LOG("Unable to initialize audio client for %s: %x.\n", DIRECTION_NAME, hr);
+    LOG("Unable to initialize audio client for %s: %x.", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
@@ -1444,7 +1444,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   hr = (*audio_client)->GetBufferSize(buffer_frame_count);
   if (FAILED(hr)) {
     LOG("Could not get the buffer size from the client"
-        " for %s %x.\n", DIRECTION_NAME, hr);
+        " for %s %x.", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
@@ -1457,14 +1457,14 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
 
   hr = (*audio_client)->SetEventHandle(event);
   if (FAILED(hr)) {
-    LOG("Could set the event handle for the %s client %x.\n",
+    LOG("Could set the event handle for the %s client %x.",
         DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
   hr = (*audio_client)->GetService(riid, (void **)render_or_capture_client);
   if (FAILED(hr)) {
-    LOG("Could not get the %s client %x.\n", DIRECTION_NAME, hr);
+    LOG("Could not get the %s client %x.", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
   }
 
@@ -1488,7 +1488,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
   XASSERT((!stm->output_client || !stm->input_client) && "WASAPI stream already setup, close it first.");
 
   if (has_input(stm)) {
-    LOG("Setup capture: device=%x\n", (int)stm->input_device);
+    LOG("Setup capture: device=%x", (int)stm->input_device);
     rv = setup_wasapi_stream_one_side(stm,
                                       &stm->input_stream_params,
                                       stm->input_device,
@@ -1505,7 +1505,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
   }
 
   if (has_output(stm)) {
-    LOG("Setup render: device=%x\n", (int)stm->output_device);
+    LOG("Setup render: device=%x", (int)stm->output_device);
     rv = setup_wasapi_stream_one_side(stm,
                                       &stm->output_stream_params,
                                       stm->output_device,
@@ -1523,7 +1523,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
     hr = stm->output_client->GetService(__uuidof(IAudioStreamVolume),
                                         (void **)&stm->audio_stream_volume);
     if (FAILED(hr)) {
-      LOG("Could not get the IAudioStreamVolume: %x\n", hr);
+      LOG("Could not get the IAudioStreamVolume: %x", hr);
       return CUBEB_ERROR;
     }
 
@@ -1531,7 +1531,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
     hr = stm->output_client->GetService(__uuidof(IAudioClock),
                                         (void **)&stm->audio_clock);
     if (FAILED(hr)) {
-      LOG("Could not get the IAudioClock: %x\n", hr);
+      LOG("Could not get the IAudioClock: %x", hr);
       return CUBEB_ERROR;
     }
 
@@ -1572,7 +1572,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
                            stm->user_ptr,
                            CUBEB_RESAMPLER_QUALITY_DESKTOP);
   if (!stm->resampler) {
-    LOG("Could not get a resampler\n");
+    LOG("Could not get a resampler");
     return CUBEB_ERROR;
   }
 
@@ -1639,7 +1639,7 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   stm->reconfigure_event = CreateEvent(NULL, 0, 0, NULL);
   if (!stm->reconfigure_event) {
-    LOG("Can't create the reconfigure event, error: %x\n", GetLastError());
+    LOG("Can't create the reconfigure event, error: %x", GetLastError());
     wasapi_stream_destroy(stm);
     return CUBEB_ERROR;
   }
@@ -1647,14 +1647,14 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   /* Unconditionally create the two events so that the wait logic is simpler. */
   stm->refill_event = CreateEvent(NULL, 0, 0, NULL);
   if (!stm->refill_event) {
-    LOG("Can't create the refill event, error: %x\n", GetLastError());
+    LOG("Can't create the refill event, error: %x", GetLastError());
     wasapi_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
   stm->input_available_event = CreateEvent(NULL, 0, 0, NULL);
   if (!stm->input_available_event) {
-    LOG("Can't create the input available event , error: %x\n", GetLastError());
+    LOG("Can't create the input available event , error: %x", GetLastError());
     wasapi_stream_destroy(stm);
     return CUBEB_ERROR;
   }
@@ -1676,7 +1676,7 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   if (FAILED(hr)) {
     /* this is not fatal, we can still play audio, but we won't be able
        to keep using the default audio endpoint if it changes. */
-    LOG("failed to register notification client, %x\n", hr);
+    LOG("failed to register notification client, %x", hr);
   }
 
   *stream = stm;
@@ -1750,30 +1750,30 @@ int stream_start_one_side(cubeb_stream * stm, StreamDirection dir)
 
   HRESULT hr = dir == OUTPUT ? stm->output_client->Start() : stm->input_client->Start();
   if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
-    LOG("audioclient invalidated for %s device, reconfiguring\n",
+    LOG("audioclient invalidated for %s device, reconfiguring",
         dir == OUTPUT ? "output" : "input");
 
     BOOL ok = ResetEvent(stm->reconfigure_event);
     if (!ok) {
-      LOG("resetting reconfig event failed for %s stream: %x\n",
+      LOG("resetting reconfig event failed for %s stream: %x",
           dir == OUTPUT ? "output" : "input", GetLastError());
     }
 
     close_wasapi_stream(stm);
     int r = setup_wasapi_stream(stm);
     if (r != CUBEB_OK) {
-      LOG("reconfigure failed\n");
+      LOG("reconfigure failed");
       return r;
     }
 
     HRESULT hr2 = dir == OUTPUT ? stm->output_client->Start() : stm->input_client->Start();
     if (FAILED(hr2)) {
-      LOG("could not start the %s stream after reconfig: %x\n",
+      LOG("could not start the %s stream after reconfig: %x",
           dir == OUTPUT ? "output" : "input", hr);
       return CUBEB_ERROR;
     }
   } else if (FAILED(hr)) {
-    LOG("could not start the %s stream: %x.\n",
+    LOG("could not start the %s stream: %x.",
         dir == OUTPUT ? "output" : "input", hr);
     return CUBEB_ERROR;
   }
@@ -1804,13 +1804,13 @@ int wasapi_stream_start(cubeb_stream * stm)
 
   stm->shutdown_event = CreateEvent(NULL, 0, 0, NULL);
   if (!stm->shutdown_event) {
-    LOG("Can't create the shutdown event, error: %x\n", GetLastError());
+    LOG("Can't create the shutdown event, error: %x", GetLastError());
     return CUBEB_ERROR;
   }
 
   stm->thread = (HANDLE) _beginthreadex(NULL, 512 * 1024, wasapi_stream_render_loop, stm, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
   if (stm->thread == NULL) {
-    LOG("could not create WASAPI render thread.\n");
+    LOG("could not create WASAPI render thread.");
     return CUBEB_ERROR;
   }
 
@@ -1830,7 +1830,7 @@ int wasapi_stream_stop(cubeb_stream * stm)
     if (stm->output_client) {
       hr = stm->output_client->Stop();
       if (FAILED(hr)) {
-        LOG("could not stop AudioClient (output)\n");
+        LOG("could not stop AudioClient (output)");
         return CUBEB_ERROR;
       }
     }
@@ -1838,7 +1838,7 @@ int wasapi_stream_stop(cubeb_stream * stm)
     if (stm->input_client) {
       hr = stm->input_client->Stop();
       if (FAILED(hr)) {
-        LOG("could not stop AudioClient (input)\n");
+        LOG("could not stop AudioClient (input)");
         return CUBEB_ERROR;
       }
     }
@@ -2134,7 +2134,7 @@ wasapi_enumerate_devices(cubeb * context, cubeb_device_type type,
   hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL,
       CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&enumerator));
   if (FAILED(hr)) {
-    LOG("Could not get device enumerator: %x\n", hr);
+    LOG("Could not get device enumerator: %x", hr);
     return CUBEB_ERROR;
   }
 
@@ -2145,13 +2145,13 @@ wasapi_enumerate_devices(cubeb * context, cubeb_device_type type,
 
   hr = enumerator->EnumAudioEndpoints(flow, DEVICE_STATEMASK_ALL, &collection);
   if (FAILED(hr)) {
-    LOG("Could not enumerate audio endpoints: %x\n", hr);
+    LOG("Could not enumerate audio endpoints: %x", hr);
     return CUBEB_ERROR;
   }
 
   hr = collection->GetCount(&cc);
   if (FAILED(hr)) {
-    LOG("IMMDeviceCollection::GetCount() failed: %x\n", hr);
+    LOG("IMMDeviceCollection::GetCount() failed: %x", hr);
     return CUBEB_ERROR;
   }
   *out = (cubeb_device_collection *) malloc(sizeof(cubeb_device_collection) +
@@ -2163,7 +2163,7 @@ wasapi_enumerate_devices(cubeb * context, cubeb_device_type type,
   for (i = 0; i < cc; i++) {
     hr = collection->Item(i, &dev);
     if (FAILED(hr)) {
-      LOG("IMMDeviceCollection::Item(%u) failed: %x\n", i-1, hr);
+      LOG("IMMDeviceCollection::Item(%u) failed: %x", i-1, hr);
     } else if ((cur = wasapi_create_device(enumerator, dev)) != NULL) {
       (*out)->device[(*out)->count++] = cur;
     }


### PR DESCRIPTION
The new LOG*() macros are too complicated for my liking, which I glossed over in my initial review:

- the stdout/stderr casting is extremely hacky and can be easily achieved in the caller-supplied log callback
- introducing variables in the LOG*() macros causes naming clashes in real code (c.f. ec775436921bbe2eb200aac89fafc2284c81ca7f for the first example)
- the macros should be as simple as possible since they're effectively inlined everywhere

There were also a bunch of places where LOG*() was being supplied with a newline, which is now fixed.