### PR TITLE
 Make API visible cubeb_device_info members and cubeb_devid const.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -167,7 +167,7 @@ typedef enum {
 
 /** An opaque handle used to refer a particular input or output device
  *  across calls. */
-typedef void * cubeb_devid;
+typedef void const * cubeb_devid;
 
 /** Level (verbosity) of logging for a particular cubeb context. */
 typedef enum {
@@ -276,10 +276,10 @@ typedef enum {
  *  `cubeb_device_info_destroy`. */
 typedef struct {
   cubeb_devid devid;          /**< Device identifier handle. */
-  char * device_id;           /**< Device identifier which might be presented in a UI. */
-  char * friendly_name;       /**< Friendly device name which might be presented in a UI. */
-  char * group_id;            /**< Two devices have the same group identifier if they belong to the same physical device; for example a headset and microphone. */
-  char * vendor_name;         /**< Optional vendor name, may be NULL. */
+  char const * device_id;     /**< Device identifier which might be presented in a UI. */
+  char const * friendly_name; /**< Friendly device name which might be presented in a UI. */
+  char const * group_id;      /**< Two devices have the same group identifier if they belong to the same physical device; for example a headset and microphone. */
+  char const * vendor_name;   /**< Optional vendor name, may be NULL. */
 
   cubeb_device_type type;     /**< Type of device (Input/Output). */
   cubeb_device_state state;   /**< State of device disabled/enabled/unplugged. */
@@ -322,7 +322,7 @@ typedef struct {
             and the stream will enter a shutdown state. */
 typedef long (* cubeb_data_callback)(cubeb_stream * stream,
                                      void * user_ptr,
-                                     const void * input_buffer,
+                                     void const * input_buffer,
                                      void * output_buffer,
                                      long nframes);
 
@@ -347,7 +347,7 @@ typedef void (* cubeb_device_collection_changed_callback)(cubeb * context,
                                                           void * user_ptr);
 
 /** User supplied callback called when a message needs logging. */
-typedef void (* cubeb_log_callback)(const char * fmt, ...);
+typedef void (* cubeb_log_callback)(char const * fmt, ...);
 
 /** Initialize an application context.  This will perform any library or
     application scoped initialization.

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -514,10 +514,10 @@ int cubeb_device_info_destroy(cubeb_device_info * info)
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 
-  free(info->device_id);
-  free(info->friendly_name);
-  free(info->group_id);
-  free(info->vendor_name);
+  free((void *) info->device_id);
+  free((void *) info->friendly_name);
+  free((void *) info->group_id);
+  free((void *) info->vendor_name);
 
   free(info);
   return CUBEB_OK;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -105,8 +105,8 @@ int wasapi_stream_stop(cubeb_stream * stm);
 int wasapi_stream_start(cubeb_stream * stm);
 void close_wasapi_stream(cubeb_stream * stm);
 int setup_wasapi_stream(cubeb_stream * stm);
-static char * wstr_to_utf8(const wchar_t * str);
-static std::unique_ptr<const wchar_t[]> utf8_to_wstr(char* str);
+static char const * wstr_to_utf8(wchar_t const * str);
+static std::unique_ptr<wchar_t const []> utf8_to_wstr(char const * str);
 
 }
 
@@ -1414,14 +1414,13 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   // possibilities.
   do {
     if (devid) {
-      std::unique_ptr<const wchar_t[]> id(utf8_to_wstr(reinterpret_cast<char*>(devid)));
+      std::unique_ptr<wchar_t const []> id(utf8_to_wstr(reinterpret_cast<char const *>(devid)));
       hr = get_endpoint(&device, id.get());
       if (FAILED(hr)) {
         LOG("Could not get %s endpoint, error: %x\n", DIRECTION_NAME, hr);
         return CUBEB_ERROR;
       }
-    }
-    else {
+    } else {
       hr = get_default_endpoint(&device, direction);
       if (FAILED(hr)) {
         LOG("Could not get default %s endpoint, error: %x\n", DIRECTION_NAME, hr);
@@ -1979,33 +1978,29 @@ int wasapi_stream_set_volume(cubeb_stream * stm, float volume)
   return CUBEB_OK;
 }
 
-static char *
+static char const *
 wstr_to_utf8(LPCWSTR str)
 {
-  char * ret = NULL;
-  int size;
-
-  size = ::WideCharToMultiByte(CP_UTF8, 0, str, -1, ret, 0, NULL, NULL);
-  if (size > 0) {
-    ret = static_cast<char *>(malloc(size));
-    ::WideCharToMultiByte(CP_UTF8, 0, str, -1, ret, size, NULL, NULL);
+  int size = ::WideCharToMultiByte(CP_UTF8, 0, str, -1, nullptr, 0, NULL, NULL);
+  if (size <= 0) {
+    return nullptr;
   }
 
+  char * ret = static_cast<char *>(malloc(size));
+  ::WideCharToMultiByte(CP_UTF8, 0, str, -1, ret, size, NULL, NULL);
   return ret;
 }
 
-static std::unique_ptr<const wchar_t[]>
-utf8_to_wstr(char* str)
+static std::unique_ptr<wchar_t const []>
+utf8_to_wstr(char const * str)
 {
-  std::unique_ptr<wchar_t[]> ret;
-  int size;
-
-  size = ::MultiByteToWideChar(CP_UTF8, 0, str, -1, nullptr, 0);
-  if (size > 0) {
-    ret.reset(new wchar_t[size]);
-    ::MultiByteToWideChar(CP_UTF8, 0, str, -1, ret.get(), size);
+  int size = ::MultiByteToWideChar(CP_UTF8, 0, str, -1, nullptr, 0);
+  if (size <= 0) {
+    return nullptr;
   }
 
+  std::unique_ptr<wchar_t []> ret(new wchar_t[size]);
+  ::MultiByteToWideChar(CP_UTF8, 0, str, -1, ret.get(), size);
   return std::move(ret);
 }
 


### PR DESCRIPTION
 Make API visible cubeb_device_info members and cubeb_devid const.

The API user is never permitted to modify these (nor deallocate them
directly, which non-const can imply), so they should marked const in the
public definition.

I suspect this happened originally because free()ing the
cubeb_device_info members requires casting const away in
cubeb_device_info_destroy, but other than being slightly ugly there's no
problem doing that and it's better to have the public API be consistent.

This also allows fixing the const-ness of utf8_to_wstr and wstr_to_utf8
const in cubeb_wasapi.cpp.

r? @padenot