### PR TITLE
audiounit: Fix race on frames_played.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -192,7 +192,7 @@ struct cubeb_stream {
   /* Frames on input buffer */
   std::atomic<uint32_t> input_buffer_frames;
   /* Frame counters */
-  uint64_t frames_played;
+  std::atomic<uint64_t> frames_played;
   uint64_t frames_queued;
   std::atomic<int64_t> frames_read;
   std::atomic<bool> shutdown;


### PR DESCRIPTION
ddbc367 removed the holding of stm->mutex from the render callback and switched some fields to std::atomic, but frames_played was missed.

Also includes some TSAN fixes for test_sanity.