### PR TITLE
Improve logging

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -384,10 +384,97 @@ int cubeb_stream_register_device_changed_callback(cubeb_stream * stream,
   return stream->context->ops->stream_register_device_changed_callback(stream, device_changed_callback);
 }
 
+void log_device(cubeb_device_info * device_info)
+{
+  char devfmts[128] = "";
+  const char * devtype, * devstate, * devdeffmt;
+
+  switch (device_info->type) {
+    case CUBEB_DEVICE_TYPE_INPUT:
+      devtype = "input";
+      break;
+    case CUBEB_DEVICE_TYPE_OUTPUT:
+      devtype = "output";
+      break;
+    case CUBEB_DEVICE_TYPE_UNKNOWN:
+    default:
+      devtype = "unknown?";
+      break;
+  };
+
+  switch (device_info->state) {
+    case CUBEB_DEVICE_STATE_DISABLED:
+      devstate = "disabled";
+      break;
+    case CUBEB_DEVICE_STATE_UNPLUGGED:
+      devstate = "unplugged";
+      break;
+    case CUBEB_DEVICE_STATE_ENABLED:
+      devstate = "enabled";
+      break;
+    default:
+      devstate = "unknown?";
+      break;
+  };
+
+  switch (device_info->default_format) {
+    case CUBEB_DEVICE_FMT_S16LE:
+      devdeffmt = "S16LE";
+      break;
+    case CUBEB_DEVICE_FMT_S16BE:
+      devdeffmt = "S16BE";
+      break;
+    case CUBEB_DEVICE_FMT_F32LE:
+      devdeffmt = "F32LE";
+      break;
+    case CUBEB_DEVICE_FMT_F32BE:
+      devdeffmt = "F32BE";
+      break;
+    default:
+      devdeffmt = "unknown?";
+      break;
+  };
+
+  if (device_info->format & CUBEB_DEVICE_FMT_S16LE) {
+    strcat(devfmts, " S16LE");
+  }
+  if (device_info->format & CUBEB_DEVICE_FMT_S16BE) {
+    strcat(devfmts, " S16BE");
+  }
+  if (device_info->format & CUBEB_DEVICE_FMT_F32LE) {
+    strcat(devfmts, " F32LE");
+  }
+  if (device_info->format & CUBEB_DEVICE_FMT_F32BE) {
+    strcat(devfmts, " F32BE");
+  }
+
+  LOG("DeviceID: \"%s\"%s\n"
+      "\tName:\t\"%s\"\n"
+      "\tGroup:\t\"%s\"\n"
+      "\tVendor:\t\"%s\"\n"
+      "\tType:\t%s\n"
+      "\tState:\t%s\n"
+      "\tMaximum channels:\t%u\n"
+      "\tFormat:\t%s (0x%x) (default: %s)\n"
+      "\tRate:\t[%u, %u] (default: %u)\n"
+      "\tLatency: lo %u frames, hi %u frames",
+      device_info->device_id, device_info->preferred ? " (PREFERRED)" : "",
+      device_info->friendly_name,
+      device_info->group_id,
+      device_info->vendor_name,
+      devtype,
+      devstate,
+      device_info->max_channels,
+      (devfmts[0] == '\0') ? devfmts : devfmts + 1, (unsigned int)device_info->format, devdeffmt,
+      device_info->min_rate, device_info->max_rate, device_info->default_rate,
+      device_info->latency_lo, device_info->latency_hi);
+}
+
 int cubeb_enumerate_devices(cubeb * context,
                             cubeb_device_type devtype,
                             cubeb_device_collection ** collection)
 {
+  int rv;
   if ((devtype & (CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT)) == 0)
     return CUBEB_ERROR_INVALID_PARAMETER;
   if (collection == NULL)
@@ -395,7 +482,15 @@ int cubeb_enumerate_devices(cubeb * context,
   if (!context->ops->enumerate_devices)
     return CUBEB_ERROR_NOT_SUPPORTED;
 
-  return context->ops->enumerate_devices(context, devtype, collection);
+  rv = context->ops->enumerate_devices(context, devtype, collection);
+
+  if (g_log_callback) {
+    for (uint32_t i = 0; i < (*collection)->count; i++) {
+      log_device((*collection)->device[i]);
+    }
+  }
+
+  return rv;
 }
 
 int cubeb_device_collection_destroy(cubeb_device_collection * collection)

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1180,6 +1180,7 @@ setup_audiounit_stream(cubeb_stream * stm)
   UInt32 size;
 
   if (has_input(stm)) {
+    LOG("Opening input side, rate: %d", stm->input_stream_params.rate);
     r = audiounit_create_unit(&stm->input_unit, true,
                               &stm->input_stream_params,
                               stm->input_device);
@@ -1190,6 +1191,7 @@ setup_audiounit_stream(cubeb_stream * stm)
   }
 
   if (has_output(stm)) {
+    LOG("Opening output side, rate: %d", stm->input_stream_params.rate);
     r = audiounit_create_unit(&stm->output_unit, false,
                               &stm->output_stream_params,
                               stm->output_device);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -756,7 +756,6 @@ refill_callback_output(cubeb_stream * stm)
     return true;
   }
 
-
   long got = refill(stm,
                     nullptr,
                     0,

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -619,9 +619,11 @@ bool get_output_buffer(cubeb_stream * stm, float *& buffer, size_t & frame_count
 
   if (stm->draining) {
     if (padding_out == 0) {
+      LOG("Draining finished.");
       stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_DRAINED);
       return false;
     }
+    LOG("Draining.");
     return true;
   }
 
@@ -684,6 +686,9 @@ refill_callback_duplex(cubeb_stream * stm)
     stm->linear_input_buffer.push_front_silence(padding * stm->input_stream_params.channels);
   }
 
+  LOGV("Duplex callback: input frames: %zu, output frames: %zu",
+       stm->linear_input_buffer.length(), output_frames);
+
   refill(stm,
          stm->linear_input_buffer.data(),
          stm->linear_input_buffer.length(),
@@ -717,6 +722,8 @@ refill_callback_input(cubeb_stream * stm)
     return true;
   }
 
+  LOGV("Input callback: input frames: %zu", stm->linear_input_buffer.length());
+
   long read = refill(stm,
                      stm->linear_input_buffer.data(),
                      stm->linear_input_buffer.length(),
@@ -749,11 +756,16 @@ refill_callback_output(cubeb_stream * stm)
     return true;
   }
 
+
   long got = refill(stm,
                     nullptr,
                     0,
                     output_buffer,
                     output_frames);
+
+  LOGV("Output callback: output frames requested: %zu, got %ld",
+       output_frames, got);
+
   XASSERT(got >= 0);
   XASSERT(got == output_frames || stm->draining);
 
@@ -824,33 +836,41 @@ wasapi_stream_render_loop(LPVOID stream)
     }
     case WAIT_OBJECT_0 + 1: { /* reconfigure */
       XASSERT(stm->output_client || stm->input_client);
+      LOG("Reconfiguring the stream");
       /* Close the stream */
       if (stm->output_client) {
         stm->output_client->Stop();
+        LOG("Output stopped.");
       }
       if (stm->input_client) {
         stm->input_client->Stop();
+        LOG("Input stopped.");
       }
       {
         auto_lock lock(stm->stream_reset_lock);
         close_wasapi_stream(stm);
+        LOG("Stream closed.");
         /* Reopen a stream and start it immediately. This will automatically pick the
            new default device for this role. */
         int r = setup_wasapi_stream(stm);
         if (r != CUBEB_OK) {
+          LOG("Error setting up the stream during reconfigure.");
           /* Don't destroy the stream here, since we expect the caller to do
              so after the error has propagated via the state callback. */
           is_playing = false;
           hr = E_FAIL;
           continue;
         }
+        LOG("Stream setup successfuly.");
       }
       XASSERT(stm->output_client || stm->input_client);
       if (stm->output_client) {
         stm->output_client->Start();
+        LOG("Output started after reconfigure.");
       }
       if (stm->input_client) {
         stm->input_client->Start();
+        LOG("Input started after reconfigure.");
       }
       break;
     }
