### PR TITLE
Avoid using cubeb_devid internally.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -168,9 +168,9 @@ struct cubeb_stream {
   /* Stream creation parameters */
   cubeb_stream_params input_stream_params;
   cubeb_stream_params output_stream_params;
-  cubeb_devid input_device;
   bool is_default_input;
-  cubeb_devid output_device;
+  AudioDeviceID input_device;
+  AudioDeviceID output_device;
   /* User pointer of data_callback */
   void * user_ptr;
   /* Format descriptions */
@@ -601,13 +601,13 @@ audiounit_property_listener_callback(AudioObjectID /* id */, UInt32 address_coun
       case kAudioHardwarePropertyDefaultOutputDevice: {
           LOG("Event[%d] - mSelector == kAudioHardwarePropertyDefaultOutputDevice", i);
           // Allow restart to choose the new default
-          stm->output_device = nullptr;
+          stm->output_device = 0;
         }
         break;
       case kAudioHardwarePropertyDefaultInputDevice: {
           LOG("Event[%d] - mSelector == kAudioHardwarePropertyDefaultInputDevice", i);
           // Allow restart to choose the new default
-          stm->input_device = nullptr;
+          stm->input_device = 0;
         }
       break;
       case kAudioDevicePropertyDeviceIsAlive: {
@@ -619,7 +619,7 @@ audiounit_property_listener_callback(AudioObjectID /* id */, UInt32 address_coun
             return noErr;
           }
           // Allow restart to choose the new default. Event register only for input.
-          stm->input_device = nullptr;
+          stm->input_device = 0;
         }
         break;
       case kAudioDevicePropertyDataSource:
@@ -758,7 +758,7 @@ audiounit_install_device_changed_callback(cubeb_stream * stm)
     }
 
     /* Event to notify when the input is going away. */
-    AudioDeviceID dev = stm->input_device ? reinterpret_cast<intptr_t>(stm->input_device) :
+    AudioDeviceID dev = stm->input_device ? stm->input_device :
                                             audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_INPUT);
     r = audiounit_add_listener(stm, dev, kAudioDevicePropertyDeviceIsAlive,
         kAudioObjectPropertyScopeGlobal, &audiounit_property_listener_callback);
