### PR TITLE
audiounit: Crash and device switch fixes

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -373,7 +373,8 @@ audiounit_input_callback(void * user_ptr,
   return noErr;
 }
 
-static bool is_extra_input_needed(cubeb_stream * stm)
+static bool
+is_extra_input_needed(cubeb_stream * stm)
 {
   /* If the output callback came first and this is a duplex stream, we need to
     * fill in some additional silence in the resampler.
@@ -381,7 +382,7 @@ static bool is_extra_input_needed(cubeb_stream * stm)
     * switching, we add some silence as well to compensate for the fact that
     * we're lacking some input data. */
 
-  /* If resampling taking place after every output callback
+  /* If resampling is taking place after every output callback
    * the input buffer expected to be empty.  Any frame left over
    * from resampling is stored inside the resampler available to
    * be used in next iteration as needed.
@@ -389,8 +390,8 @@ static bool is_extra_input_needed(cubeb_stream * stm)
    * frames since it does not store anything internally. */
   return stm->frames_read == 0 ||
          (stm->input_linear_buffer->length() == 0 &&
-            (stm->output_callback_in_a_row > stm->expected_output_callbacks_in_a_row ||
-            stm->switching_device));
+         (stm->output_callback_in_a_row > stm->expected_output_callbacks_in_a_row ||
+         stm->switching_device));
 }
 
 static OSStatus