@@ -866,6 +886,7 @@ wasapi_stream_render_loop(LPVOID stream)
     case WAIT_TIMEOUT:
       XASSERT(stm->shutdown_event == wait_array[0]);
       if (++timeout_count >= timeout_limit) {
+        LOG("Render loop reached the timeout limit.");
         is_playing = false;
         hr = E_FAIL;
       }
@@ -1116,7 +1137,9 @@ int wasapi_init(cubeb ** context, char const * context_name)
 namespace {
 void stop_and_join_render_thread(cubeb_stream * stm)
 {
+  LOG("Stop and join render thread.");
   if (!stm->thread) {
+    LOG("No thread present.");
     return;
   }
 
@@ -1137,6 +1160,8 @@ void stop_and_join_render_thread(cubeb_stream * stm)
   if (r == WAIT_FAILED) {
     LOG("Destroy WaitForSingleObject on thread failed: %d", GetLastError());
   }
+
+  LOG("Closing thread.");
 
   CloseHandle(stm->thread);
   stm->thread = NULL;
@@ -1246,6 +1271,8 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
 
   *latency_frames = hns_to_frames(params.rate, default_period);
 
+  LOG("Minimum latency in frames: %u", *latency_frames);
+
   SafeRelease(client);
 
   return CUBEB_OK;
@@ -1283,6 +1310,8 @@ wasapi_get_preferred_sample_rate(cubeb * ctx, uint32_t * rate)
   }
 
   *rate = mix_format->nSamplesPerSec;
+
+  LOG("Preferred sample rate for output: %u", *rate);
 
   CoTaskMemFree(mix_format);
   SafeRelease(client);
@@ -1500,6 +1529,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
 
   auto_com com;
   if (!com.ok()) {
+    LOG("Failure to initialize COM.");
     return CUBEB_ERROR;
   }
 
@@ -1518,6 +1548,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
                                       &stm->capture_client,
                                       &stm->input_mix_params);
     if (rv != CUBEB_OK) {
+      LOG("Failure to open the input side.");
       return rv;
     }
   }
