### PR TITLE
wasapi: First pass at using modern C++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ if(USE_WASAPI)
   target_sources(cubeb PRIVATE
     src/cubeb_wasapi.cpp)
   target_compile_definitions(cubeb PRIVATE USE_WASAPI)
+  target_link_libraries(cubeb PRIVATE avrt)
 endif()
 
 check_include_files("windows.h;mmsystem.h" USE_WINMM)

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
+#include <mutex>
 #include <type_traits>
 #if defined(WIN32)
 #include "cubeb_utils_win.h"
@@ -198,18 +199,6 @@ private:
   size_t length_;
 };
 
-struct auto_lock {
-  explicit auto_lock(owned_critical_section & lock)
-    : lock(lock)
-  {
-    lock.enter();
-  }
-  ~auto_lock()
-  {
-    lock.leave();
-  }
-private:
-  owned_critical_section & lock;
-};
+using auto_lock = std::lock_guard<owned_critical_section>;
 
 #endif /* CUBEB_UTILS */

--- a/src/cubeb_utils_unix.h
+++ b/src/cubeb_utils_unix.h
@@ -48,7 +48,7 @@ public:
 #endif
   }
 
-  void enter()
+  void lock()
   {
 #ifndef NDEBUG
     int r =
@@ -59,7 +59,7 @@ public:
 #endif
   }
 
-  void leave()
+  void unlock()
   {
 #ifndef NDEBUG
     int r =

--- a/src/cubeb_utils_win.h
+++ b/src/cubeb_utils_win.h
@@ -29,7 +29,7 @@ public:
     DeleteCriticalSection(&critical_section);
   }
 
-  void enter()
+  void lock()
   {
     EnterCriticalSection(&critical_section);
 #ifndef NDEBUG
@@ -38,7 +38,7 @@ public:
 #endif
   }
 
-  void leave()
+  void unlock()
   {
 #ifndef NDEBUG
     /* GetCurrentThreadId cannot return 0: it is not a the valid thread id */

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -168,10 +168,6 @@ private:
   HRESULT result;
 };
 
-typedef HANDLE (WINAPI *set_mm_thread_characteristics_function)(
-                                      const char * TaskName, LPDWORD TaskIndex);
-typedef BOOL (WINAPI *revert_mm_thread_characteristics_function)(HANDLE handle);
-
 extern cubeb_ops const wasapi_ops;
 
 int wasapi_stream_stop(cubeb_stream * stm);
@@ -185,11 +181,6 @@ static std::unique_ptr<wchar_t const []> utf8_to_wstr(char const * str);
 
 struct cubeb {
   cubeb_ops const * ops = &wasapi_ops;
-  /* Library dynamically opened to increase the render thread priority, and
-     the two function pointers we need. */
-  HMODULE mmcss_module = nullptr;
-  set_mm_thread_characteristics_function set_mm_thread_characteristics = nullptr;
-  revert_mm_thread_characteristics_function revert_mm_thread_characteristics = nullptr;
 };
 
 class wasapi_endpoint_notification_client;
@@ -875,8 +866,7 @@ wasapi_stream_render_loop(LPVOID stream)
 
   /* We could consider using "Pro Audio" here for WebAudio and
      maybe WebRTC. */
-  mmcss_handle =
-    stm->context->set_mm_thread_characteristics("Audio", &mmcss_task_index);
+  mmcss_handle = AvSetMmThreadCharacteristicsA("Audio", &mmcss_task_index);
   if (!mmcss_handle) {
     /* This is not fatal, but we might glitch under heavy load. */
     LOG("Unable to use mmcss to bump the render thread priority: %x", GetLastError());
@@ -978,22 +968,12 @@ wasapi_stream_render_loop(LPVOID stream)
     stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
   }
 
-  stm->context->revert_mm_thread_characteristics(mmcss_handle);
+  AvRevertMmThreadCharacteristics(mmcss_handle);
 
   return 0;
 }
 
 void wasapi_destroy(cubeb * context);
-
-HANDLE WINAPI set_mm_thread_characteristics_noop(const char *, LPDWORD mmcss_task_index)
-{
-  return (HANDLE)1;
-}
-
-BOOL WINAPI revert_mm_thread_characteristics_noop(HANDLE mmcss_handle)
-{
-  return true;
-}
 
 HRESULT register_notification_client(cubeb_stream * stm)
 {
@@ -1172,27 +1152,6 @@ int wasapi_init(cubeb ** context, char const * context_name)
 
   ctx->ops = &wasapi_ops;
 
-  ctx->mmcss_module = LoadLibraryA("Avrt.dll");
-
-  if (ctx->mmcss_module) {
-    ctx->set_mm_thread_characteristics =
-      (set_mm_thread_characteristics_function) GetProcAddress(
-          ctx->mmcss_module, "AvSetMmThreadCharacteristicsA");
-    ctx->revert_mm_thread_characteristics =
-      (revert_mm_thread_characteristics_function) GetProcAddress(
-          ctx->mmcss_module, "AvRevertMmThreadCharacteristics");
-    if (!(ctx->set_mm_thread_characteristics && ctx->revert_mm_thread_characteristics)) {
-      LOG("Could not load AvSetMmThreadCharacteristics or AvRevertMmThreadCharacteristics: %x", GetLastError());
-      FreeLibrary(ctx->mmcss_module);
-    }
-  } else {
-    // This is not a fatal error, but we might end up glitching when
-    // the system is under high load.
-    LOG("Could not load Avrt.dll");
-    ctx->set_mm_thread_characteristics = &set_mm_thread_characteristics_noop;
-    ctx->revert_mm_thread_characteristics = &revert_mm_thread_characteristics_noop;
-  }
-
   *context = ctx;
 
   return CUBEB_OK;
@@ -1244,9 +1203,6 @@ bool stop_and_join_render_thread(cubeb_stream * stm)
 
 void wasapi_destroy(cubeb * context)
 {
-  if (context->mmcss_module) {
-    FreeLibrary(context->mmcss_module);
-  }
   delete context;
 }
 


### PR DESCRIPTION
This converts the WASAPI backend to using smart pointers where possible.  I wrote a small com_ptr since the standard Microsoft version requires building with ATL, which we (and Gecko) want to avoid.

There's plenty more we can do (e.g. avoid double-initializating cubeb_stream by passing the params into a constructor), but I've tried to make each of these changes minimal to make review easier.

r? @padenot 