@@ -442,7 +443,7 @@ audiounit_output_callback(void * user_ptr,
       uint32_t min_input_frames_required = ceilf(stm->input_hw_rate / stm->output_hw_rate *
                                                                       stm->input_buffer_frames);
       stm->input_linear_buffer->push_silence(min_input_frames_required * stm->input_desc.mChannelsPerFrame);
-      LOG("%s pushed %u frames of input silence.", stm->frames_read == 0 ? "Input hasn't started," :
+      LOG("(%p) %s pushed %u frames of input silence.", stm, stm->frames_read == 0 ? "Input hasn't started," :
           stm->switching_device ? "Device switching," : "Drop out,", min_input_frames_required);
     }
     // The input buffer

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -583,13 +583,13 @@ audiounit_property_listener_callback(AudioObjectID /* id */, UInt32 address_coun
     for (UInt32 i = 0; i < address_count; i++) {
       switch(addresses[i].mSelector) {
         case kAudioHardwarePropertyDefaultOutputDevice:
-          LOG("(%p) %d mSelector == kAudioHardwarePropertyDefaultOutputDevice", stm, i);
+          LOG("(%p) Event[%d] mSelector == kAudioHardwarePropertyDefaultOutputDevice", stm, i);
           break;
         case kAudioHardwarePropertyDefaultInputDevice:
-          LOG("(%p) %d mSelector == kAudioHardwarePropertyDefaultInputDevice", stm, i);
+          LOG("(%p) Event[%d] mSelector == kAudioHardwarePropertyDefaultInputDevice", stm, i);
           break;
         case kAudioDevicePropertyDataSource:
-          LOG("(%p) %d mSelector == kAudioHardwarePropertyDataSource", stm, i);
+          LOG("(%p) Event[%d] mSelector == kAudioHardwarePropertyDataSource", stm, i);
           break;
       }
     }
@@ -1057,11 +1057,11 @@ audiounit_create_unit(AudioUnit * unit,
     } else {
       devid = reinterpret_cast<intptr_t>(device);
     }
-    int err = AudioUnitSetProperty(*unit, kAudioOutputUnitProperty_CurrentDevice,
+    rv = AudioUnitSetProperty(*unit, kAudioOutputUnitProperty_CurrentDevice,
                                    kAudioUnitScope_Global,
                                    is_input ? AU_IN_BUS : AU_OUT_BUS,
                                    &devid, sizeof(AudioDeviceID));
-    if (err != noErr) {
+    if (rv != noErr) {
       PRINT_ERROR_CODE("AudioUnitSetProperty/kAudioOutputUnitProperty_CurrentDevice", rv);
       return CUBEB_ERROR;
     }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1182,7 +1182,6 @@ setup_audiounit_stream(cubeb_stream * stm)
   UInt32 size;
 
   if (has_input(stm)) {
-    LOG("(%p) Opening input side, rate: %u", stm, stm->input_stream_params.rate);
     r = audiounit_create_unit(&stm->input_unit, true,
                               &stm->input_stream_params,
                               stm->input_device);
@@ -1193,7 +1192,6 @@ setup_audiounit_stream(cubeb_stream * stm)
   }
 
   if (has_output(stm)) {
-    LOG("(%p) Opening output side, rate: %u", stm, stm->input_stream_params.rate);
     r = audiounit_create_unit(&stm->output_unit, false,
                               &stm->output_stream_params,
                               stm->output_device);
@@ -1205,6 +1203,9 @@ setup_audiounit_stream(cubeb_stream * stm)
 
   /* Setup Input Stream! */
   if (has_input(stm)) {
+    LOG("(%p) Opening input side: rate %u, channels %u, format %d, latency in frames %u.",
+        stm, stm->input_stream_params.rate, stm->input_stream_params.channels,
+        stm->input_stream_params.format, stm->latency_frames);
     /* Get input device sample rate. */
     AudioStreamBasicDescription input_hw_desc;
     size = sizeof(AudioStreamBasicDescription);
@@ -1219,6 +1220,7 @@ setup_audiounit_stream(cubeb_stream * stm)
       return CUBEB_ERROR;
     }
     stm->input_hw_rate = input_hw_desc.mSampleRate;
+    LOG("(%p) Input device sampling rate: %.2f", stm, stm->input_hw_rate);
 
     /* Set format description according to the input params. */
     r = audio_stream_desc_init(&stm->input_desc, &stm->input_stream_params);
@@ -1298,6 +1300,9 @@ setup_audiounit_stream(cubeb_stream * stm)
 
   /* Setup Output Stream! */
   if (has_output(stm)) {
+    LOG("(%p) Opening output side: rate %u, channels %u, format %d, latency in frames %u.",
+        stm, stm->output_stream_params.rate, stm->output_stream_params.channels,
+        stm->output_stream_params.format, stm->latency_frames);
     r = audio_stream_desc_init(&stm->output_desc, &stm->output_stream_params);
     if (r != CUBEB_OK) {
       LOG("(%p) Could not initialize the audio stream description.", stm);
@@ -1318,6 +1323,7 @@ setup_audiounit_stream(cubeb_stream * stm)
       PRINT_ERROR_CODE("AudioUnitGetProperty/output/tkAudioUnitProperty_StreamFormat", r);
       return CUBEB_ERROR;
     }
+    LOG("(%p) Output device sampling rate: %.2f", stm, output_hw_desc.mSampleRate);
 
     r = AudioUnitSetProperty(stm->output_unit,
                              kAudioUnitProperty_StreamFormat,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -258,6 +258,8 @@ audiotimestamp_to_latency(AudioTimeStamp const * tstamp, cubeb_stream * stream)
 static void
 audiounit_make_silent(AudioBuffer * ioData)
 {
+  assert(ioData);
+  assert(ioData->mData);
   memset(ioData->mData, 0, ioData->mDataByteSize);
 }
 
@@ -286,7 +288,6 @@ audiounit_render_input(cubeb_stream * stm,
 
   if (r != noErr) {
     PRINT_ERROR_CODE("AudioUnitRender", r);
-    audiounit_make_silent(&input_buffer_list.mBuffers[0]);
     return r;
   }
 


### PR DESCRIPTION
The branch contains an number of fixes found using the Logitech c920 and c930 webcam.

- Bug1306247: Do not crash when camera is unplugged.
- Bug1272386: Do not assert on debug when c930 starts.
- Bug1311911: Build up latency with c920.
- Switch to default device when camera is unplugged or when a different default device is chosen from audio settings.
- Add some useful debug logs.
- Correct small errors.

About device switching behavior a discussion is on going on #167. The device switching behavior implemented here is not the final but a good compromise till we reach to a conclusion.