@@ -1535,6 +1566,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
                                       &stm->render_client,
                                       &stm->output_mix_params);
     if (rv != CUBEB_OK) {
+      LOG("Failure to open the output side.");
       return rv;
     }
 
@@ -1555,6 +1587,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
 
     /* Restore the stream volume over a device change. */
     if (stream_set_volume(stm, stm->volume) != CUBEB_OK) {
+      LOG("Could not set the volume.");
       return CUBEB_ERROR;
     }
   }
@@ -1571,6 +1604,8 @@ int setup_wasapi_stream(cubeb_stream * stm)
     XASSERT(has_output(stm));
     target_sample_rate = stm->output_stream_params.rate;
   }
+
+  LOG("Target sample rate: %d", target_sample_rate);
 
   /* If we are playing/capturing a mono stream, we only resample one channel,
    and copy it over, so we are always resampling the number
@@ -1628,6 +1663,10 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   if (output_stream_params && output_stream_params->format != CUBEB_SAMPLE_FLOAT32NE ||
       input_stream_params && input_stream_params->format != CUBEB_SAMPLE_FLOAT32NE) {
+    LOG("Invalid format, %p %p %d %d",
+        output_stream_params, input_stream_params,
+        output_stream_params && output_stream_params->format,
+        input_stream_params && input_stream_params->format);
     return CUBEB_ERROR_INVALID_FORMAT;
   }
 


### PR DESCRIPTION
We need to be able to ask people to enable logging and have a lot of info from machines we don't control, so I added a bunch of logging statements. Sometimes, the logging statement is only there to see where the program errored.

This includes logging about device enumeration, that I copied and adapted from `test_device.c`.

@kinetiknz, @achronop, can you have a look ?