### PR TITLE
Revert part of 6ae23a635.

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -263,8 +263,8 @@ public:
    * number of output frames will be exactly equal. */
   uint32_t input_needed_for_output(uint32_t output_frame_count)
   {
-    return (uint32_t)roundf((output_frame_count - samples_to_frames(resampling_out_buffer.length()))
-                          * resampling_ratio);
+    return (uint32_t)ceilf((output_frame_count - samples_to_frames(resampling_out_buffer.length()))
+                           * resampling_ratio);
 
   }
 


### PR DESCRIPTION
It helps on some configuration (Plantronics 648 headset + internal mic, rounding
instead of ceiling would make an rounding error not accumulate), but break
others (Creative X-Fi Titanium Fatal1ty Pro and some Android phones), so I want
to revert this and try another fix.