### PR TITLE
Implement a lock-free single consumer single producer queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
     - compiler: clang
       env: SCAN_BUILD=true
       os: linux
-    - compiler: gcc
+    - compiler: gcc-5
       os: linux
-    - compiler: gcc
+    - compiler: gcc-5
       env: HOST=i686-w64-mingw32
       os: linux
     - compiler: clang
@@ -19,6 +19,7 @@ matrix:
       env: SCAN_BUILD=true
       os: osx
     - env: ANDROID=android-ndk-r13b
+      compiler: gcc-5
       os: linux
 before_install:
   - if [[ -n $SCAN_BUILD ]]; then
@@ -63,7 +64,7 @@ before_script:
       if [[ -n $ANDROID ]]; then
         cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-cross-android.cmake -DANDROID_NATIVE_API_LEVEL=android-15 -DCMAKE_BUILD_TYPE=Debug ..;
       else
-        $SCAN_BUILD_PATH cmake -DCMAKE_BUILD_TYPE=Debug ..;
+        $SCAN_BUILD_PATH cmake -DCMAKE_BUILD_TYPE=Debug VERBOSE=1 ..;
       fi;
     fi
 script:
@@ -79,5 +80,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - gcc-5
+      - g++-5
       - clang-3.8
       - libc++-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,5 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-5
-      - g++-5
       - clang-3.8
       - libc++-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,3 +204,8 @@ target_include_directories(test_utils PRIVATE ${gtest_SOURCE_DIR}/include)
 target_include_directories(test_utils PRIVATE src)
 target_link_libraries(test_utils PRIVATE cubeb gtest_main)
 add_test(utils test_utils)