@@ -1043,7 +1043,7 @@ static int
 audiounit_create_unit(AudioUnit * unit,
                       bool is_input,
                       const cubeb_stream_params * /* stream_params */,
-                      cubeb_devid device)
+                      AudioDeviceID device)
 {
   AudioComponentDescription desc;
   AudioComponent comp;
@@ -1060,7 +1060,7 @@ audiounit_create_unit(AudioUnit * unit,
   // so we retain automatic output device switching when the default
   // changes.  Once we have complete support for device notifications
   // and switching, we can use the AUHAL for everything.
-  bool use_default_output = device == NULL && !is_input;
+  bool use_default_output = device == 0 && !is_input;
   if (use_default_output) {
     desc.componentSubType = kAudioUnitSubType_DefaultOutput;
   } else {
@@ -1101,11 +1101,11 @@ audiounit_create_unit(AudioUnit * unit,
       return CUBEB_ERROR;
     }
 
-    if (device == NULL) {
+    if (device == 0) {
       assert(is_input);
       devid = audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_INPUT);
     } else {
-      devid = reinterpret_cast<intptr_t>(device);
+      devid = device;
     }
     rv = AudioUnitSetProperty(*unit, kAudioOutputUnitProperty_CurrentDevice,
                               kAudioUnitScope_Global,
@@ -1560,14 +1560,13 @@ audiounit_stream_init(cubeb * context,
   stm->device_changed_callback = NULL;
   if (input_stream_params) {
     stm->input_stream_params = *input_stream_params;
-    stm->input_device = input_device;
-    stm->is_default_input = input_device == nullptr ||
-                            (audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_INPUT) ==
-                                                  reinterpret_cast<intptr_t>(input_device));
+    stm->input_device = reinterpret_cast<uintptr_t>(input_device);
+    stm->is_default_input = stm->input_device == 0 ||
+                            (audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_INPUT) == stm->input_device);
   }
   if (output_stream_params) {
     stm->output_stream_params = *output_stream_params;
-    stm->output_device = output_device;
+    stm->output_device = reinterpret_cast<uintptr_t>(output_device);
   }
 
   /* Init data members where necessary */
@@ -1821,7 +1820,7 @@ int audiounit_stream_set_panning(cubeb_stream * stm, float panning)
 }
 
 int audiounit_stream_get_current_device(cubeb_stream * stm,
-                                        cubeb_device ** const  device)
+                                        cubeb_device ** const device)
 {
 #if TARGET_OS_IPHONE
   //TODO
@@ -2111,7 +2110,8 @@ audiounit_create_device_from_hwdev(AudioObjectID devid, cubeb_device_type type)
   adr.mSelector = kAudioDevicePropertyDeviceUID;
   if (AudioObjectGetPropertyData(devid, &adr, 0, NULL, &size, &str) == noErr && str != NULL) {
     ret->device_id = audiounit_strref_to_cstr_utf8(str);
-    ret->devid = (cubeb_devid)(size_t)devid;
+    static_assert(sizeof(cubeb_devid) >= sizeof(decltype(devid)), "cubeb_devid can't represent devid");
+    ret->devid = reinterpret_cast<cubeb_devid>(devid);
     ret->group_id = strdup(ret->device_id);
     CFRelease(str);
   }

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -993,9 +993,9 @@ cbjack_enumerate_devices(cubeb * context, cubeb_device_type type,
   const char * j_out = "JACK playback";
 
   if (type & CUBEB_DEVICE_TYPE_OUTPUT) {
-    context->devinfo[i] = (cubeb_device_info *)malloc(sizeof(cubeb_device_info));
+    context->devinfo[i] = (cubeb_device_info *) malloc(sizeof(cubeb_device_info));
     context->devinfo[i]->device_id = strdup(j_out);
-    context->devinfo[i]->devid = context->devinfo[i]->device_id;
+    context->devinfo[i]->devid = (cubeb_devid) context->devinfo[i]->device_id;
     context->devinfo[i]->friendly_name = strdup(j_out);
     context->devinfo[i]->group_id = strdup(j_out);
     context->devinfo[i]->vendor_name = strdup(j_out);
@@ -1014,9 +1014,9 @@ cbjack_enumerate_devices(cubeb * context, cubeb_device_type type,
   }
 
   if (type & CUBEB_DEVICE_TYPE_INPUT) {
-    context->devinfo[i] = (cubeb_device_info *)malloc(sizeof(cubeb_device_info));
+    context->devinfo[i] = (cubeb_device_info *) malloc(sizeof(cubeb_device_info));
     context->devinfo[i]->device_id = strdup(j_in);
-    context->devinfo[i]->devid = context->devinfo[i]->device_id;
+    context->devinfo[i]->devid = (cubeb_devid) context->devinfo[i]->device_id;
     context->devinfo[i]->friendly_name = strdup(j_in);
     context->devinfo[i]->group_id = strdup(j_in);
     context->devinfo[i]->vendor_name = strdup(j_in);

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -752,7 +752,7 @@ pulse_stream_init(cubeb * context,
 
     battr = set_buffering_attribute(latency_frames, &stm->output_sample_spec);
     WRAP(pa_stream_connect_playback)(stm->output_stream,
-                                     output_device,
+                                     (char const *) output_device,
                                      &battr,
                                      PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING |
                                      PA_STREAM_START_CORKED | PA_STREAM_ADJUST_LATENCY,
@@ -775,7 +775,7 @@ pulse_stream_init(cubeb * context,
 
     battr = set_buffering_attribute(latency_frames, &stm->input_sample_spec);
     WRAP(pa_stream_connect_record)(stm->input_stream,
-                                   input_device,
+                                   (char const *) input_device,
                                    &battr,
                                    PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING |
                                    PA_STREAM_START_CORKED | PA_STREAM_ADJUST_LATENCY);
@@ -1070,7 +1070,7 @@ pulse_get_state_from_sink_port(pa_sink_port_info * info)
 
 static void
 pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
-    int eol, void * user_data)
+                   int eol, void * user_data)
 {
   pulse_dev_list_data * list_data = user_data;
   cubeb_device_info * devinfo;
@@ -1084,7 +1084,7 @@ pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
   devinfo = calloc(1, sizeof(cubeb_device_info));
 
   devinfo->device_id = strdup(info->name);
-  devinfo->devid = devinfo->device_id;
+  devinfo->devid = (cubeb_devid) devinfo->device_id;
   devinfo->friendly_name = strdup(info->description);
   prop = WRAP(pa_proplist_gets)(info->proplist, "sysfs.path");
   if (prop)
@@ -1144,7 +1144,7 @@ pulse_source_info_cb(pa_context * context, const pa_source_info * info,
   devinfo = calloc(1, sizeof(cubeb_device_info));
 
   devinfo->device_id = strdup(info->name);
-  devinfo->devid = devinfo->device_id;
+  devinfo->devid = (cubeb_devid) devinfo->device_id;
   devinfo->friendly_name = strdup(info->description);
   prop = WRAP(pa_proplist_gets)(info->proplist, "sysfs.path");
   if (prop)

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -803,11 +803,11 @@ winmm_query_supported_formats(UINT devid, DWORD formats,
 static char *
 guid_to_cstr(LPGUID guid)
 {
-  char * ret = malloc(sizeof(char) * 40);
+  char * ret = malloc(40);
   if (!ret) {
     return NULL;
   }
-  _snprintf_s(ret, sizeof(char) * 40, _TRUNCATE,
+  _snprintf_s(ret, 40, _TRUNCATE,
       "{%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}",
       guid->Data1, guid->Data2, guid->Data3,
       guid->Data4[0], guid->Data4[1], guid->Data4[2], guid->Data4[3],
@@ -821,12 +821,12 @@ winmm_query_preferred_out_device(UINT devid)
   DWORD mmpref = WAVE_MAPPER, compref = WAVE_MAPPER, status;
   cubeb_device_pref ret = CUBEB_DEVICE_PREF_NONE;
 
-  if (waveOutMessage((HWAVEOUT)(size_t)WAVE_MAPPER, DRVM_MAPPER_PREFERRED_GET,
+  if (waveOutMessage((HWAVEOUT) WAVE_MAPPER, DRVM_MAPPER_PREFERRED_GET,
         (DWORD_PTR)&mmpref, (DWORD_PTR)&status) == MMSYSERR_NOERROR &&
       devid == mmpref)
     ret |= CUBEB_DEVICE_PREF_MULTIMEDIA | CUBEB_DEVICE_PREF_NOTIFICATION;
 
-  if (waveOutMessage((HWAVEOUT)(size_t)WAVE_MAPPER, DRVM_MAPPER_CONSOLEVOICECOM_GET,
+  if (waveOutMessage((HWAVEOUT) WAVE_MAPPER, DRVM_MAPPER_CONSOLEVOICECOM_GET,
         (DWORD_PTR)&compref, (DWORD_PTR)&status) == MMSYSERR_NOERROR &&
       devid == compref)
     ret |= CUBEB_DEVICE_PREF_VOICE;
@@ -837,7 +837,7 @@ winmm_query_preferred_out_device(UINT devid)
 static char *
 device_id_idx(UINT devid)
 {
-  char * ret = (char *)malloc(sizeof(char)*16);
+  char * ret = malloc(16);
   if (!ret) {
     return NULL;
   }
@@ -854,7 +854,7 @@ winmm_create_device_from_outcaps2(LPWAVEOUTCAPS2A caps, UINT devid)
   if (!ret) {
     return NULL;
   }
-  ret->devid = (cubeb_devid)(size_t)devid;
+  ret->devid = (cubeb_devid) devid;
   ret->device_id = device_id_idx(devid);
   ret->friendly_name = _strdup(caps->szPname);
   ret->group_id = guid_to_cstr(&caps->ProductGuid);
@@ -885,7 +885,7 @@ winmm_create_device_from_outcaps(LPWAVEOUTCAPSA caps, UINT devid)
   if (!ret) {
     return NULL;
   }
-  ret->devid = (cubeb_devid)(size_t)devid;
+  ret->devid = (cubeb_devid) devid;
   ret->device_id = device_id_idx(devid);
   ret->friendly_name = _strdup(caps->szPname);
   ret->group_id = NULL;
@@ -913,12 +913,12 @@ winmm_query_preferred_in_device(UINT devid)
   DWORD mmpref = WAVE_MAPPER, compref = WAVE_MAPPER, status;
   cubeb_device_pref ret = CUBEB_DEVICE_PREF_NONE;
 
-  if (waveInMessage((HWAVEIN)(size_t)WAVE_MAPPER, DRVM_MAPPER_PREFERRED_GET,
+  if (waveInMessage((HWAVEIN) WAVE_MAPPER, DRVM_MAPPER_PREFERRED_GET,
         (DWORD_PTR)&mmpref, (DWORD_PTR)&status) == MMSYSERR_NOERROR &&
       devid == mmpref)
     ret |= CUBEB_DEVICE_PREF_MULTIMEDIA | CUBEB_DEVICE_PREF_NOTIFICATION;
 
-  if (waveInMessage((HWAVEIN)(size_t)WAVE_MAPPER, DRVM_MAPPER_CONSOLEVOICECOM_GET,
+  if (waveInMessage((HWAVEIN) WAVE_MAPPER, DRVM_MAPPER_CONSOLEVOICECOM_GET,
         (DWORD_PTR)&compref, (DWORD_PTR)&status) == MMSYSERR_NOERROR &&
       devid == compref)
     ret |= CUBEB_DEVICE_PREF_VOICE;
@@ -935,7 +935,7 @@ winmm_create_device_from_incaps2(LPWAVEINCAPS2A caps, UINT devid)
   if (!ret) {
     return NULL;
   }
-  ret->devid = (cubeb_devid)(size_t)devid;
+  ret->devid = (cubeb_devid) devid;
   ret->device_id = device_id_idx(devid);
   ret->friendly_name = _strdup(caps->szPname);
   ret->group_id = guid_to_cstr(&caps->ProductGuid);
@@ -966,7 +966,7 @@ winmm_create_device_from_incaps(LPWAVEINCAPSA caps, UINT devid)
   if (!ret) {
     return NULL;
   }
-  ret->devid = (cubeb_devid)(size_t)devid;
+  ret->devid = (cubeb_devid) devid;
   ret->device_id = device_id_idx(devid);
   ret->friendly_name = _strdup(caps->szPname);
   ret->group_id = NULL;


### PR DESCRIPTION
cubeb_devid is intended to be an opaque type for API users.  Internally,
a cubeb_devid should be converted to the original type at the earliest
possible point.

It's difficult to get the types right on all platforms, since some of the internal types for cubeb_devid have implicit conversion to and from void*.  A useful compile test is to change the definition of cubeb_devid from void* to uintptr_t and rebuild, fixing whatever breaks.

It'd be nice if cubeb_devid was always defined as uintptr_t, but that loses the nice API property that allows passing a NULL pointer for the default device.

Note, this is based on the constify_api branch, so must be merged in the correct order.