### PR TITLE
Support multiple channels on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 add_library(cubeb
   src/cubeb.c
+  src/cubeb_mixer.cpp
   src/cubeb_resampler.cpp
   src/cubeb_panner.cpp
    $<TARGET_OBJECTS:speex>)
@@ -198,6 +199,12 @@ target_include_directories(test_ring_array PRIVATE ${gtest_SOURCE_DIR}/include)
 target_include_directories(test_ring_array PRIVATE src)
 target_link_libraries(test_ring_array PRIVATE cubeb gtest_main)
 add_test(ring_array test_ring_array)
+
+add_executable(test_mixer test/test_mixer.cpp)
+target_include_directories(test_mixer PRIVATE ${gtest_SOURCE_DIR}/include)
+target_include_directories(test_mixer PRIVATE src)
+target_link_libraries(test_mixer PRIVATE cubeb gtest_main)
+add_test(mixer test_mixer)
 
 add_executable(test_utils test/test_utils.cpp)
 target_include_directories(test_utils PRIVATE ${gtest_SOURCE_DIR}/include)

--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -435,7 +435,7 @@ CUBEB_EXPORT int cubeb_get_max_channel_count(cubeb * context, uint32_t * max_cha
 
 /** Get the minimal latency value, in frames, that is guaranteed to work
     when creating a stream for the specified sample rate. This is platform,
-    hardware and backend dependant.
+    hardware and backend dependent.
     @param context A pointer to the cubeb context.
     @param params On some backends, the minimum achievable latency depends on
                   the characteristics of the stream.
@@ -449,7 +449,7 @@ CUBEB_EXPORT int cubeb_get_min_latency(cubeb * context,
                                        uint32_t * latency_frames);
 
 /** Get the preferred sample rate for this backend: this is hardware and
-    platform dependant, and can avoid resampling, and/or trigger fastpaths.
+    platform dependent, and can avoid resampling, and/or trigger fastpaths.
     @param context A pointer to the cubeb context.
     @param rate The samplerate (in Hz) the current configuration prefers.
     @retval CUBEB_OK
@@ -458,7 +458,7 @@ CUBEB_EXPORT int cubeb_get_min_latency(cubeb * context,
 CUBEB_EXPORT int cubeb_get_preferred_sample_rate(cubeb * context, uint32_t * rate);
 
 /** Get the preferred layout for this backend: this is hardware and
-    platform dependant.
+    platform dependent.
     @param context A pointer to the cubeb context.
     @param layout The layout of the current speaker configuration.
     @retval CUBEB_OK

--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -176,12 +176,71 @@ typedef enum {
   CUBEB_LOG_VERBOSE = 2, /**< Verbose logging of callbacks, can have performance implications. */
 } cubeb_log_level;
 
