### PR TITLE
Bail out safely from the rendering loop if we could not join the rendering thread in time

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <memory>
 #include <limits>
+#include <atomic>
 
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
@@ -220,8 +221,10 @@ struct cubeb_stream
   float volume;
   /* True if the stream is draining. */
   bool draining;
+  /* True when we've destroyed the stream. This pointer is leaked on stream
+   * destruction if we could not join the thread. */
+  std::atomic<std::atomic<bool>*> emergency_bailout;
 };
-
 
 class wasapi_endpoint_notification_client : public IMMNotificationClient
 {
@@ -781,6 +784,7 @@ static unsigned int __stdcall
 wasapi_stream_render_loop(LPVOID stream)
 {
   cubeb_stream * stm = static_cast<cubeb_stream *>(stream);
+  std::atomic<bool> * emergency_bailout = stm->emergency_bailout;
 
   bool is_playing = true;
   HANDLE wait_array[4] = {
@@ -820,6 +824,10 @@ wasapi_stream_render_loop(LPVOID stream)
                                               wait_array,
                                               FALSE,
                                               1000);
+    if (*emergency_bailout) {
+      delete emergency_bailout;
+      return 0;
+    }
     if (waitResult != WAIT_TIMEOUT) {
       timeout_count = 0;
     }
@@ -1134,12 +1142,13 @@ int wasapi_init(cubeb ** context, char const * context_name)
 }
 
 namespace {
-void stop_and_join_render_thread(cubeb_stream * stm)
+bool stop_and_join_render_thread(cubeb_stream * stm)
 {
+  bool rv = true;
   LOG("Stop and join render thread.");
   if (!stm->thread) {
     LOG("No thread present.");
-    return;
+    return true;
   }
 
   BOOL ok = SetEvent(stm->shutdown_event);
@@ -1155,9 +1164,13 @@ void stop_and_join_render_thread(cubeb_stream * stm)
      * process. */
     LOG("Destroy WaitForSingleObject on thread timed out,"
         " leaking the thread: %d", GetLastError());
+    *(stm->emergency_bailout) = true;
+    rv = false;
   }
   if (r == WAIT_FAILED) {
+    *(stm->emergency_bailout) = true;
     LOG("Destroy WaitForSingleObject on thread failed: %d", GetLastError());
+    rv = false;
   }
 
   LOG("Closing thread.");
@@ -1167,6 +1180,8 @@ void stop_and_join_render_thread(cubeb_stream * stm)
 
   CloseHandle(stm->shutdown_event);
   stm->shutdown_event = 0;
+
+  return rv;
 }
 
 void wasapi_destroy(cubeb * context)
@@ -1775,7 +1790,18 @@ void wasapi_stream_destroy(cubeb_stream * stm)
 {
   XASSERT(stm);
 
-  stop_and_join_render_thread(stm);
+  // Only free stm->emergency_bailout if we could not join the thread.
+  // If we could not join the thread, stm->emergency_bailout is true 
+  // and is still alive until the thread wakes up and exits cleanly.
+  if (stop_and_join_render_thread(stm)) {
+    if (stm->emergency_bailout.load()) {
+      delete stm->emergency_bailout.load();
+      stm->emergency_bailout = nullptr;
+    }
+  } else {
+    // If we're leaking, it must be that this is true.
+    assert(*(stm->emergency_bailout));
+  }
 
   unregister_notification_client(stm);
 
@@ -1844,6 +1870,8 @@ int wasapi_stream_start(cubeb_stream * stm)
 
   auto_lock lock(stm->stream_reset_lock);
 
+  stm->emergency_bailout = new std::atomic<bool>(false);
+
   if (stm->output_client) {
     int rv = stream_start_one_side(stm, OUTPUT);
     if (rv != CUBEB_OK) {
@@ -1903,7 +1931,12 @@ int wasapi_stream_stop(cubeb_stream * stm)
     stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_STOPPED);
   }
 
-  stop_and_join_render_thread(stm);
+  if (stop_and_join_render_thread(stm)) {
+    if (stm->emergency_bailout.load()) {
+      delete stm->emergency_bailout.load();
+      stm->emergency_bailout = nullptr;
+    }
+  }
 
   return CUBEB_OK;
 }


### PR DESCRIPTION
This is over-complicated because we don't have `atomic_shared_ptr` in standard C++ for now, and because I don't want this to be non-atomic, and I don't want to add a global lock or another mutex.