+
+add_executable(test_ring_buffer test/test_ring_buffer.cpp)
+target_include_directories(test_ring_buffer PRIVATE src)
+target_link_libraries(test_ring_buffer PRIVATE cubeb)
+add_test(ring_buffer test_ring_buffer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ target_link_libraries(test_utils PRIVATE cubeb gtest_main)
 add_test(utils test_utils)
 
 add_executable(test_ring_buffer test/test_ring_buffer.cpp)
+target_include_directories(test_ring_buffer PRIVATE ${gtest_SOURCE_DIR}/include)
 target_include_directories(test_ring_buffer PRIVATE src)
-target_link_libraries(test_ring_buffer PRIVATE cubeb)
+target_link_libraries(test_ring_buffer PRIVATE cubeb gtest_main)
 add_test(ring_buffer test_ring_buffer)

--- a/src/cubeb_ringbuffer.h
+++ b/src/cubeb_ringbuffer.h
@@ -5,12 +5,14 @@
  * accompanying file LICENSE for details.
  */
 
+#ifndef CUBEB_RING_BUFFER_H
+#define CUBEB_RING_BUFFER_H
+
 #include <memory>
 #include <cstdint>
 #include <atomic>
 #include <algorithm>
 #include "cubeb_utils.h"
-
 
 /* This enum allow choosing the behaviour of the queue. */
 enum ThreadSafety
@@ -64,13 +66,11 @@ struct ThreadSafePolicy<Unsafe>
  * producer should always be on one thread and the consumer should always be on
  * another thread.
  *
- * The public interface of this class uses frames.
- *
  * Some words about the inner workings of this class:
  * - Capacity is fixed. Only one allocation is performed, in the constructor.
  *   When reading and writing, the return value of the method allow checking if
  *   the ring buffer is empty or full.
- * - We always keep the read index at least one frame ahead of the write
+ * - We always keep the read index at least one element ahead of the write
  *   index, so we can distinguish between an empty and a full ring buffer: an
  *   empty ring buffer is when the write index is at the same position as the
  *   read index. A full buffer is when the write index is exactly one position
@@ -80,7 +80,7 @@ struct ThreadSafePolicy<Unsafe>
  *   thread can only touch a portion of the buffer that is not touched by the
  *   other thread.
  * - Callers are expected to provide buffers. When writing to the queue,
- *   frames are copied into the internal storage from the buffer passed in.
+ *   elements are copied into the internal storage from the buffer passed in.
  *   When reading from the queue, the user is expected to provide a buffer.
  *   Because this is a ring buffer, data might not be contiguous in memory,
  *   providing an external buffer to copy into is an easy way to have linear
@@ -97,62 +97,71 @@ public:
    * This performs an allocation, but is the only allocation that will happen
    * for the life time of a `ring_buffer_base`.
    *
-   * @param channel_count the number of channels of the stream for this ring buffer.
-   * @param capacity_in_frames The maximum number of frames this ring buffer will hold.
+   * @param capacity The maximum number of element this ring buffer will hold.
    */
-  ring_buffer_base(int channel_count, int capacity_in_frames)
+  ring_buffer_base(int capacity)
     : read_index_(0)
     , write_index_(0)
-    , channel_count_(channel_count)
-    /* One frame more to distinguish from emtpy and full buffer. */
-    , capacity_(frames_to_samples(capacity_in_frames + 1))
+    /* One more element to distinguish from emtpy and full buffer. */
+    , capacity_(capacity + 1)
   {
-    static_assert(std::is_trivial<T>::value,
+    static_assert(std::is_trivially_copyable<T>::value,
                   "ring_buffer_base requires trivial type");
 
     assert(storage_capacity() <
            std::numeric_limits<RingBufferIndex>::max() &&
            "buffer to large for the type of index used.");
-    assert(channel_count_ > 0);
-    assert(capacity_in_frames > 0);
+    assert(capacity_ > 0);
 
-    data_.reset(new T[frames_to_samples(storage_capacity())]);
+    data_.reset(new T[storage_capacity()]);
     PodZero(data_.get(), storage_capacity());
   }
   /**
-   * Push `count` silent frames into the ring buffer.
+   * Push `count` zero or default constructed elements in the array.
    *
    * Only safely called on the producer thread.
    *
-   * @param count The number of frames of silence to enqueue.
-   * @return The number of frames of silence actually enqueued.
+   * @param count The number of elements to enqueue.
+   * @return The number of element enqueued.
    */
-  int enqueue_silence(int count)
+  int enqueue_default(int count)
   {
     return enqueue(nullptr, count);
   }
   /**
-   * Push `count` frames of audio in the ring buffer.
+   * @brief Put an element in the queue
    *
    * Only safely called on the producer thread.
    *
-   * @param frames a pointer to a buffer containing at least `count` audio
-   * frames. If `frames` is `nullptr`, silence is enqueued.
-   * @param count The number of audio frames to read from `frames`
-   * @return The number of frames successfully copy from `frames` and inserted
+   * @param element The element to put in the queue.
+   *
+   * @return 1 if the element was inserted, 0 otherwise.
+   */
+  int enqueue(T& element)
+  {
+    return enqueue(&element, 1);
+  }
+  /**
+   * Push `count` elements in the ring buffer.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @param elements a pointer to a buffer containing at least `count` elements.
+   * If `elements` is nullptr, zero or default constructed elements are enqueued.
+   * @param count The number of elements to read from `elements`
+   * @return The number of elements successfully coped from `elements` and inserted
    * into the ring buffer.
    */
-  int enqueue(T * frames, int count)
+  int enqueue(T * elements, int count)
   {
     int rd_idx = read_index_;
     int wr_idx = write_index_;
 
-    if (full_internal_samples(rd_idx, wr_idx)) {
+    if (full_internal(rd_idx, wr_idx)) {
       return 0;
     }
 
-    int to_write = std::min(available_write_internal_samples(rd_idx, wr_idx),
-                            frames_to_samples(count));
+    int to_write = std::min(available_write_internal(rd_idx, wr_idx), count);
 
     /* First part, from the write index to the end of the array. */
     int first_part = std::min(storage_capacity() - wr_idx,
@@ -160,9 +169,9 @@ public:
     /* Second part, from the beginning of the array */
     int second_part = to_write - first_part;
 
-    if (frames) {
-      PodCopy(data_.get() + wr_idx, frames, first_part);
-      PodCopy(data_.get(), frames + first_part, second_part);
+    if (elements) {
+      PodCopy(data_.get() + wr_idx, elements, first_part);
+      PodCopy(data_.get(), elements + first_part, second_part);
     } else {
       PodZero(data_.get() + wr_idx, first_part);
       PodZero(data_.get(), second_part);
@@ -172,59 +181,57 @@ public:
 
     write_index_ = wr_idx;
 
-    return samples_to_frames(to_write);
+    return to_write;
   }
   /**
-   * Retrieve at most `count` frames from the ring buffer, and copy them to
-   * `frames`, if non-null.
+   * Retrieve at most `count` elements from the ring buffer, and copy them to
+   * `elements`, if non-null.
    *
    * Only safely called on the consumer side.
    *
-   * @param frames A pointer to a buffer with space for at least `count`
-   * frames of audio. If `frames` is `nullptr`, count frames will be discarded.
-   * @param count The maximum number of frames to dequeue.
-   * @return The number of frames of audio written to `frames`.
+   * @param elements A pointer to a buffer with space for at least `count`
+   * elements. If `elements` is `nullptr`, `count` element will be discarded.
+   * @param count The maximum number of elements to dequeue.
+   * @return The number of elements written to `elements`.
    */
-  int dequeue(T * frames, int count)
+  int dequeue(T * elements, int count)
   {
     int wr_idx = write_index_;
     int rd_idx = read_index_;
 
-    if (empty_internal_samples(rd_idx, wr_idx)) {
+    if (empty_internal(rd_idx, wr_idx)) {
       return 0;
     }
 
-    int to_read = std::min(available_read_internal_samples(rd_idx, wr_idx),
-                           frames_to_samples(count));
+    int to_read = std::min(available_read_internal(rd_idx, wr_idx), count);
 
     int first_part = std::min(storage_capacity() - rd_idx, to_read);
     int second_part = to_read - first_part;
 
-    if (frames) {
-      PodCopy(frames, data_.get() + rd_idx, first_part); 
-      PodCopy(frames + first_part, data_.get(), second_part);
+    if (elements) {
+      PodCopy(elements, data_.get() + rd_idx, first_part); 
+      PodCopy(elements + first_part, data_.get(), second_part);
     }
 
     increment_index(rd_idx, to_read);
 
     read_index_ = rd_idx;
 
-    return samples_to_frames(to_read);
+    return to_read;
   }
   /**
-   * Get the number of available frames of audio for consuming.
+   * Get the number of available element for consuming.
    *
    * Only safely called on the consumer thread.
    *
-   * @return The number of available frames of audio for reading.
+   * @return The number of available elements for reading.
    */
   int available_read() const
   {
-    return samples_to_frames(available_read_internal_samples(read_index_,
-                                                             write_index_));
+    return available_read_internal(read_index_, write_index_);
   }
   /**
-   * Get the number of available frames of audio for consuming.
+   * Get the number of available elements for consuming.
    *
    * Only safely called on the producer thread.
    *
@@ -232,19 +239,18 @@ public:
    */
   int available_write() const
   {
-    return samples_to_frames(available_write_internal_samples(read_index_,
-                                                              write_index_));
+    return available_write_internal(read_index_, write_index_);
   }
   /**
-   * Get total capacity, in frames, for this ring buffer.
+   * Get the total capacity, for this ring buffer.
    *
    * Can be called safely on any thread.
    *
-   * @return The maximum capacity, in frames, of this ring buffer.
+   * @return The maximum capacity of this ring buffer.
    */
   int capacity() const
   {
-    return samples_to_frames(capacity_) - 1;
+    return storage_capacity() - 1;
   }
   /** Return true if the ring buffer is empty.
    *
@@ -254,20 +260,20 @@ public:
    **/
   bool empty() const
   {
-    return empty_internal_samples(read_index_, write_index_);
+    return empty_internal(read_index_, write_index_);
   }
   /** Return true if the ring buffer is full.
    *
    * Can be called safely on any thread.
    *
-   * This happens if the write index is exactly one frame behind the read
+   * This happens if the write index is exactly one element behind the read
    * index.
    *
    * @return true if the ring buffer is full, false otherwise.
    **/
   bool full() const
   {
-    return full_internal_samples(read_index_, write_index_);
+    return full_internal(read_index_, write_index_);
   }
 private:
   /** Return true if the ring buffer is empty.
@@ -276,59 +282,39 @@ private:
    * @param write_index the write index to consider
    * @return true if the ring buffer is empty, false otherwise.
    **/
-  bool empty_internal_samples(int read_index, int write_index) const
+  bool empty_internal(int read_index, int write_index) const
   {
     return write_index == read_index;
   }
   /** Return true if the ring buffer is full.
    *
-   * This happens if the write index is exactly one frame behind the read
+   * This happens if the write index is exactly one element behind the read
    * index.
    *
    * @param read_index the read index to consider
    * @param write_index the write index to consider
    * @return true if the ring buffer is full, false otherwise.
    **/
-  bool full_internal_samples(int read_index, int write_index) const
+  bool full_internal(int read_index, int write_index) const
   {
-    return (write_index + channel_count_) % capacity_ == read_index;
+    return (write_index + 1) % capacity_ == read_index;
   }
   /**
-   * Return the size of the storage. It is one more than the number of frames
+   * Return the size of the storage. It is one more than the number of elements
    * that can be stored in the buffer.
    *
-   * @return the number of frames that can be stored in the buffer.
+   * @return the number of elements that can be stored in the buffer.
    */
   int storage_capacity() const
   {
     return capacity_;
   }
   /**
-   * Convert from frames to samples.
+   * Returns the number of elements available for reading.
    *
-   * @param frames A number of frames
-   * @return int The number of samples.
+   * @return the number of available elements for reading.
    */
-  int frames_to_samples(int frames) const
-  {
-     return frames * channel_count_;
-  }
-  /**
-   * Convert from samples to frames.
-   *
-   * @param frames A number of samples
-   * @return int The number of frames.
-   */
-  int samples_to_frames(int samples) const
-  {
-     return samples / channel_count_;
-  }
-  /**
-   * Returns the number of samples available for reading.
-   *
-   * @return the number of available samples for reading.
-   */
-  int available_read_internal_samples(int read_index, int write_index) const
+  int available_read_internal(int read_index, int write_index) const
   {
     if (write_index >= read_index) {
       return write_index - read_index;
@@ -337,16 +323,15 @@ private:
     }
   }
   /**
-   * Returns the number of empty samples, available for writing.
+   * Returns the number of empty elements, available for writing.
    *
-   * @return the number of samples that can be written into the array.
+   * @return the number of elements that can be written into the array.
    */
-  int available_write_internal_samples(int read_index, int write_index) const
+  int available_write_internal(int read_index, int write_index) const
   {
-    /* We substract one frame (`channel_count_` samples) here to always keep at
-     * least one sample free in the buffer, to distinguish between full and
-     * empty array. */
-    int rv = read_index - write_index - channel_count_;
+    /* We substract one element here to always keep at least one sample
+     * free in the buffer, to distinguish between full and empty array. */
+    int rv = read_index - write_index - 1;
     if (write_index >= read_index) {
       rv += capacity_;
     }
@@ -366,17 +351,165 @@ private:
      * computation step: it should only be assigned once. */
     index = (index + increment) % capacity_;
   }
-  /** Index at which the oldest frame is at, in samples. */
+  /** Index at which the oldest element is at, in samples. */
   typename ThreadSafePolicy<Safety>::IndexType read_index_;
-  /** Index at which to write new frames, in samples. `write_index` is always at
-   * least one frames ahead of `read_index_`. */
+  /** Index at which to write new elements. `write_index` is always at
+   * least one element ahead of `read_index_`. */
   typename ThreadSafePolicy<Safety>::IndexType write_index_;
-  /** Channel count for this ring buffer. */
-  const int channel_count_;
-  /** Number of samples at maximum that can be stored in the ring buffer. */
+  /** Maximum number of elements that can be stored in the ring buffer. */
   const int capacity_;
   /** Data storage */
   std::unique_ptr<T[]> data_;
+};
+
+/**
+ * Adapter for `ring_buffer_base` that exposes an interface in frames.
+ */
+template <typename T,
+          ThreadSafety Safety = ThreadSafety::Safe>
+class audio_ring_buffer_base
+{
+public:
+  /**
+   * @brief Constructor.
+   *
+   * @param channel_count       Number of channels.
+   * @param capacity_in_frames  The capacity in frames.
+   */
+  audio_ring_buffer_base(int channel_count, int capacity_in_frames)
+    : channel_count(channel_count)
+    , ring_buffer(frames_to_samples(capacity_in_frames))
+  {
+    assert(channel_count > 0);
+  }
+  /**
+   * @brief Enqueue silence.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @param frame_count The number of frames of silence to enqueue.
+   * @return  The number of frames of silence actually written to the queue.
+   */
+  int enqueue_default(int frame_count)
+  {
+    return samples_to_frames(ring_buffer.enqueue(nullptr, frames_to_samples(frame_count)));
+  }
+  /**
+   * @brief Enqueue `frames_count` frames of audio.
+   * 
+   * Only safely called from the producer thread.
+   *
+   * @param [in] frames If non-null, the frames to enqueue.
+   *                    Otherwise, silent frames are enqueued.
+   * @param frame_count The number of frames to enqueue.
+   *
+   * @return The number of frames enqueued
+   */
+
+  int enqueue(T * frames, int frame_count)
+  {
+    return samples_to_frames(ring_buffer.enqueue(frames, frames_to_samples(frame_count)));
+  }
+
+  /**
+   * @brief Removes `frame_count` frames from the buffer, and
+   *        write them to `frames` if it is non-null.
+   *
+   * Only safely called on the consumer thread.
+   *
+   * @param frames      If non-null, the frames are copied to `frames`.
+   *                    Otherwise, they are dropped.
+   * @param frame_count The number of frames to remove.
+   *
+   * @return  The number of frames actually dequeud.
+   */
+  int dequeue(T * frames, int frame_count)
+  {
+    return samples_to_frames(ring_buffer.dequeue(frames, frames_to_samples(frame_count)));
+  }
+  /**
+   * Get the number of available frames of audio for consuming.
+   *
+   * Only safely called on the consumer thread.
+   *
+   * @return The number of available frames of audio for reading.
+   */
+  int available_read() const
+  {
+    return samples_to_frames(ring_buffer.available_read());
+  }
+  /**
+   * Get the number of available frames of audio for consuming.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @return The number of empty slots in the buffer, available for writing.
+   */
+  int available_write() const
+  {
+    return samples_to_frames(ring_buffer.available_write());
+  }
+  /**
+   * Get the total capacity, for this ring buffer.
+   *
+   * Can be called safely on any thread.
+   *
+   * @return The maximum capacity of this ring buffer.
+   */
+  int capacity() const
+  {
+    return samples_to_frames(ring_buffer.capacity());
+  }
+  /** Return true if the ring buffer is empty.
+   *
+   * Can be called safely on any thread.
+   *
+   * @return true if the ring buffer is empty, false otherwise.
+   **/
+  bool empty() const
+  {
+    return ring_buffer.empty();
+  }
+  /** Return true if the ring buffer is full.
+   *
+   * Can be called safely on any thread.
+   *
+   * This happens if the write index is exactly one frame behind the read
+   * index.
+   *
+   * @return true if the ring buffer is full, false otherwise.
+   **/
+  bool full() const
+  {
+    return ring_buffer.full();
+  }
+private:
+  /**
+   * @brief Frames to samples conversion.
+   *
+   * @param frames The number of frames.
+   *
+   * @return  A number of samples.
+   */
+  int frames_to_samples(int frames) const
+  {
+    return frames * channel_count;
+  }
+  /**
+   * @brief Samples to frames conversion.
+   *
+   * @param samples The number of samples.
+   *
+   * @return  A number of frames.
+   */
+  int samples_to_frames(int samples) const
+  {
+    return samples / channel_count;
+  }
+  /** Number of channels of audio that will stream through this ring buffer. */
+  int channel_count;
+  /** The underlying ring buffer that is used to store the data. */
+  ring_buffer_base<T, Safety> ring_buffer;
 };
 
 /**
@@ -393,3 +526,19 @@ using lock_free_queue = ring_buffer_base<T, Safe>;
  */
 template<typename T>
 using queue = ring_buffer_base<T, Unsafe>;
+/**
+ * Lock-free instantiation of the `audio_ring_buffer` type. This is safe to use
+ * from two threads, one producer, one consumer (that never change role),
+ * without explicit synchronization.
+ */
+template<typename T>
+using lock_free_audio_ring_buffer = audio_ring_buffer_base<T, Safe>;
+/**
+ * An instantiation of the `audio_ring_buffer` type, to be used on a single
+ * thread: it is not safe to use from multiple threads without explicit external
+ * synchronization.
+ */
+template<typename T>
+using audio_ring_buffer = audio_ring_buffer_base<T, Unsafe>;
+
+#endif // CUBEB_RING_BUFFER_H

--- a/src/cubeb_ringbuffer.h
+++ b/src/cubeb_ringbuffer.h
@@ -1,0 +1,391 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#include <memory>
+#include <cstdint>
+#include <atomic>
+#include <algorithm>
+#include "cubeb_utils.h"
+
+
+/* This enum allow choosing the behaviour of the queue. */
+enum ThreadSafety
+{
+  /* No attempt to synchronize the queue is made. The queue is only safe when
+   * used on a single thread. */
+  Unsafe,
+  /** Atomics are used to synchronize read and write. The queue is safe to used
+   * from two thread: one producer, one consumer. */
+  Safe
+};
+
+/** Policy to enable thread safety on the queue. */
+template<ThreadSafety>
+struct ThreadSafePolicy;
+
+/** Policy for thread-safe internal index for the queue.
+ *
+ * For now, we use 32-bits index. 64-bits index could be used if needed, but it
+ * does not seem useful for real-time audio: that would mean we're buffering
+ * quite a lot of data if we go over the 32-bits limit.
+ */
+template<>
+struct ThreadSafePolicy<Safe>
+{
+  typedef std::atomic<int> IndexType;
+};
+
+/**
+ * This is the version with a simple `int` for index, for use when only a single
+ * thread is producing and releasing data.
+ */
+template<>
+struct ThreadSafePolicy<Unsafe>
+{
+  typedef int IndexType;
+};
+
+/**
+ * Single producer single consumer lock-free and wait-free ring buffer.
+ *
+ * This data structure allow producing data from one thread, and consuming it on
+ * another thread, safely and without explicit synchronization. If used on two
+ * threads, this data structure uses atomics for thread safety. It is possible
+ * to disable the use of atomics at compile time and only use this data
+ * structure on one thread.
+ *
+ * The role for the producer and the consumer must be constant, i.e., the same
+ * thread should always be the producer and another thread should always be the
+ * consumer.
+ *
+ * The public interface of this class uses frames.
+ *
+ * Some words about the inner workings of this class:
+ * - Capacity is fixed. Only one allocation is performed, in the constructor.
+ *   When reading and writing, the return value of the method allow checking is
+ *   the ring buffer is empty or full.
+ * - We always keep the read index at least one element ahead of the write
+ *   index, so we can distinguish between an empty and a full ring buffer: an
+ *   empty ring buffer is when the write index is at the same position as the
+ *   write index. A full buffer is when the write index is exactly one position
+ *   before the read index.
+ * - We synchronize updates to the read index after having read the data, and
+ *   the write index after having written the data. This means that the each
+ *   thread can only touch a portion of the buffer that is not touched by the
+ *   other thread.
+ * - Caller is expected to provide an output buffer. When writing to the queue,
+ *   elements are copied. When reading from the queue, the user is expected to
+ *   provide a buffer. Because this is a ring buffer, data might not be
+ *   contiguous in memory, providing an external buffer to copy into is an easy
+ *   way to have linear data for further processing.
+ */
+template <typename T,
+          ThreadSafety Safety = ThreadSafety::Safe>
+class ring_buffer_base
+{
+public:
+  /**
+   * Constructor for a ring buffer.
+   *
+   * This performs an allocation, but is the only allocation that will happen
+   * for the life time of a `ring_buffer_base`.
+   *
+   * @param channel_count the number of channels of the stream for this ring buffer.
+   * @param capacity_in_frames The maximum number of frames this ring buffer will hold.
+   */
+  ring_buffer_base(int channel_count, int capacity_in_frames)
+    : read_index_(0)
+    , write_index_(0)
+    , channel_count_(channel_count)
+    /* One element more to distinguish from emtpy and full buffer. */
+    , capacity_(frames_to_samples(capacity_in_frames + 1))
+  {
+    static_assert(std::is_trivial<T>::value,
+                  "ring_buffer_base requires trivial type");
+
+    assert(storage_capacity() < std::numeric_limits<T>::max() &&
+           "buffer to large for the type of index used.");
+    assert(channel_count_ > 0);
+    assert(capacity_in_frames > 0);
+
+    data_.reset(new T[frames_to_samples(storage_capacity())]);
+    PodZero(data_.get(), storage_capacity());
+  }
+  /**
+   * Push `count` silent frames into the ring buffer.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @param count The number of frames of silence to enqueue.
+   * @return The number of frames of silence actually enqueued.
+   */
+  int enqueue_silence(int count)
+  {
+    return enqueue(nullptr, count);
+  }
+  /**
+   * Push `count` frames of audio in the ring buffer.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @param elements a pointer to a buffer containing at least `count` audio
+   * frames. If `elements` is `nullptr`, silence is enqueued.
+   * @param count The number of audio frames to read from `elements`
+   * @return The number of frames successfully copy from elements and inserted
+   * into the ring buffer.
+   */
+  int enqueue(T * elements, int count)
+  {
+    int rd_idx = read_index_;
+    int wr_idx = write_index_;
+
+    if (full_internal(rd_idx, wr_idx)) {
+      return 0;
+    }
+
+    int to_write = std::min(available_write_internal(rd_idx, wr_idx),
+                            frames_to_samples(count));
+
+    /* First part, from the write index to the end of the array. */
+    int first_part = std::min(storage_capacity() - wr_idx,
+                              to_write);
+    /* Second part, from the beginning of the array */
+    int second_part = std::max(to_write - first_part, 0);
+
+    if (elements) {
+      PodCopy(data_.get() + wr_idx, elements, first_part);
+      PodCopy(data_.get(), elements + first_part, second_part);
+    } else {
+      PodZero(data_.get() + wr_idx, first_part);
+      PodZero(data_.get(), second_part);
+    }
+
+    increment_index(wr_idx, to_write);
+
+    write_index_ = wr_idx;
+
+    return samples_to_frames(to_write);
+  }
+  /**
+   * Retrieve at most `count` frames from the ring buffer, and copy them to
+   * `elements`, if non-null.
+   *
+   * Only safely called on the consumer side.
+   *
+   * @param elements A pointer to a buffer with space for at least `count`
+   * frames of audio. If `elements` is `nullptr`, elements will be discarded.
+   * @param count The maximum number of elements to dequeue.
+   * @return The number of frames of audio written to `elements`.
+   */
+  int dequeue(T * elements, int count)
+  {
+    int wr_idx = write_index_;
+    int rd_idx = read_index_;
+
+    if (empty_internal(rd_idx, wr_idx)) {
+      return 0;
+    }
+
+    int to_read = std::min(available_read_internal(rd_idx, wr_idx),
+                           frames_to_samples(count));
+
+    int first_part = std::min(storage_capacity() - rd_idx, to_read);
+    int second_part = std::max(to_read - first_part, 0);
+
+    if (elements) {
+      PodCopy(elements, data_.get() + rd_idx, first_part); 
+      PodCopy(elements + first_part, data_.get(), second_part);
+    }
+
+    increment_index(rd_idx, to_read);
+
+    read_index_ = rd_idx;
+
+    return samples_to_frames(to_read);
+  }
+  /**
+   * Get the number of available frames of audio for consuming.
+   *
+   * Only safely called on the consumer thread.
+   *
+   * @return The number of available frames of audio for reading.
+   */
+  int available_read() const
+  {
+    return samples_to_frames(available_read_internal(read_index_,
+                                                     write_index_));
+  }
+  /**
+   * Get the number of available frames of audio for consuming.
+   *
+   * Only safely called on the producer thread.
+   *
+   * @return The number of empty slots in the buffer, available for writing.
+   */
+  int available_write() const
+  {
+    return samples_to_frames(available_write_internal(read_index_,
+                                                      write_index_));
+  }
+  /**
+   * Get total capacity, in frames, for this ring buffer.
+   *
+   * Can be called safely on any thread.
+   *
+   * @return The maximum capacity, in frames, of this ring buffer.
+   */
+  int capacity() const
+  {
+    return samples_to_frames(capacity_) - 1;
+  }
+  /** Return true if the ring buffer is empty.
+   *
+   * Can be called safely on any thread.
+   *
+   * @return true if the ring buffer is empty, false otherwise.
+   **/
+  bool empty() const
+  {
+    return empty_internal(read_index_, write_index_);
+  }
+  /** Return true if the ring buffer is full.
+   *
+   * Can be called safely on any thread.
+   *
+   * This happens if the write index is exactly one element behind the read
+   * index.
+   *
+   * @return true if the ring buffer is full, false otherwise.
+   **/
+  bool full() const
+  {
+    return full_internal(read_index_, write_index_);
+  }
+private:
+  /** Return true if the ring buffer is empty.
+   *
+   * @param read_index the read index to consider
+   * @param write_index the write index to consider
+   * @return true if the ring buffer is empty, false otherwise.
+   **/
+  bool empty_internal(int read_index, int write_index) const
+  {
+    return write_index == read_index;
+  }
+  /** Return true if the ring buffer is full.
+   *
+   * This happens if the write index is exactly one element behind the read
+   * index.
+   *
+   * @param read_index the read index to consider
+   * @param write_index the write index to consider
+   * @return true if the ring buffer is full, false otherwise.
+   **/
+  bool full_internal(int read_index, int write_index) const
+  {
+    return (write_index + channel_count_) % capacity_ == read_index;
+  }
+  /**
+   * Return the size of the storage. It is one more than the number of elements
+   * that can be stored in the buffer.
+   *
+   * @return the number of elements that can be stored in the buffer.
+   */
+  int storage_capacity() const
+  {
+    return capacity_;
+  }
+  /**
+   * Convert from frames to samples.
+   *
+   * @param frames A number of frames
+   * @return int The number of samples.
+   */
+  int frames_to_samples(int frames) const
+  {
+     return frames * channel_count_;
+  }
+  /**
+   * Convert from samples to frames.
+   *
+   * @param frames A number of samples
+   * @return int The number of frames.
+   */
+  int samples_to_frames(int samples) const
+  {
+     return samples / channel_count_;
+  }
+  /**
+   * Returns the number of samples available for reading.
+   *
+   * @return the number of available samples for reading.
+   */
+  int available_read_internal(int read_index, int write_index) const
+  {
+    if (write_index >= read_index) {
+      return write_index - read_index;
+    } else {
+      return write_index + capacity_ - read_index;
+    }
+  }
+  /**
+   * Returns the number of empty elements, available for writing.
+   *
+   * @return the number of elements that can be written into the array.
+   */
+  int available_write_internal(int read_index, int write_index) const
+  {
+    /* We substract one frame (`channel_count_` samples) here to always keep at
+     * least one element free in the buffer, to distinguish between full and
+     * empty array. */
+    int rv = read_index - write_index - channel_count_;
+    if (write_index >= read_index) {
+      rv += capacity_;
+    }
+    return rv;
+  }
+  /**
+   * Increments an index, wrapping it around the storage.
+   *
+   * @param index a reference to the index to increment.
+   * @param increment the number by which `index` is incremented.
+   */
+  template <typename IndexType>
+  void increment_index(IndexType& index, uint32_t increment) const
+  {
+    /** Don't make this two operations, `index` might be atomic, we want other
+     * threads to see either the old or the new value, but not an intermediary
+     * computation step: it should only be assigned once. */
+    index = (index + increment) % capacity_;
+  }
+  /** Index at which the oldest frame is at. In samples. */
+  typename ThreadSafePolicy<Safety>::IndexType read_index_;
+  /** Index at which to write new frames. In samples. `write_index` is always at
+   * most one element behind `read_index_`. */
+  typename ThreadSafePolicy<Safety>::IndexType write_index_;
+  /** Channel count for this ring buffer. */
+  const int channel_count_;
+  /** Number of samples at maximum that can be stored in the ring buffer. */
+  const int capacity_;
+  /** Data storage */
+  std::unique_ptr<T[]> data_;
+};
+
+/**
+ * Lock-free instantiation of the `ring_buffer_base` type. This is safe to use
+ * from two threads, one producer, one consumer (that never change role),
+ * without explicit synchronization.
+ */
+template<typename T>
+using lock_free_queue = ring_buffer_base<T, Safe>;
+/**
+ * An instantiation of the `ring_buffer_base` type, to be used on a single
+ * thread: it is not safe to use from multiple threads without explicit external
+ * synchronization.
+ */
+template<typename T>
+using queue = ring_buffer_base<T, Unsafe>;

--- a/src/cubeb_ringbuffer.h
+++ b/src/cubeb_ringbuffer.h
@@ -105,9 +105,6 @@ public:
     /* One more element to distinguish from emtpy and full buffer. */
     , capacity_(capacity + 1)
   {
-    static_assert(std::is_trivially_copyable<T>::value,
-                  "ring_buffer_base requires trivial type");
-
     assert(storage_capacity() <
            std::numeric_limits<RingBufferIndex>::max() &&
            "buffer to large for the type of index used.");
@@ -170,11 +167,11 @@ public:
     int second_part = to_write - first_part;
 
     if (elements) {
-      PodCopy(data_.get() + wr_idx, elements, first_part);
-      PodCopy(data_.get(), elements + first_part, second_part);
+      Copy(data_.get() + wr_idx, elements, first_part);
+      Copy(data_.get(), elements + first_part, second_part);
     } else {
-      PodZero(data_.get() + wr_idx, first_part);
-      PodZero(data_.get(), second_part);
+      ConstructDefault(data_.get() + wr_idx, first_part);
+      ConstructDefault(data_.get(), second_part);
     }
 
     increment_index(wr_idx, to_write);
@@ -209,8 +206,8 @@ public:
     int second_part = to_read - first_part;
 
     if (elements) {
-      PodCopy(elements, data_.get() + rd_idx, first_part); 
-      PodCopy(elements + first_part, data_.get(), second_part);
+      Copy(elements, data_.get() + rd_idx, first_part);
+      Copy(elements + first_part, data_.get(), second_part);
     }
 
     increment_index(rd_idx, to_read);

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -46,6 +46,63 @@ void PodZero(T * destination, size_t count)
   memset(destination, 0,  count * sizeof(T));
 }
 
+namespace {
+template<typename T, typename Trait>
+void Copy(T * destination, const T * source, size_t count, Trait)
+{
+  for (size_t i = 0; i < count; i++) {
+    destination[i] = source[i];
+  }
+}
+
+template<typename T>
+void Copy(T * destination, const T * source, size_t count, std::true_type)
+{
+  PodCopy(destination, source, count);
+}
+}
+
+/**
+ * This allows copying a number of elements from a `source` pointer to a
+ * `destination` pointer, using `memcpy` if it is safe to do so, or a loop that
+ * calls the constructors and destructors otherwise.
+ */
+template<typename T>
+void Copy(T * destination, const T * source, size_t count)
+{
+  assert(destination && source);
+  Copy(destination, source, count, typename std::is_trivial<T>::type());
+}
+
+namespace {
+template<typename T, typename Trait>
+void ConstructDefault(T * destination, size_t count, Trait)
+{
+  for (size_t i = 0; i < count; i++) {
+    destination[i] = T();
+  }
+}
+
+template<typename T>
+void ConstructDefault(T * destination,
+                      size_t count, std::true_type)
+{
+  PodZero(destination, count);
+}
+}
+
+/**
+ * This allows zeroing (using memset) or default-constructing a number of
+ * elements calling the constructors and destructors if necessary.
+ */
+template<typename T>
+void ConstructDefault(T * destination, size_t count)
+{
+  assert(destination);
+  ConstructDefault(destination, count,
+                   typename std::is_arithmetic<T>::type());
+}
+
 template<typename T>
 class auto_array
 {

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -19,6 +19,12 @@
 #include "cubeb_utils_unix.h"
 #endif
 
+#ifndef NDEBUG
+#define CUBEB_RELEASE_CONST
+#else
+#define CUBEB_RELEASE_CONST const
+#endif /* NDEBUG */
+
 /** Similar to memcpy, but accounts for the size of an element. */
 template<typename T>
 void PodCopy(T * destination, const T * source, size_t count)

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -95,7 +95,7 @@ void test_ring_multi(lock_free_queue<T>& buf, int channels, int capacity_frames)
 
   const int block_size = 128;
 
-  std::thread t([&buf, capacity_frames, channels] {
+  std::thread t([&buf, capacity_frames, channels, block_size] {
     int iterations = 1002;
     std::unique_ptr<T[]> in_buffer(new T[capacity_frames * channels]);
     sequence_generator<T> gen(channels);

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -111,7 +111,7 @@ void test_ring_multi(lock_free_queue<T>& buf, int channels, int capacity_frames)
     }
   });
 
-  uint32_t remaining = 1002;
+  int remaining = 1002;
 
   while(remaining--) {
     std::this_thread::sleep_for(std::chrono::microseconds(10));
@@ -123,9 +123,9 @@ void test_ring_multi(lock_free_queue<T>& buf, int channels, int capacity_frames)
   t.join();
 }
 
-void basic_api_test()
+void basic_api_test(int channels)
 {
-  queue<float> ring(2, 128);
+  queue<float> ring(channels, 128);
 
   assert(ring.capacity() == 128);
 
@@ -166,22 +166,32 @@ void basic_api_test()
 int main()
 {
   /* Basic API test. */
-  basic_api_test();
+  const int min_channels = 1;
+  const int max_channels = 10;
+  const int min_capacity = 199;
+  const int max_capacity = 1277;
+  const int capacity_increment = 27;
+
+  for (size_t channels = min_channels; channels < max_channels; channels++) {
+    basic_api_test(channels);
+  }
 
   /* Single thread testing. */
   /* Test mono to 9.1 */
-  for (size_t channels = 1; channels < 10; channels++) {
+  for (size_t channels = min_channels; channels < max_channels; channels++) {
     /* Use non power-of-two numbers to catch edge-cases. */
-    for (size_t capacity_frames = 199; capacity_frames < 1277; capacity_frames+=37) {
+    for (size_t capacity_frames = min_capacity;
+         capacity_frames < max_capacity; capacity_frames+=capacity_increment) {
       queue<float> ring(channels, capacity_frames);
       test_ring(ring, channels, capacity_frames);
     }
   }
 
   /* Multi thread testing */
-  for (size_t channels = 1; channels < 10; channels++) {
+  for (size_t channels = max_channels; channels < min_channels; channels++) {
     /* Use non power-of-two numbers to catch edge-cases. */
-    for (size_t capacity_frames = 199; capacity_frames < 1277; capacity_frames+=37) {
+    for (size_t capacity_frames = min_capacity;
+         capacity_frames < max_capacity; capacity_frames+=capacity_increment) {
       lock_free_queue<long> ring(channels, capacity_frames);
       test_ring_multi(ring, channels, capacity_frames);
     }

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -1,7 +1,6 @@
 #include "cubeb_ringbuffer.h"
 #include <iostream>
 #include <thread>
-#include <unistd.h>
 #include <chrono>
 
 /* Generate a monotonically increasing sequence of numbers. */

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -1,0 +1,183 @@
+#include "cubeb_ringbuffer.h"
+#include <iostream>
+#include <thread>
+#include <unistd.h>
+#include <chrono>
+
+/* Generate a monotonically increasing sequence of numbers. */
+template<typename T>
+class sequence_generator
+{
+public:
+  sequence_generator(size_t channels)
+    : channels(channels)
+  { }
+  void get(T * elements, size_t frames)
+  {
+    for (size_t i = 0; i < frames; i++) {
+      for (size_t c = 0; c < channels; c++) {
+        elements[i * channels + c] = static_cast<T>(index_);
+      }
+      index_++;
+    }
+  }
+  void rewind(size_t frames)
+  {
+    index_ -= frames;
+  }
+private:
+  size_t index_ = 0;
+  size_t channels = 0;
+};
+
+/* Checks that a sequence is monotonically increasing. */
+template<typename T>
+class sequence_verifier
+{
+  public:
+  sequence_verifier(size_t channels)
+    : channels(channels)
+  { }
+    void check(T * elements, size_t frames)
+    {
+      for (size_t i = 0; i < frames; i++) {
+        for (size_t c = 0; c < channels; c++) {
+          if (elements[i * channels + c] != static_cast<T>(index_)) {
+            std::cerr << "Element " << i << " is different. Expected " 
+              << static_cast<T>(index_) << ", got " << elements[i]
+              << ". (channel count: " << channels << ")." << std::endl;
+            assert(false);
+          }
+        }
+        index_++;
+      }
+    }
+  private:
+    size_t index_ = 0;
+    size_t channels = 0;
+};
+
+template<typename T>
+void test_ring(queue<T>& buf, int channels, int capacity_frames)
+{
+  std::unique_ptr<T[]> seq(new T[capacity_frames * channels]);
+  sequence_generator<T> gen(channels);
+  sequence_verifier<T> checker(channels);
+
+  int iterations = 1002;
+
+  const int block_size = 128;
+
+  while(iterations--) {
+    gen.get(seq.get(), block_size);
+    int rv = buf.enqueue(seq.get(), block_size);
+    assert(rv == block_size);
+    PodZero(seq.get(), block_size);
+    rv = buf.dequeue(seq.get(), block_size);
+    assert(rv == block_size);
+    checker.check(seq.get(), block_size);
+  }
+}
+
+template<typename T>
+void test_ring_multi(lock_free_queue<T>& buf, int channels, int capacity_frames)
+{
+  sequence_verifier<T> checker(channels);
+  std::unique_ptr<T[]> out_buffer(new T[capacity_frames * channels]);
+
+  const int block_size = 128;
+
+  std::thread t([&buf, capacity_frames, channels] {
+    int iterations = 1002;
+    std::unique_ptr<T[]> in_buffer(new T[capacity_frames * channels]);
+    sequence_generator<T> gen(channels);
+
+    while(iterations--) {
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+      gen.get(in_buffer.get(), block_size);
+      int rv = buf.enqueue(in_buffer.get(), block_size);
+      assert(rv <= block_size);
+      if (rv != block_size) {
+        gen.rewind(block_size - rv);
+      }
+    }
+  });
+
+  uint32_t remaining = 1002;
+
+  while(remaining--) {
+    std::this_thread::sleep_for(std::chrono::microseconds(10));
+    int rv = buf.dequeue(out_buffer.get(), block_size);
+    assert(rv <= block_size);
+    checker.check(out_buffer.get(), rv);
+  }
+
+  t.join();
+}
+
+void basic_api_test()
+{
+  queue<float> ring(2, 128);
+
+  assert(ring.capacity() == 128);
+
+  assert(ring.empty());
+  assert(!ring.full());
+
+  int rv = ring.enqueue_silence(63);
+
+  assert(rv == 63);
+  assert(ring.available_read() == 63);
+  assert(ring.available_write() == 65);
+  assert(!ring.empty());
+  assert(!ring.full());
+
+  rv = ring.enqueue_silence(65);
+
+  assert(rv = 65);
+  assert(!ring.empty());
+  assert(ring.full());
+  assert(ring.available_read() == 128);
+  assert(ring.available_write() == 0);
+
+  rv = ring.dequeue(nullptr, 63);
+
+  assert(!ring.empty());
+  assert(!ring.full());
+  assert(ring.available_read() == 65);
+  assert(ring.available_write() == 63);
+
+  rv = ring.dequeue(nullptr, 65);
+
+  assert(ring.empty());
+  assert(!ring.full());
+  assert(ring.available_read() == 0);
+  assert(ring.available_write() == 128);
+}
+
+int main()
+{
+  /* Basic API test. */
+  basic_api_test();
+
+  /* Single thread testing. */
+  /* Test mono to 9.1 */
+  for (size_t channels = 1; channels < 10; channels++) {
+    /* Use non power-of-two numbers to catch edge-cases. */
+    for (size_t capacity_frames = 199; capacity_frames < 1277; capacity_frames+=37) {
+      queue<float> ring(channels, capacity_frames);
+      test_ring(ring, channels, capacity_frames);
+    }
+  }
+
+  /* Multi thread testing */
+  for (size_t channels = 1; channels < 10; channels++) {
+    /* Use non power-of-two numbers to catch edge-cases. */
+    for (size_t capacity_frames = 199; capacity_frames < 1277; capacity_frames+=37) {
+      lock_free_queue<long> ring(channels, capacity_frames);
+      test_ring_multi(ring, channels, capacity_frames);
+    }
+  }
+
+  return 0;
+}

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -1,3 +1,12 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#define NOMINMAX
+
 #include "cubeb_ringbuffer.h"
 #include <iostream>
 #include <thread>

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -129,36 +129,28 @@ void basic_api_test(T& ring)
 {
   ASSERT_EQ(ring.capacity(), 128);
 
-  ASSERT_TRUE(ring.empty());
-  ASSERT_TRUE(!ring.full());
+  ASSERT_EQ(ring.available_read(), 0);
+  ASSERT_EQ(ring.available_write(), 128);
 
   int rv = ring.enqueue_default(63);
 
   ASSERT_TRUE(rv == 63);
   ASSERT_EQ(ring.available_read(), 63);
   ASSERT_EQ(ring.available_write(), 65);
-  ASSERT_TRUE(!ring.empty());
-  ASSERT_TRUE(!ring.full());
 
   rv = ring.enqueue_default(65);
 
   ASSERT_EQ(rv, 65);
-  ASSERT_TRUE(!ring.empty());
-  ASSERT_TRUE(ring.full());
   ASSERT_EQ(ring.available_read(), 128);
   ASSERT_EQ(ring.available_write(), 0);
 
   rv = ring.dequeue(nullptr, 63);
 
-  ASSERT_TRUE(!ring.empty());
-  ASSERT_TRUE(!ring.full());
   ASSERT_EQ(ring.available_read(), 65);
   ASSERT_EQ(ring.available_write(), 63);
 
   rv = ring.dequeue(nullptr, 65);
 
-  ASSERT_TRUE(ring.empty());
-  ASSERT_TRUE(!ring.full());
   ASSERT_EQ(ring.available_read(), 0);
   ASSERT_EQ(ring.available_write(), 128);
 }


### PR DESCRIPTION
This is going to be useful for a number of things:
- I'm trying to fix drifting on WASAPI by using multiple threads for input and output first, before implementing a real adaptative resampling pass (more new on that soon)
- We're locking around the array buffer access on OSX, it's best to use a lock-free wait-free queue
- Possibly for OpenSL ES and PulseAudio as well, we need a buffer between input and output

This queue can be configured at compile time to use atomics or not, so it's quite versatile and we could use it for non-concurrent scenario as well.

In terms of testing, it's clear that this does not _prove_ that the list is correct, but has found a lot of issues on my system: making one of the index non-atomic fails every time on my machine, for example. The design is very classic. Juce's [`AbstractFifo`](https://github.com/julianstorer/JUCE/blob/master/modules/juce_core/containers/juce_AbstractFifo.h) and boost's [`spsc_queue`](https://github.com/boostorg/lockfree/blob/develop/include/boost/lockfree/spsc_queue.hpp) implement something similar.