+/** SMPTE channel layout (also known as wave order)
+ * DUAL-MONO      L   R
+ * DUAL-MONO-LFE  L   R   LFE
+ * MONO           M
+ * MONO-LFE       M   LFE
+ * STEREO         L   R
+ * STEREO-LFE     L   R   LFE
+ * 3F             L   R   C
+ * 3F-LFE         L   R   C    LFE
+ * 2F1            L   R   S
+ * 2F1-LFE        L   R   LFE  S
+ * 3F1            L   R   C    S
+ * 3F1-LFE        L   R   C    LFE S
+ * 2F2            L   R   LS   RS
+ * 2F2-LFE        L   R   LFE  LS   RS
+ * 3F2            L   R   C    LS   RS
+ * 3F2-LFE        L   R   C    LFE  LS   RS
+ * 3F3R-LFE       L   R   C    LFE  RC   LS   RS
+ * 3F4-LFE        L   R   C    LFE  RLS  RRS  LS   RS
+ *
+ * The abbreviation of channel name is defined in following table:
+ * Abbr  Channel name
+ * ---------------------------
+ * M     Mono
+ * L     Left
+ * R     Right
+ * C     Center
+ * LS    Left Surround
+ * RS    Right Surround
+ * RLS   Rear Left Surround
+ * RC    Rear Center
+ * RRS   Rear Right Surround
+ * LFE   Low Frequency Effects
+ */
+
+typedef enum {
+  CUBEB_LAYOUT_UNDEFINED, // Indicate the speaker's layout is undefined.
+  CUBEB_LAYOUT_DUAL_MONO,
+  CUBEB_LAYOUT_DUAL_MONO_LFE,
+  CUBEB_LAYOUT_MONO,
+  CUBEB_LAYOUT_MONO_LFE,
+  CUBEB_LAYOUT_STEREO,
+  CUBEB_LAYOUT_STEREO_LFE,
+  CUBEB_LAYOUT_3F,
+  CUBEB_LAYOUT_3F_LFE,
+  CUBEB_LAYOUT_2F1,
+  CUBEB_LAYOUT_2F1_LFE,
+  CUBEB_LAYOUT_3F1,
+  CUBEB_LAYOUT_3F1_LFE,
+  CUBEB_LAYOUT_2F2,
+  CUBEB_LAYOUT_2F2_LFE,
+  CUBEB_LAYOUT_3F2,
+  CUBEB_LAYOUT_3F2_LFE,
+  CUBEB_LAYOUT_3F3R_LFE,
+  CUBEB_LAYOUT_3F4_LFE,
+  CUBEB_LAYOUT_MAX
+} cubeb_channel_layout;
+
 /** Stream format initialization parameters. */
 typedef struct {
-  cubeb_sample_format format; /**< Requested sample format.  One of
-                                   #cubeb_sample_format. */
-  unsigned int rate;          /**< Requested sample rate.  Valid range is [1000, 192000]. */
-  unsigned int channels;      /**< Requested channel count.  Valid range is [1, 8]. */
+  cubeb_sample_format format;   /**< Requested sample format.  One of
+                                     #cubeb_sample_format. */
+  unsigned int rate;            /**< Requested sample rate.  Valid range is [1000, 192000]. */
+  unsigned int channels;        /**< Requested channel count.  Valid range is [1, 8]. */
+  cubeb_channel_layout layout;  /**< Requested channel layout. This must be consistent with the provided channels. */
 #if defined(__ANDROID__)
   cubeb_stream_type stream_type; /**< Used to map Android audio stream types */
 #endif
@@ -397,6 +456,15 @@ CUBEB_EXPORT int cubeb_get_min_latency(cubeb * context,
     @retval CUBEB_ERROR_INVALID_PARAMETER
     @retval CUBEB_ERROR_NOT_SUPPORTED */
 CUBEB_EXPORT int cubeb_get_preferred_sample_rate(cubeb * context, uint32_t * rate);
+
+/** Get the preferred layout for this backend: this is hardware and
+    platform dependant.
+    @param context A pointer to the cubeb context.
+    @param layout The layout of the current speaker configuration.
+    @retval CUBEB_OK
+    @retval CUBEB_ERROR_INVALID_PARAMETER
+    @retval CUBEB_ERROR_NOT_SUPPORTED */
+CUBEB_EXPORT int cubeb_get_preferred_channel_layout(cubeb * context, cubeb_channel_layout * layout);
 
 /** Destroy an application context. This must be called after all stream have
  *  been destroyed.

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -41,7 +41,7 @@ typedef struct {
   cubeb_channel_layout const layout;
 } cubeb_layout_map;
 
-static const cubeb_layout_map CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
+static cubeb_layout_map const CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
   { "undefined",      0,  CUBEB_LAYOUT_UNDEFINED },
   { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },
   { "dual mono lfe",  3,  CUBEB_LAYOUT_DUAL_MONO_LFE },

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -35,6 +35,34 @@ void cubeb_crash() CLANG_ANALYZER_NORETURN;
 }
 #endif
 
+typedef struct {
+  char const * name;
+  unsigned int const channels;
+  cubeb_channel_layout const layout;
+} cubeb_layout_map;
+
+static const cubeb_layout_map CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
+  { "undefined",      0,  CUBEB_LAYOUT_UNDEFINED },
+  { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },
+  { "dual mono lfe",  3,  CUBEB_LAYOUT_DUAL_MONO_LFE },
+  { "mono",           1,  CUBEB_LAYOUT_MONO },
+  { "mono lfe",       2,  CUBEB_LAYOUT_MONO_LFE },
+  { "stereo",         2,  CUBEB_LAYOUT_STEREO },
+  { "stereo lfe",     3,  CUBEB_LAYOUT_STEREO_LFE },
+  { "3f",             3,  CUBEB_LAYOUT_3F },
+  { "3f lfe",         4,  CUBEB_LAYOUT_3F_LFE },
+  { "2f1",            3,  CUBEB_LAYOUT_2F1 },
+  { "2f1 lfe",        4,  CUBEB_LAYOUT_2F1_LFE },
+  { "3f1",            4,  CUBEB_LAYOUT_3F1 },
+  { "3f1 lfe",        5,  CUBEB_LAYOUT_3F1_LFE },
+  { "2f2",            4,  CUBEB_LAYOUT_2F2 },
+  { "2f2 lfe",        5,  CUBEB_LAYOUT_2F2_LFE },
+  { "3f2",            5,  CUBEB_LAYOUT_3F2 },
+  { "3f2 lfe",        6,  CUBEB_LAYOUT_3F2_LFE },
+  { "3f3r lfe",       7,  CUBEB_LAYOUT_3F3R_LFE },
+  { "3f4 lfe",        8,  CUBEB_LAYOUT_3F4_LFE }
+};
+
 struct cubeb_ops {
   int (* init)(cubeb ** context, char const * context_name);
   char const * (* get_backend_id)(cubeb * context);
@@ -43,6 +71,7 @@ struct cubeb_ops {
                           cubeb_stream_params params,
                           uint32_t * latency_ms);
   int (* get_preferred_sample_rate)(cubeb * context, uint32_t * rate);
+  int (* get_preferred_channel_layout)(cubeb * context, cubeb_channel_layout * layout);
   int (* enumerate_devices)(cubeb * context, cubeb_device_type type,
                             cubeb_device_collection ** collection);
   void (* destroy)(cubeb * context);

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -215,6 +215,20 @@ cubeb_get_preferred_sample_rate(cubeb * context, uint32_t * rate)
   return context->ops->get_preferred_sample_rate(context, rate);
 }
 
+int
+cubeb_get_preferred_channel_layout(cubeb * context, cubeb_channel_layout * layout)
+{
+  if (!context || !layout) {
+    return CUBEB_ERROR_INVALID_PARAMETER;
+  }
+
+  if (!context->ops->get_preferred_channel_layout) {
+    return CUBEB_ERROR_NOT_SUPPORTED;
+  }
+
+  return context->ops->get_preferred_channel_layout(context, layout);
+}
+
 void
 cubeb_destroy(cubeb * context)
 {
@@ -562,4 +576,3 @@ cubeb_crash()
   abort();
   *((volatile int *) NULL) = 0;
 }
-

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -1131,6 +1131,7 @@ static struct cubeb_ops const alsa_ops = {
   .get_max_channel_count = alsa_get_max_channel_count,
   .get_min_latency = alsa_get_min_latency,
   .get_preferred_sample_rate = alsa_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
   .destroy = alsa_destroy,
   .stream_init = alsa_stream_init,

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -421,6 +421,7 @@ static struct cubeb_ops const audiotrack_ops = {
   .get_max_channel_count = audiotrack_get_max_channel_count,
   .get_min_latency = audiotrack_get_min_latency,
   .get_preferred_sample_rate = audiotrack_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
   .destroy = audiotrack_destroy,
   .stream_init = audiotrack_stream_init,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -133,8 +133,8 @@ struct cubeb_stream {
   cubeb_state_callback state_callback = nullptr;
   cubeb_device_changed_callback device_changed_callback = nullptr;
   /* Stream creation parameters */
-  cubeb_stream_params input_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0 };
-  cubeb_stream_params output_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0 };
+  cubeb_stream_params input_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0, CUBEB_LAYOUT_UNDEFINED };
+  cubeb_stream_params output_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0, CUBEB_LAYOUT_UNDEFINED };
   bool is_default_input;
   AudioDeviceID input_device = 0;
   AudioDeviceID output_device = 0;
@@ -2294,6 +2294,7 @@ cubeb_ops const audiounit_ops = {
   /*.get_max_channel_count =*/ audiounit_get_max_channel_count,
   /*.get_min_latency =*/ audiounit_get_min_latency,
   /*.get_preferred_sample_rate =*/ audiounit_get_preferred_sample_rate,
+  /*.get_preferred_channel_layout =*/ nullptr,
   /*.enumerate_devices =*/ audiounit_enumerate_devices,
   /*.destroy =*/ audiounit_destroy,
   /*.stream_init =*/ audiounit_stream_init,

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -114,6 +114,7 @@ static struct cubeb_ops const cbjack_ops = {
   .get_max_channel_count = cbjack_get_max_channel_count,
   .get_min_latency = cbjack_get_min_latency,
   .get_preferred_sample_rate = cbjack_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = cbjack_enumerate_devices,
   .destroy = cbjack_destroy,
   .stream_init = cbjack_stream_init,

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -343,6 +343,7 @@ static struct cubeb_ops const kai_ops = {
   /*.get_max_channel_count=*/ kai_get_max_channel_count,
   /*.get_min_latency=*/ kai_get_min_latency,
   /*.get_preferred_sample_rate =*/ kai_get_preferred_sample_rate,
+  /*.get_preferred_channel_layout =*/ NULL,
   /*.enumerate_devices =*/ NULL,
   /*.destroy =*/ kai_destroy,
   /*.stream_init =*/ kai_stream_init,

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -9,7 +9,7 @@
 #include "cubeb-internal.h"
 #include "cubeb_mixer.h"
 
-static const int CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
+static int const CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
  // M | L | R | C | LS | RS | RLS | RC | RRS | LFE
   { -1, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // UNSUPPORTED
   { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // DUAL_MONO
@@ -39,15 +39,15 @@ static const int CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
 // [1] https://www.itu.int/dms_pubrec/itu-r/rec/bs/R-REC-BS.775-3-201208-I!!PDF-E.pdf
 
 // Number of converted layouts: 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs.
-const unsigned int SUPPORTED_LAYOUT_NUM = 12;
+unsigned int const SUPPORTED_LAYOUT_NUM = 12;
 // Number of input channel for downmix conversion.
-const unsigned int INPUT_CHANNEL_NUM = 6; // 3F2-LFE
+unsigned int const INPUT_CHANNEL_NUM = 6; // 3F2-LFE
 // Max number of possible output channels.
-const unsigned int MAX_OUTPUT_CHANNEL_NUM = 5; // 2F2-LFE or 3F1-LFE
-const float INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
+unsigned int const MAX_OUTPUT_CHANNEL_NUM = 5; // 2F2-LFE or 3F1-LFE
+float const INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
 // Each array contains coefficients that will be multiplied with
 // { L, R, C, LFE, LS, RS } channels respectively.
-static const float DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANNEL_NUM][INPUT_CHANNEL_NUM] =
+static float const DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANNEL_NUM][INPUT_CHANNEL_NUM] =
 {
 // 1F Mono
   {
@@ -130,7 +130,7 @@ static const float DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANN
 /* Convert audio data from 3F2(-LFE) to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs. */
 template<typename T>
 bool
-downmix_3f2(const T * in, long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+downmix_3f2(T const * const in, long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
   if ((in_layout != CUBEB_LAYOUT_3F2 && in_layout != CUBEB_LAYOUT_3F2_LFE) ||
       out_layout < CUBEB_LAYOUT_MONO || out_layout > CUBEB_LAYOUT_2F2_LFE) {
@@ -162,10 +162,10 @@ downmix_3f2(const T * in, long inframes, T * out, cubeb_channel_layout in_layout
   return true;
 }
 
-/* Map the audio data by channel name */
+/* Map the audio data by channel name. */
 template<class T>
 bool
-mix_remap(const T* in, long inframes, T* out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout) {
+mix_remap(T const * const in, long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout) {
   assert(in_layout != out_layout);
   unsigned int in_channels = CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels;
   unsigned int out_channels = CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels;
@@ -208,7 +208,7 @@ mix_remap(const T* in, long inframes, T* out, cubeb_channel_layout in_layout, cu
 /* Drop the extra channels beyond the provided output channels. */
 template<typename T>
 void
-downmix_fallback(const T * in, long inframes, T * out, unsigned int in_channels, unsigned int out_channels)
+downmix_fallback(T const * const in, long inframes, T * out, unsigned int in_channels, unsigned int out_channels)
 {
   assert(in_channels >= out_channels);
   long out_index = 0;
@@ -223,7 +223,7 @@ downmix_fallback(const T * in, long inframes, T * out, unsigned int in_channels,
 
 template<typename T>
 void
-cubeb_downmix(const T * in, long inframes, T * out,
+cubeb_downmix(T const * const in, long inframes, T * out,
               unsigned int in_channels, unsigned int out_channels,
               cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
@@ -245,10 +245,10 @@ cubeb_downmix(const T * in, long inframes, T * out,
   downmix_fallback(in, inframes, out, in_channels, out_channels);
 }
 
-/* Upmix function, copies a mono channel into L and R */
+/* Upmix function, copies a mono channel into L and R. */
 template<typename T>
 void
-mono_to_stereo(const T * in, long insamples, T * out, unsigned int out_channels)
+mono_to_stereo(T const * in, long insamples, T * out, unsigned int out_channels)
 {
   for (long i = 0, j = 0; i < insamples; ++i, j += out_channels) {
     out[j] = out[j + 1] = in[i];
@@ -257,7 +257,7 @@ mono_to_stereo(const T * in, long insamples, T * out, unsigned int out_channels)
 
 template<typename T>
 void
-cubeb_upmix(const T * in, long inframes, T * out,
+cubeb_upmix(T const * in, long inframes, T * out,
             unsigned int in_channels, unsigned int out_channels)
 {
   assert(out_channels >= in_channels && in_channels > 0);

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -1,0 +1,326 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#include <cassert>
+#include "cubeb-internal.h"
+#include "cubeb_mixer.h"
+
+static const int CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
+ // M | L | R | C | LS | RS | RLS | RC | RRS | LFE
+  { -1, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // UNSUPPORTED
+  { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // DUAL_MONO
+  { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,   2 }, // DUAL_MONO_LFE
+  {  0, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // MONO
+  {  0, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,   1 }, // MONO_LFE
+  { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // STEREO
+  { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,   2 }, // STEREO_LFE
+  { -1,  0,  1,  2,  -1,  -1,   -1,  -1,   -1,  -1 }, // 3F
+  { -1,  0,  1,  2,  -1,  -1,   -1,  -1,   -1,   3 }, // 3F_LFE
+  { -1,  0,  1, -1,  -1,  -1,   -1,   2,   -1,  -1 }, // 2F1
+  { -1,  0,  1, -1,  -1,  -1,   -1,   3,   -1,   2 }, // 2F1_LFE
+  { -1,  0,  1,  2,  -1,  -1,   -1,   3,   -1,  -1 }, // 3F1
+  { -1,  0,  1,  2,  -1,  -1,   -1,   4,   -1,   3 }, // 3F1_LFE
+  { -1,  0,  1, -1,   2,   3,   -1,  -1,   -1,  -1 }, // 2F2
+  { -1,  0,  1, -1,   3,   4,   -1,  -1,   -1,   2 }, // 2F2_LFE
+  { -1,  0,  1,  2,   3,   4,   -1,  -1,   -1,  -1 }, // 3F2
+  { -1,  0,  1,  2,   4,   5,   -1,  -1,   -1,   3 }, // 3F2_LFE
+  { -1,  0,  1,  2,   5,   6,   -1,   4,   -1,   3 }, // 3F3R_LFE
+  { -1,  0,  1,  2,   6,   7,    4,  -1,    5,   3 }, // 3F4_LFE
+};
+
+// The downmix matrix from TABLE 2 in the ITU-R BS.775-3[1] defines a way to
+// convert 3F2 input data to 1F, 2F, 3F, 2F1, 3F1, 2F2 output data. We extend it
+// to convert 3F2-LFE input data to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs
+// output data.
+// [1] https://www.itu.int/dms_pubrec/itu-r/rec/bs/R-REC-BS.775-3-201208-I!!PDF-E.pdf
+
+// Number of converted layouts: 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs.
+const unsigned int SUPPORTED_LAYOUT_NUM = 12;
+// Number of input channel for downmix conversion.
+const unsigned int INPUT_CHANNEL_NUM = 6; // 3F2-LFE
+// Max number of possible output channels.
+const unsigned int MAX_OUTPUT_CHANNEL_NUM = 5; // 2F2-LFE or 3F1-LFE
+const float INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
+// Each array contains coefficients that will be multiplied with
+// { L, R, C, LFE, LS, RS } channels respectively.
+static const float DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANNEL_NUM][INPUT_CHANNEL_NUM] =
+{
+// 1F Mono
+  {
+    { INV_SQRT_2, INV_SQRT_2, 1, 0, 0.5, 0.5 }, // M
+  },
+// 1F Mono-LFE
+  {
+    { INV_SQRT_2, INV_SQRT_2, 1, 0, 0.5, 0.5 }, // M
+    { 0, 0, 0, 1, 0, 0 }                        // LFE
+  },
+// 2F Stereo
+  {
+    { 1, 0, INV_SQRT_2, 0, INV_SQRT_2, 0 },     // L
+    { 0, 1, INV_SQRT_2, 0, 0, INV_SQRT_2 }      // R
+  },
+// 2F Stereo-LFE
+  {
+    { 1, 0, INV_SQRT_2, 0, INV_SQRT_2, 0 },     // L
+    { 0, 1, INV_SQRT_2, 0, 0, INV_SQRT_2 },     // R
+    { 0, 0, 0, 1, 0, 0 }                        // LFE
+  },
+// 3F
+  {
+    { 1, 0, 0, 0, INV_SQRT_2, 0 },              // L
+    { 0, 1, 0, 0, 0, INV_SQRT_2 },              // R
+    { 0, 0, 1, 0, 0, 0 }                        // C
+  },
+// 3F-LFE
+  {
+    { 1, 0, 0, 0, INV_SQRT_2, 0 },              // L
+    { 0, 1, 0, 0, 0, INV_SQRT_2 },              // R
+    { 0, 0, 1, 0, 0, 0 },                       // C
+    { 0, 0, 0, 1, 0, 0 }                        // LFE
+  },
+// 2F1
+  {
+    { 1, 0, INV_SQRT_2, 0, 0, 0 },              // L
+    { 0, 1, INV_SQRT_2, 0, 0, 0 },              // R
+    { 0, 0, 0, 0, INV_SQRT_2, INV_SQRT_2 }      // S
+  },
+// 2F1-LFE
+  {
+    { 1, 0, INV_SQRT_2, 0, 0, 0 },              // L
+    { 0, 1, INV_SQRT_2, 0, 0, 0 },              // R
+    { 0, 0, 0, 1, 0, 0 },                       // LFE
+    { 0, 0, 0, 0, INV_SQRT_2, INV_SQRT_2 }      // S
+  },
+// 3F1
+  {
+    { 1, 0, 0, 0, 0, 0 },                       // L
+    { 0, 1, 0, 0, 0, 0 },                       // R
+    { 0, 0, 1, 0, 0, 0 },                       // C
+    { 0, 0, 0, 0, INV_SQRT_2, INV_SQRT_2 }      // S
+  },
+// 3F1-LFE
+  {
+    { 1, 0, 0, 0, 0, 0 },                       // L
+    { 0, 1, 0, 0, 0, 0 },                       // R
+    { 0, 0, 1, 0, 0, 0 },                       // C
+    { 0, 0, 0, 1, 0, 0 },                       // LFE
+    { 0, 0, 0, 0, INV_SQRT_2, INV_SQRT_2 }      // S
+  },
+// 2F2
+  {
+    { 1, 0, INV_SQRT_2, 0, 0, 0 },              // L
+    { 0, 1, INV_SQRT_2, 0, 0, 0 },              // R
+    { 0, 0, 0, 0, 1, 0 },                       // LS
+    { 0, 0, 0, 0, 0, 1 }                        // RS
+  },
+// 2F2-LFE
+  {
+    { 1, 0, INV_SQRT_2, 0, 0, 0 },              // L
+    { 0, 1, INV_SQRT_2, 0, 0, 0 },              // R
+    { 0, 0, 0, 1, 0, 0 },                       // LFE
+    { 0, 0, 0, 0, 1, 0 },                       // LS
+    { 0, 0, 0, 0, 0, 1 }                        // RS
+  }
+};
+
+/* Convert audio data from 3F2(-LFE) to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs. */
+template<typename T>
+bool
+downmix_3f2(const T * in, long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  if ((in_layout != CUBEB_LAYOUT_3F2 && in_layout != CUBEB_LAYOUT_3F2_LFE) ||
+      out_layout < CUBEB_LAYOUT_MONO || out_layout > CUBEB_LAYOUT_2F2_LFE) {
+    return false;
+  }
+
+  unsigned int in_channels = CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels;
+  unsigned int out_channels = CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels;
+
+  // Conversion from 3F2 to 2F2-LFE or 3F1-LFE is allowed, so we use '<=' instead of '<'.
+  assert(out_channels <= in_channels);
+
+  long out_index = 0;
+  auto & downmix_matrix = DOWNMIX_MATRIX_3F2_LFE[out_layout - CUBEB_LAYOUT_MONO]; // The matrix is started from mono.
+  for (long i = 0; i < inframes * in_channels; i += in_channels) {
+    for (unsigned int j = 0; j < out_channels; ++j) {
+      out[out_index + j] = 0; // Clear its value.
+      for (unsigned int k = 0 ; k < INPUT_CHANNEL_NUM ; ++k) {
+        // 3F2-LFE has 6 channels: L, R, C, LFE, LS, RS, while 3F2 has only 5
+        // channels: L, R, C, LS, RS. Thus, we need to append 0 to LFE(index 3)
+        // to simulate a 3F2-LFE data when input layout is 3F2.
+        T data = (in_layout == CUBEB_LAYOUT_3F2_LFE) ? in[i + k] : (k == 3) ? 0 : in[i + ((k < 3) ? k : k - 1)];
+        out[out_index + j] += downmix_matrix[j][k] * data;
+      }
+    }
+    out_index += out_channels;
+  }
+
+  return true;
+}
+
+/* Map the audio data by channel name */
+template<class T>
+bool
+mix_remap(const T* in, long inframes, T* out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout) {
+  assert(in_layout != out_layout);
+  unsigned int in_channels = CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels;
+  unsigned int out_channels = CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels;
+
+  uint32_t in_layout_mask = 0;
+  for (unsigned int i = 0 ; i < in_channels ; ++i) {
+    in_layout_mask |= 1 << CHANNEL_INDEX_TO_ORDER[in_layout][i];
+  }
+
+  uint32_t out_layout_mask = 0;
+  for (unsigned int i = 0 ; i < out_channels ; ++i) {
+    out_layout_mask |= 1 << CHANNEL_INDEX_TO_ORDER[out_layout][i];
+  }
+
+  // If there is no matched channel, then do nothing.
+  if (!(out_layout_mask & in_layout_mask)) {
+    return false;
+  }
+
+  long out_index = 0;
+  for (long i = 0; i < inframes * in_channels; i += in_channels) {
+    for (unsigned int j = 0; j < out_channels; ++j) {
+      cubeb_channel channel = CHANNEL_INDEX_TO_ORDER[out_layout][j];
+      uint32_t channel_mask = 1 << channel;
+      int channel_index = CHANNEL_ORDER_TO_INDEX[in_layout][channel];
+      if (in_layout_mask & channel_mask) {
+        assert(channel_index != -1);
+        out[out_index + j] = in[i + channel_index];
+      } else {
+        assert(channel_index == -1);
+        out[out_index + j] = 0;
+      }
+    }
+    out_index += out_channels;
+  }
+
+  return true;
+}
+
+/* Drop the extra channels beyond the provided output channels. */
+template<typename T>
+void
+downmix_fallback(const T * in, long inframes, T * out, unsigned int in_channels, unsigned int out_channels)
+{
+  assert(in_channels >= out_channels);
+  long out_index = 0;
+  for (long i = 0; i < inframes * in_channels; i += in_channels) {
+    for (unsigned int j = 0; j < out_channels; ++j) {
+      out[out_index + j] = in[i + j];
+    }
+    out_index += out_channels;
+  }
+}
+
+
+template<typename T>
+void
+cubeb_downmix(const T * in, long inframes, T * out,
+              unsigned int in_channels, unsigned int out_channels,
+              cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  assert(in_channels >= out_channels && in_layout != CUBEB_LAYOUT_UNDEFINED);
+
+  // If the channel number is different from the layout's setting or it's not a
+  // valid audio 5.1 downmix, then we use fallback downmix mechanism.
+  if (out_channels == CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels &&
+      in_channels == CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels) {
+    if (downmix_3f2(in, inframes, out, in_layout, out_layout)) {
+      return;
+    }
+
+    if (mix_remap(in, inframes, out, in_layout, out_layout)) {
+      return;
+    }
+  }
+
+  downmix_fallback(in, inframes, out, in_channels, out_channels);
+}
+
+/* Upmix function, copies a mono channel into L and R */
+template<typename T>
+void
+mono_to_stereo(const T * in, long insamples, T * out, unsigned int out_channels)
+{
+  for (long i = 0, j = 0; i < insamples; ++i, j += out_channels) {
+    out[j] = out[j + 1] = in[i];
+  }
+}
+
+template<typename T>
+void
+cubeb_upmix(const T * in, long inframes, T * out,
+            unsigned int in_channels, unsigned int out_channels)
+{
+  assert(out_channels >= in_channels && in_channels > 0);
+
+  /* Either way, if we have 2 or more channels, the first two are L and R. */
+  /* If we are playing a mono stream over stereo speakers, copy the data over. */
+  if (in_channels == 1 && out_channels >= 2) {
+    mono_to_stereo(in, inframes, out, out_channels);
+  } else {
+    /* Copy through. */
+    for (unsigned int i = 0, o = 0; i < inframes * in_channels;
+        i += in_channels, o += out_channels) {
+      for (unsigned int j = 0; j < in_channels; ++j) {
+        out[o + j] = in[i + j];
+      }
+    }
+  }
+
+  /* Check if more channels. */
+  if (out_channels <= 2) {
+    return;
+  }
+
+  /* Put silence in remaining channels. */
+  for (long i = 0, o = 0; i < inframes; ++i, o += out_channels) {
+    for (unsigned int j = 2; j < out_channels; ++j) {
+      out[o + j] = 0.0;
+    }
+  }
+}
+
+bool
+cubeb_should_upmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer)
+{
+  return mixer->channels > stream->channels;
+}
+
+bool
+cubeb_should_downmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer)
+{
+  if (mixer->channels > stream->channels || mixer->layout == stream->layout) {
+    return false;
+  }
+
+  return mixer->channels < stream->channels ||
+         // When mixer.channels == stream.channels
+         mixer->layout == CUBEB_LAYOUT_UNDEFINED ||  // fallback downmix
+         (stream->layout == CUBEB_LAYOUT_3F2 &&        // 3f2 downmix
+          (mixer->layout == CUBEB_LAYOUT_2F2_LFE ||
+           mixer->layout == CUBEB_LAYOUT_3F1_LFE));
+}
+
+void
+cubeb_downmix_float(float * const in, long inframes, float * out,
+                    unsigned int in_channels, unsigned int out_channels,
+                    cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  cubeb_downmix(in, inframes, out, in_channels, out_channels, in_layout, out_layout);
+}
+
+void
+cubeb_upmix_float(float * const in, long inframes, float * out,
+                  unsigned int in_channels, unsigned int out_channels)
+{
+  cubeb_upmix(in, inframes, out, in_channels, out_channels);
+}

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -29,7 +29,7 @@ typedef enum {
   CHANNEL_MAX // Max number of supported channels.
 } cubeb_channel;
 
-static const cubeb_channel CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
+static cubeb_channel const CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
   { CHANNEL_INVALID },                                                                                            // UNSUPPORTED
   { CHANNEL_LEFT, CHANNEL_RIGHT },                                                                                // DUAL_MONO
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE },                                                                   // DUAL_MONO_LFE

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#ifndef CUBEB_MIXING
+#define CUBEB_MIXING
+
+#include "cubeb/cubeb.h" // for cubeb_channel_layout ,CUBEB_CHANNEL_LAYOUT_MAPS and cubeb_stream_params.
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef enum {
+  CHANNEL_INVALID = -1,
+  CHANNEL_MONO = 0,
+  CHANNEL_LEFT,
+  CHANNEL_RIGHT,
+  CHANNEL_CENTER,
+  CHANNEL_LS,
+  CHANNEL_RS,
+  CHANNEL_RLS,
+  CHANNEL_RCENTER,
+  CHANNEL_RRS,
+  CHANNEL_LFE,
+  CHANNEL_MAX // Max number of supported channels.
+} cubeb_channel;
+
+static const cubeb_channel CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
+  { CHANNEL_INVALID },                                                                                            // UNSUPPORTED
+  { CHANNEL_LEFT, CHANNEL_RIGHT },                                                                                // DUAL_MONO
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE },                                                                   // DUAL_MONO_LFE
+  { CHANNEL_MONO },                                                                                               // MONO
+  { CHANNEL_MONO, CHANNEL_LFE },                                                                                  // MONO_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT },                                                                                // STEREO
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE },                                                                   // STEREO_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER },                                                                // 3F
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE },                                                   // 3F_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_RCENTER },                                                               // 2F1
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE, CHANNEL_RCENTER },                                                  // 2F1_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_RCENTER },                                               // 3F1
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RCENTER },                                  // 3F1_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LS, CHANNEL_RS },                                                        // 2F2
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE, CHANNEL_LS, CHANNEL_RS },                                           // 2F2_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LS, CHANNEL_RS },                                        // 3F2
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_LS, CHANNEL_RS },                           // 3F2_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RCENTER, CHANNEL_LS, CHANNEL_RS },          // 3F3R_LFE
+  { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RLS, CHANNEL_RRS, CHANNEL_LS, CHANNEL_RS }  // 3F4_LFE
+};
+
+bool cubeb_should_upmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);
+
+bool cubeb_should_downmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);
+
+void cubeb_downmix_float(float * const in, long inframes, float * out,
+                         unsigned int in_channels, unsigned int out_channels,
+                         cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
+
+void cubeb_upmix_float(float * const in, long inframes, float * out,
+                       unsigned int in_channels, unsigned int out_channels);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // CUBEB_MIXING

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1740,6 +1740,7 @@ static struct cubeb_ops const opensl_ops = {
   .get_max_channel_count = opensl_get_max_channel_count,
   .get_min_latency = opensl_get_min_latency,
   .get_preferred_sample_rate = opensl_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
   .destroy = opensl_destroy,
   .stream_init = opensl_stream_init,

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1410,6 +1410,7 @@ static struct cubeb_ops const pulse_ops = {
   .get_max_channel_count = pulse_get_max_channel_count,
   .get_min_latency = pulse_get_min_latency,
   .get_preferred_sample_rate = pulse_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = pulse_enumerate_devices,
   .destroy = pulse_destroy,
   .stream_init = pulse_stream_init,

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -366,6 +366,7 @@ static struct cubeb_ops const sndio_ops = {
   .get_max_channel_count = sndio_get_max_channel_count,
   .get_min_latency = sndio_get_min_latency,
   .get_preferred_sample_rate = sndio_get_preferred_sample_rate,
+  .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
   .destroy = sndio_destroy,
   .stream_init = sndio_stream_init,

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -1048,6 +1048,7 @@ static struct cubeb_ops const winmm_ops = {
   /*.get_max_channel_count=*/ winmm_get_max_channel_count,
   /*.get_min_latency=*/ winmm_get_min_latency,
   /*.get_preferred_sample_rate =*/ winmm_get_preferred_sample_rate,
+  /*.get_preferred_channel_layout =*/ NULL,
   /*.enumerate_devices =*/ winmm_enumerate_devices,
   /*.destroy =*/ winmm_destroy,
   /*.stream_init =*/ winmm_stream_init,

--- a/test/common.h
+++ b/test/common.h
@@ -43,7 +43,7 @@ typedef struct {
   cubeb_channel_layout const layout;
 } layout_info;
 
-const layout_info layout_infos[CUBEB_LAYOUT_MAX] = {
+layout_info const layout_infos[CUBEB_LAYOUT_MAX] = {
   { "unsupported",    0,  CUBEB_LAYOUT_UNDEFINED },
   { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },
   { "dual mono lfe",  3,  CUBEB_LAYOUT_DUAL_MONO_LFE },

--- a/test/common.h
+++ b/test/common.h
@@ -16,6 +16,13 @@
 #include <unistd.h>
 #endif
 
+template<typename T, size_t N>
+constexpr size_t
+ARRAY_LENGTH(T(&)[N])
+{
+  return N;
+}
+
 void delay(unsigned int ms)
 {
 #if defined(_WIN32)
@@ -29,6 +36,34 @@ void delay(unsigned int ms)
 #if !defined(M_PI)
 #define M_PI 3.14159265358979323846
 #endif
+
+typedef struct {
+  char const * name;
+  unsigned int const channels;
+  cubeb_channel_layout const layout;
+} layout_info;
+
+const layout_info layout_infos[CUBEB_LAYOUT_MAX] = {
+  { "unsupported",    0,  CUBEB_LAYOUT_UNDEFINED },
+  { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },
+  { "dual mono lfe",  3,  CUBEB_LAYOUT_DUAL_MONO_LFE },
+  { "mono",           1,  CUBEB_LAYOUT_MONO },
+  { "mono lfe",       2,  CUBEB_LAYOUT_MONO_LFE },
+  { "stereo",         2,  CUBEB_LAYOUT_STEREO },
+  { "stereo lfe",     3,  CUBEB_LAYOUT_STEREO_LFE },
+  { "3f",             3,  CUBEB_LAYOUT_3F },
+  { "3f lfe",         4,  CUBEB_LAYOUT_3F_LFE },
+  { "2f1",            3,  CUBEB_LAYOUT_2F1 },
+  { "2f1 lfe",        4,  CUBEB_LAYOUT_2F1_LFE },
+  { "3f1",            4,  CUBEB_LAYOUT_3F1 },
+  { "3f1 lfe",        5,  CUBEB_LAYOUT_3F1_LFE },
+  { "2f2",            4,  CUBEB_LAYOUT_2F2 },
+  { "2f2 lfe",        5,  CUBEB_LAYOUT_2F2_LFE },
+  { "3f2",            5,  CUBEB_LAYOUT_3F2 },
+  { "3f2 lfe",        6,  CUBEB_LAYOUT_3F2_LFE },
+  { "3f3r lfe",       7,  CUBEB_LAYOUT_3F3R_LFE },
+  { "3f4 lfe",        8,  CUBEB_LAYOUT_3F4_LFE }
+};
 
 int has_available_input_device(cubeb * ctx)
 {

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -24,41 +24,12 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#define NELEMS(x) ((int) (sizeof(x) / sizeof(x[0])))
 #define VOLUME 0.2
 
 float get_frequency(int channel_index)
 {
   return 220.0f * (channel_index+1);
 }
-
-typedef struct {
-  char const * name;
-  unsigned int const channels;
-  cubeb_channel_layout const layout;
-} layout_info;
-
-const layout_info layout_infos[CUBEB_LAYOUT_MAX] = {
-  { "undefined",      0,  CUBEB_LAYOUT_UNDEFINED },
-  { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },
-  { "dual mono lfe",  3,  CUBEB_LAYOUT_DUAL_MONO_LFE },
-  { "mono",           1,  CUBEB_LAYOUT_MONO },
-  { "mono lfe",       2,  CUBEB_LAYOUT_MONO_LFE },
-  { "stereo",         2,  CUBEB_LAYOUT_STEREO },
-  { "stereo lfe",     3,  CUBEB_LAYOUT_STEREO_LFE },
-  { "3f",             3,  CUBEB_LAYOUT_3F },
-  { "3f lfe",         4,  CUBEB_LAYOUT_3F_LFE },
-  { "2f1",            3,  CUBEB_LAYOUT_2F1 },
-  { "2f1 lfe",        4,  CUBEB_LAYOUT_2F1_LFE },
-  { "3f1",            4,  CUBEB_LAYOUT_3F1 },
-  { "3f1 lfe",        5,  CUBEB_LAYOUT_3F1_LFE },
-  { "2f2",            4,  CUBEB_LAYOUT_2F2 },
-  { "2f2 lfe",        5,  CUBEB_LAYOUT_2F2_LFE },
-  { "3f2",            5,  CUBEB_LAYOUT_3F2 },
-  { "3f2 lfe",        6,  CUBEB_LAYOUT_3F2_LFE },
-  { "3f3r lfe",       7,  CUBEB_LAYOUT_3F3R_LFE },
-  { "3f4 lfe",        8,  CUBEB_LAYOUT_3F4_LFE }
-};
 
 /* store the phase of the generated waveform */
 typedef struct {
@@ -304,11 +275,11 @@ TEST(cubeb, run_channel_rate_test)
     48000,
   };
 
-  for(int j = 0; j < NELEMS(channel_values); ++j) {
-    for(int i = 0; i < NELEMS(freq_values); ++i) {
+  for(unsigned int j = 0; j < ARRAY_LENGTH(channel_values); ++j) {
+    for(unsigned int i = 0; i < ARRAY_LENGTH(freq_values); ++i) {
       ASSERT_TRUE(channel_values[j] < MAX_NUM_CHANNELS);
       fprintf(stderr, "--------------------------\n");
-      for (int k = 0 ; k < NELEMS(layout_infos); ++k ) {
+      for (unsigned int k = 0 ; k < ARRAY_LENGTH(layout_infos); ++k ) {
         if (layout_infos[k].channels == channel_values[j]) {
           ASSERT_EQ(run_test(channel_values[j], layout_infos[k], freq_values[i], 0), CUBEB_OK);
           ASSERT_EQ(run_test(channel_values[j], layout_infos[k], freq_values[i], 1), CUBEB_OK);

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -108,9 +108,11 @@ TEST(cubeb, duplex)
   input_params.format = STREAM_FORMAT;
   input_params.rate = 48000;
   input_params.channels = 1;
+  input_params.layout = CUBEB_LAYOUT_MONO;
   output_params.format = STREAM_FORMAT;
   output_params.rate = 48000;
   output_params.channels = 2;
+  output_params.layout = CUBEB_LAYOUT_STEREO;
 
   r = cubeb_get_min_latency(ctx, output_params, &latency_frames);
 

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -9,6 +9,7 @@ TEST(cubeb, latency)
   uint32_t max_channels;
   uint32_t preferred_rate;
   uint32_t latency_frames;
+  cubeb_channel_layout layout;
 
   r = cubeb_init(&ctx, "Cubeb audio test");
   ASSERT_EQ(r, CUBEB_OK);
@@ -25,10 +26,17 @@ TEST(cubeb, latency)
     ASSERT_GT(preferred_rate, 0u);
   }
 
+  r = cubeb_get_preferred_channel_layout(ctx, &layout);
+  ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);
+  if (r == CUBEB_OK) {
+    ASSERT_NE(layout, CUBEB_LAYOUT_UNDEFINED);
+  }
+
   cubeb_stream_params params = {
     CUBEB_SAMPLE_FLOAT32NE,
     preferred_rate,
-    max_channels
+    max_channels,
+    (r == CUBEB_OK) ? layout : CUBEB_LAYOUT_UNDEFINED
   };
   r = cubeb_get_min_latency(ctx, params, &latency_frames);
   ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+#include "gtest/gtest.h"
+#include "cubeb/cubeb.h"
+#include "cubeb_mixer.h"
+#include "common.h"
+#include <vector>
+
+using std::vector;
+
+#define STREAM_FREQUENCY 48000
+#define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
+
+const float M = 1.0f;     // Mono
+const float L = 2.0f;     // Left
+const float R = 3.0f;     // Right
+const float C = 4.0f;     // Center
+const float LS = 5.0f;    // Left Surround
+const float RS = 6.0f;    // Right Surround
+const float RLS = 7.0f;   // Rear Left Surround
+const float RC = 8.0f;    // Rear Center
+const float RRS = 9.0f;   // Rear Right Surround
+const float LFE = 10.0f;  // Low Frequency Effects
+
+const float INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
+static const float DOWNMIX_3F2_RESULTS[2][12][5] = {
+  // 3F2
+  {
+    { INV_SQRT_2*(L+R) + C + 0.5f*(LS+RS) },                          // Mono
+    { INV_SQRT_2*(L+R) + C + 0.5f*(LS+RS), 0 },                       // Mono-LFE
+    { L + INV_SQRT_2*(C+LS), R + INV_SQRT_2*(C+RS) },                 // Stereo
+    { L + INV_SQRT_2*(C+LS), R + INV_SQRT_2*(C+RS), 0 },              // Stereo-LFE
+    { L + INV_SQRT_2*LS, R + INV_SQRT_2*RS, C },                      // 3F
+    { L + INV_SQRT_2*LS, R + INV_SQRT_2*RS, C, 0 },                   // 3F-LFE
+    { L + C*INV_SQRT_2, R + C*INV_SQRT_2, INV_SQRT_2*(LS+RS) },       // 2F1
+    { L + C*INV_SQRT_2, R + C*INV_SQRT_2, 0, INV_SQRT_2*(LS+RS) },    // 2F1-LFE
+    { L, R, C, INV_SQRT_2*(LS+RS) },                                  // 3F1
+    { L, R, C, 0, INV_SQRT_2*(LS+RS) },                               // 3F1-LFE
+    { L + INV_SQRT_2*C, R + INV_SQRT_2*C, LS, RS },                   // 2F2
+    { L + INV_SQRT_2*C, R + INV_SQRT_2*C, 0, LS, RS }                 // 2F2-LFE
+  },
+  // 3F2-LFE
+  {
+    { INV_SQRT_2*(L+R) + C + 0.5f*(LS+RS) },                          // Mono
+    { INV_SQRT_2*(L+R) + C + 0.5f*(LS+RS), LFE },                     // Mono-LFE
+    { L + INV_SQRT_2*(C+LS), R + INV_SQRT_2*(C+RS) },                 // Stereo
+    { L + INV_SQRT_2*(C+LS), R + INV_SQRT_2*(C+RS), LFE },            // Stereo-LFE
+    { L + INV_SQRT_2*LS, R + INV_SQRT_2*RS, C },                      // 3F
+    { L + INV_SQRT_2*LS, R + INV_SQRT_2*RS, C, LFE },                 // 3F-LFE
+    { L + C*INV_SQRT_2, R + C*INV_SQRT_2, INV_SQRT_2*(LS+RS) },       // 2F1
+    { L + C*INV_SQRT_2, R + C*INV_SQRT_2, LFE, INV_SQRT_2*(LS+RS) },  // 2F1-LFE
+    { L, R, C, INV_SQRT_2*(LS+RS) },                                  // 3F1
+    { L, R, C, LFE, INV_SQRT_2*(LS+RS) },                             // 3F1-LFE
+    { L + INV_SQRT_2*C, R + INV_SQRT_2*C, LS, RS },                   // 2F2
+    { L + INV_SQRT_2*C, R + INV_SQRT_2*C, LFE, LS, RS }               // 2F2-LFE
+  }
+};
+
+typedef struct {
+  cubeb_channel_layout layout;
+  float data[10];
+} audio_input;
+
+audio_input audio_inputs[CUBEB_LAYOUT_MAX] = {
+  { CUBEB_LAYOUT_UNDEFINED,     { } },
+  { CUBEB_LAYOUT_DUAL_MONO,     { L, R } },
+  { CUBEB_LAYOUT_DUAL_MONO_LFE, { L, R, LFE } },
+  { CUBEB_LAYOUT_MONO,          { M } },
+  { CUBEB_LAYOUT_MONO_LFE,      { M, LFE } },
+  { CUBEB_LAYOUT_STEREO,        { L, R } },
+  { CUBEB_LAYOUT_STEREO_LFE,    { L, R, LFE } },
+  { CUBEB_LAYOUT_3F,            { L, R, C } },
+  { CUBEB_LAYOUT_3F_LFE,        { L, R, C, LFE } },
+  { CUBEB_LAYOUT_2F1,           { L, R, RC } },
+  { CUBEB_LAYOUT_2F1_LFE,       { L, R, LFE, RC } },
+  { CUBEB_LAYOUT_3F1,           { L, R, C, RC } },
+  { CUBEB_LAYOUT_3F1_LFE,       { L, R, C, LFE, RC } },
+  { CUBEB_LAYOUT_2F2,           { L, R, LS, RS } },
+  { CUBEB_LAYOUT_2F2_LFE,       { L, R, LFE, LS, RS } },
+  { CUBEB_LAYOUT_3F2,           { L, R, C, LS, RS } },
+  { CUBEB_LAYOUT_3F2_LFE,       { L, R, C, LFE, LS, RS } },
+  { CUBEB_LAYOUT_3F3R_LFE,      { L, R, C, LFE, RC, LS, RS } },
+  { CUBEB_LAYOUT_3F4_LFE,       { L, R, C, LFE, RLS, RRS, LS, RS } }
+};
+
+void
+downmix_test(const float* data, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  if (in_layout == CUBEB_LAYOUT_UNDEFINED) {
+    return; // Only possible output layout would be UNSUPPORTED.
+  }
+
+  cubeb_stream_params in_params = {
+    STREAM_FORMAT,
+    STREAM_FREQUENCY,
+    layout_infos[in_layout].channels,
+    in_layout
+  };
+
+  cubeb_stream_params out_params = {
+    STREAM_FORMAT,
+    STREAM_FREQUENCY,
+    // To downmix audio data with unsupported layout, its channel number must be
+    // smaller than or equal to the input channels.
+    (out_layout == CUBEB_LAYOUT_UNDEFINED) ?
+      layout_infos[in_layout].channels : layout_infos[out_layout].channels,
+    out_layout
+   };
+
+  if (!cubeb_should_downmix(&in_params, &out_params)) {
+    return;
+  }
+
+  fprintf(stderr, "Downmix from %s to %s\n", layout_infos[in_layout].name, layout_infos[out_layout].name);
+
+  const unsigned int inframes = 10;
+  vector<float> in(in_params.channels * inframes);
+  vector<float> out(out_params.channels * inframes);
+
+  for (unsigned int offset = 0 ; offset < inframes * in_params.channels ; offset += in_params.channels) {
+    for (unsigned int i = 0 ; i < in_params.channels ; ++i) {
+      in[offset + i] = data[i];
+    }
+  }
+
+  cubeb_downmix_float(in.data(), inframes, out.data(), in_params.channels, out_params.channels, in_params.layout, out_params.layout);
+
+  uint32_t in_layout_mask = 0;
+  for (unsigned int i = 0 ; i < in_params.channels; ++i) {
+    in_layout_mask |= 1 << CHANNEL_INDEX_TO_ORDER[in_layout][i];
+  }
+
+  uint32_t out_layout_mask = 0;
+  for (unsigned int i = 0 ; out_layout != CUBEB_LAYOUT_UNDEFINED && i < out_params.channels; ++i) {
+    out_layout_mask |= 1 << CHANNEL_INDEX_TO_ORDER[out_layout][i];
+  }
+
+  for (unsigned int i = 0 ; i < inframes * out_params.channels ; ++i) {
+    unsigned int index = i % out_params.channels;
+
+    // downmix_3f2
+    if ((in_layout == CUBEB_LAYOUT_3F2 || in_layout == CUBEB_LAYOUT_3F2_LFE) &&
+        out_layout >= CUBEB_LAYOUT_MONO && out_layout <= CUBEB_LAYOUT_2F2_LFE) {
+      auto & downmix_results = DOWNMIX_3F2_RESULTS[in_layout - CUBEB_LAYOUT_3F2][out_layout - CUBEB_LAYOUT_MONO];
+      fprintf(stderr, "[3f2] Expect: %lf, Get: %lf\n", downmix_results[index], out[index]);
+      ASSERT_EQ(out[index], downmix_results[index]);
+      continue;
+    }
+
+    // mix_remap
+    if (out_layout_mask & in_layout_mask) {
+      uint32_t mask = 1 << CHANNEL_INDEX_TO_ORDER[out_layout][index];
+      fprintf(stderr, "[map channels] Expect: %lf, Get: %lf\n", (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[index]);
+      ASSERT_EQ(out[index], (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0);
+      continue;
+    }
+
+    // downmix_fallback
+    fprintf(stderr, "[fallback] Expect: %lf, Get: %lf\n", audio_inputs[in_layout].data[index], out[index]);
+    ASSERT_EQ(out[index], audio_inputs[in_layout].data[index]);
+  }
+}
+
+TEST(cubeb, run_mixing_test)
+{
+  for (unsigned int i = 0 ; i < ARRAY_LENGTH(audio_inputs) ; ++i) {
+    for (unsigned int j = 0 ; j < ARRAY_LENGTH(layout_infos) ; ++j) {
+      downmix_test(audio_inputs[i].data, audio_inputs[i].layout, layout_infos[j].layout);
+    }
+  }
+}

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -15,19 +15,19 @@ using std::vector;
 #define STREAM_FREQUENCY 48000
 #define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
 
-const float M = 1.0f;     // Mono
-const float L = 2.0f;     // Left
-const float R = 3.0f;     // Right
-const float C = 4.0f;     // Center
-const float LS = 5.0f;    // Left Surround
-const float RS = 6.0f;    // Right Surround
-const float RLS = 7.0f;   // Rear Left Surround
-const float RC = 8.0f;    // Rear Center
-const float RRS = 9.0f;   // Rear Right Surround
-const float LFE = 10.0f;  // Low Frequency Effects
+float const M = 1.0f;     // Mono
+float const L = 2.0f;     // Left
+float const R = 3.0f;     // Right
+float const C = 4.0f;     // Center
+float const LS = 5.0f;    // Left Surround
+float const RS = 6.0f;    // Right Surround
+float const RLS = 7.0f;   // Rear Left Surround
+float const RC = 8.0f;    // Rear Center
+float const RRS = 9.0f;   // Rear Right Surround
+float const LFE = 10.0f;  // Low Frequency Effects
 
-const float INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
-static const float DOWNMIX_3F2_RESULTS[2][12][5] = {
+float const INV_SQRT_2 = 0.707106f; // 1/sqrt(2)
+static float const DOWNMIX_3F2_RESULTS[2][12][5] = {
   // 3F2
   {
     { INV_SQRT_2*(L+R) + C + 0.5f*(LS+RS) },                          // Mono
@@ -88,7 +88,7 @@ audio_input audio_inputs[CUBEB_LAYOUT_MAX] = {
 };
 
 void
-downmix_test(const float* data, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
   if (in_layout == CUBEB_LAYOUT_UNDEFINED) {
     return; // Only possible output layout would be UNSUPPORTED.
@@ -117,7 +117,7 @@ downmix_test(const float* data, cubeb_channel_layout in_layout, cubeb_channel_la
 
   fprintf(stderr, "Downmix from %s to %s\n", layout_infos[in_layout].name, layout_infos[out_layout].name);
 
-  const unsigned int inframes = 10;
+  unsigned int const inframes = 10;
   vector<float> in(in_params.channels * inframes);
   vector<float> out(out_params.channels * inframes);
 

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -95,6 +95,7 @@ TEST(cubeb, record)
   params.format = STREAM_FORMAT;
   params.rate = SAMPLE_FREQUENCY;
   params.channels = 1;
+  params.layout = CUBEB_LAYOUT_MONO;
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb record (mono)", NULL, &params, NULL, nullptr,
                         4096, data_cb_record, state_cb_record, &stream_state);

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -25,13 +25,6 @@
 #define STREAM_FORMAT CUBEB_SAMPLE_S16LE
 #endif
 
-template<typename T, size_t N>
-constexpr size_t
-ARRAY_LENGTH(T(&)[N])
-{
-  return N;
-}
-
 int is_windows_7()
 {
 #ifdef __MINGW32__

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -18,6 +18,7 @@
 #define STREAM_RATE 44100
 #define STREAM_LATENCY 100 * STREAM_RATE / 1000
 #define STREAM_CHANNELS 1
+#define STREAM_LAYOUT CUBEB_LAYOUT_MONO
 #if (defined(_WIN32) || defined(__WIN32__))
 #define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
 #else
@@ -137,6 +138,7 @@ TEST(cubeb, context_variables)
   params.channels = STREAM_CHANNELS;
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -169,6 +171,7 @@ TEST(cubeb, init_destroy_stream)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -197,6 +200,7 @@ TEST(cubeb, init_destroy_multiple_streams)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -229,6 +233,7 @@ TEST(cubeb, configure_stream)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = 2; // panning
+  params.layout = CUBEB_LAYOUT_STEREO;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -264,6 +269,7 @@ test_init_start_stop_destroy_multiple_streams(int early, int delay_ms)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -350,6 +356,7 @@ TEST(cubeb, init_destroy_multiple_contexts_and_streams)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -390,6 +397,7 @@ TEST(cubeb, basic_stream_operations)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -440,6 +448,7 @@ TEST(cubeb, stream_position)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif
@@ -579,6 +588,7 @@ TEST(cubeb, drain)
   params.format = STREAM_FORMAT;
   params.rate = STREAM_RATE;
   params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
 #if defined(__ANDROID__)
   params.stream_type = CUBEB_STREAM_TYPE_MUSIC;
 #endif

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -110,6 +110,7 @@ TEST(cubeb, tone)
   params.format = STREAM_FORMAT;
   params.rate = SAMPLE_FREQUENCY;
   params.channels = 1;
+  params.layout = CUBEB_LAYOUT_MONO;
 
   user_data = (struct cb_user_data *) malloc(sizeof(*user_data));
   if (user_data == NULL) {


### PR DESCRIPTION
changes:
- Add a `enum` for channel layout
- Add a property in `cubeb_stream_params` to specify the channel layout
- Set `dwChannelMask` by the given channel layout in cubeb_wasapi
- Test channel layout in test_audio
