### PR TITLE
OpenSL ES full duplex restored

### DIFF
--- a/src/cubeb_array_queue.h
+++ b/src/cubeb_array_queue.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#ifndef CUBEB_ARRAY_QUEUE_H
+#define CUBEB_ARRAY_QUEUE_H
+
+#include <assert.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef struct
+{
+  void ** buf;
+  size_t num;
+  size_t writePos;
+  size_t readPos;
+  pthread_mutex_t mutex;
+  pthread_cond_t empty_convar;
+} array_queue;
+
+array_queue * array_queue_create(size_t num)
+{
+  assert(num != 0);
+  array_queue * new_queue = (array_queue*)calloc(1, sizeof(array_queue));
+  new_queue->buf = (void **)calloc(1, sizeof(void *) * num);
+  new_queue->readPos = 0;
+  new_queue->writePos = 0;
+  new_queue->num = num;
+
+  pthread_mutex_init(&new_queue->mutex, NULL);
+  pthread_cond_init(&new_queue->empty_convar, NULL);
+
+  return new_queue;
+}
+
+void array_queue_destroy(array_queue * aq)
+{
+  assert(aq);
+
+  free(aq->buf);
+  pthread_mutex_destroy(&aq->mutex);
+  pthread_cond_destroy(&aq->empty_convar);
+  free(aq);
+}
+
+int array_queue_push(array_queue * aq, void * item)
+{
+  assert(item);
+
+  pthread_mutex_lock(&aq->mutex);
+  int ret = -1;
+  if(aq->buf[aq->writePos % aq->num] == NULL)
+  {
+    aq->buf[aq->writePos % aq->num] = item;
+    aq->writePos = (aq->writePos + 1) % aq->num;
+    ret = 0;
+  }
+  // else queue is full
+  pthread_cond_signal(&aq->empty_convar);
+  pthread_mutex_unlock(&aq->mutex);
+  return ret;
+}
+
+void* array_queue_pop(array_queue * aq)
+{
+  pthread_mutex_lock(&aq->mutex);
+  void * value = aq->buf[aq->readPos % aq->num];
+  if(value)
+  {
+    aq->buf[aq->readPos % aq->num] = NULL;
+    aq->readPos = (aq->readPos + 1) % aq->num;
+  }
+  pthread_mutex_unlock(&aq->mutex);
+  return value;
+}
+
+void* array_queue_wait_pop(array_queue * aq)
+{
+  pthread_mutex_lock(&aq->mutex);
+  while (aq->readPos == aq->writePos) {
+    // Wait here if queue is empty
+    pthread_cond_wait(&aq->empty_convar, &aq->mutex);
+  }
+  void * value = aq->buf[aq->readPos % aq->num];
+  // Since it has been waiting it is expected to
+  // return a non NULL value.
+  assert(value);
+  aq->buf[aq->readPos % aq->num] = NULL;
+  aq->readPos = (aq->readPos + 1) % aq->num;
+  pthread_mutex_unlock(&aq->mutex);
+  return value;
+}
+
+size_t array_queue_get_size(array_queue * aq)
+{
+  pthread_mutex_lock(&aq->mutex);
+  ssize_t r = aq->writePos - aq->readPos;
+  if (r < 0) {
+    r = aq->num + r;
+    assert(r >= 0);
+  }
+  pthread_mutex_unlock(&aq->mutex);
+  return (size_t)r;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif //CUBE_ARRAY_QUEUE_H

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1014,7 +1014,7 @@ opensl_configure_capture(cubeb_stream * stm, cubeb_stream_params * params)
 
   res = (*stm->recorderItf)->RegisterCallback(stm->recorderItf, recorder_marker_callback, stm);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to register recorder marker callback. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1022,7 +1022,7 @@ opensl_configure_capture(cubeb_stream * stm, cubeb_stream_params * params)
 
   res = (*stm->recorderItf)->SetCallbackEventsMask(stm->recorderItf, (SLuint32)SL_RECORDEVENT_HEADATMARKER);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to set headatmarker event mask. Error code: %lu", res);
     return CUBEB_ERROR;
   }
   // get the simple android buffer queue interface
@@ -1172,7 +1172,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
   }
 
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to create audio player. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1201,7 +1201,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
                                           stm->context->SL_IID_ANDROIDCONFIGURATION,
                                           &playerConfig);
     if (res != SL_RESULT_SUCCESS) {
-      opensl_stream_destroy(stm);
+      LOG("Failed to get android configuration interface. Error code: %lu", res);
       return CUBEB_ERROR;
     }
 
@@ -1210,7 +1210,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
                                             &stream_type,
                                             sizeof(SLint32));
     if (res != SL_RESULT_SUCCESS) {
-      opensl_stream_destroy(stm);
+      LOG("Failed to set android configuration interface. Error code: %lu", res);
       return CUBEB_ERROR;
     }
   }
@@ -1218,7 +1218,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
 
   res = (*stm->playerObj)->Realize(stm->playerObj, SL_BOOLEAN_FALSE);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to realize player object. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1226,7 +1226,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
                                         stm->context->SL_IID_PLAY,
                                         &stm->play);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to get play interface. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1234,7 +1234,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
                                         stm->context->SL_IID_BUFFERQUEUE,
                                         &stm->bufq);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to get bufferqueue interface. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1242,13 +1242,13 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
                                         stm->context->SL_IID_VOLUME,
                                         &stm->volume);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to get volume interface. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
   res = (*stm->play)->RegisterCallback(stm->play, play_callback, stm);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to register play callback. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1257,7 +1257,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
 
   res = (*stm->play)->SetCallbackEventsMask(stm->play, (SLuint32)SL_PLAYEVENT_HEADATMARKER);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to set headatmarker event mask. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 
@@ -1267,7 +1267,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
   }
   res = (*stm->bufq)->RegisterCallback(stm->bufq, player_callback, stm);
   if (res != SL_RESULT_SUCCESS) {
-    opensl_stream_destroy(stm);
+    LOG("Failed to register bufferqueue callback. Error code: %lu", res);
     return CUBEB_ERROR;
   }
 

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -165,7 +165,7 @@ opensl_get_draining(cubeb_stream * stm)
 {
 #ifdef DEBUG
   int r = pthread_mutex_trylock(&stm->mutex);
-  assert(r == EDEADLK && "get_draining deadlock");
+  assert(r == EDEADLK && "get_draining: mutex should be locked but it's not.");
 #endif
   return stm->draining;
 }
@@ -175,7 +175,7 @@ opensl_set_draining(cubeb_stream * stm, int value)
 {
 #ifdef DEBUG
   int r = pthread_mutex_trylock(&stm->mutex);
-  assert(r == EDEADLK && "set_draining deadlock");
+  assert(r == EDEADLK && "set_draining: mutex should be locked but it's not.");
 #endif
   assert(value == 0 || value == 1);
   stm->draining = value;
@@ -186,7 +186,7 @@ opensl_get_shutdown(cubeb_stream * stm)
 {
 #ifdef DEBUG
   int r = pthread_mutex_trylock(&stm->mutex);
-  assert(r == EDEADLK && "get_shutdown deadlock");
+  assert(r == EDEADLK && "get_shutdown: mutex should be locked but it's not.");
 #endif
   return stm->shutdown;
 }
@@ -196,7 +196,7 @@ opensl_set_shutdown(cubeb_stream * stm, uint32_t value)
 {
 #ifdef DEBUG
   int r = pthread_mutex_trylock(&stm->mutex);
-  assert(r == EDEADLK && "set_shutdown deadlock");
+  assert(r == EDEADLK && "set_shutdown: mutex should be locked but it's not.");
 #endif
   assert(value == 0 || value == 1);
   stm->shutdown = value;

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -746,6 +746,7 @@ opensl_init(cubeb ** context, char const * context_name)
 
   *context = ctx;
 
+  LOG("Cubeb init (%p) success", ctx);
   return CUBEB_OK;
 }
 
@@ -1360,6 +1361,9 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
   assert(r == 0);
 
   if (output_stream_params) {
+    LOG("Playback params: Rate %d, channels %d, format %d, latency in frames %d.",
+        output_stream_params->rate, output_stream_params->channels,
+        output_stream_params->format, stm->latency_frames);
     r = opensl_configure_playback(stm, output_stream_params);
     if (r != CUBEB_OK) {
       opensl_stream_destroy(stm);
@@ -1368,6 +1372,9 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
   }
 
   if (input_stream_params) {
+    LOG("Capture params: Rate %d, channels %d, format %d, latency in frames %d.",
+        input_stream_params->rate, input_stream_params->channels,
+        input_stream_params->format, stm->latency_frames);
     r = opensl_configure_capture(stm, input_stream_params);
     if (r != CUBEB_OK) {
       opensl_stream_destroy(stm);

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -20,7 +20,17 @@
 #include <SLES/OpenSLES_Android.h>
 #include <android/log.h>
 #include <android/api-level.h>
+#endif
+#include "cubeb/cubeb.h"
+#include "cubeb-internal.h"
+#include "cubeb_resampler.h"
+#include "cubeb-sles.h"
+#include "cubeb_array_queue.h"
 
+#if defined(__ANDROID__)
+#ifdef LOG
+#undef LOG
+#endif
 //#define LOGGING_ENABLED
 #ifdef LOGGING_ENABLED
 #define LOG(args...)  __android_log_print(ANDROID_LOG_INFO, "Cubeb_OpenSL" , ## args)
@@ -49,11 +59,6 @@
 #define ANDROID_VERSION_LOLLIPOP 21
 #define ANDROID_VERSION_MARSHMALLOW 23
 #endif
-#include "cubeb/cubeb.h"
-#include "cubeb-internal.h"
-#include "cubeb_resampler.h"
-#include "cubeb-sles.h"
-#include "cubeb_array_queue.h"
 
 #define DEFAULT_SAMPLE_RATE 48000
 

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -9,6 +9,7 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <errno.h>
 #include <SLES/OpenSLES.h>
 #include <math.h>
 #include <time.h>
@@ -19,7 +20,31 @@
 #include <SLES/OpenSLES_Android.h>
 #include <android/log.h>
 #include <android/api-level.h>
+
+//#define LOGGING_ENABLED
+#ifdef LOGGING_ENABLED
 #define LOG(args...)  __android_log_print(ANDROID_LOG_INFO, "Cubeb_OpenSL" , ## args)
+#else
+#define LOG(...)
+#endif
+
+//#define TIMESTAMP_ENABLED
+#ifdef TIMESTAMP_ENABLED
+#define FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define LOG_TS(args...)  __android_log_print(ANDROID_LOG_INFO, "Cubeb_OpenSL ES: Timestamp(usec)" , ## args)
+#define TIMESTAMP(msg) do {                           \
+  struct timeval timestamp;                           \
+  int ts_ret = gettimeofday(&timestamp, NULL);        \
+  if (ts_ret == 0) {                                  \
+    LOG_TS("%lld: %s (%s %s:%d)", timestamp.tv_sec * 1000000LL + timestamp.tv_usec, msg, __FUNCTION__, FILENAME, __LINE__);\
+  } else {                                            \
+    LOG_TS("Error: %s (%s %s:%d) - %s", msg, __FUNCTION__, FILENAME, __LINE__);\
+  }                                                   \
+} while(0)
+#else
+#define TIMESTAMP(...)
+#endif
+
 #define ANDROID_VERSION_GINGERBREAD_MR1 10
 #define ANDROID_VERSION_LOLLIPOP 21
 #define ANDROID_VERSION_MARSHMALLOW 23
@@ -28,6 +53,9 @@
 #include "cubeb-internal.h"
 #include "cubeb_resampler.h"
 #include "cubeb-sles.h"
+#include "cubeb_array_queue.h"
+
+#define DEFAULT_SAMPLE_RATE 48000
 
 static struct cubeb_ops const opensl_ops;
 
@@ -58,27 +86,123 @@ struct cubeb_stream {
   SLPlayItf play;
   SLBufferQueueItf bufq;
   SLVolumeItf volume;
-  uint8_t *queuebuf[NBUFS];
+  void ** queuebuf;
+  uint32_t queuebuf_capacity;
   int queuebuf_idx;
   long queuebuf_len;
   long bytespersec;
   long framesize;
+  /* Total number of played frames.
+   * Synchronized by stream::mutex lock. */
   long written;
+  /* Flag indicating draining. Synchronized
+   * by stream::mutex lock. */
   int draining;
   cubeb_stream_type stream_type;
 
+  array_queue * output_queue;
+
+  /* Flags to determine in/out.*/
+  uint32_t input_enabled;
+  uint32_t output_enabled;
+
+  /* Recorder abstract object. */
+  SLObjectItf recorderObj;
+  /* Recorder Itf for input capture. */
+  SLRecordItf recorderItf;
+  /* Buffer queue for input capture. */
+  SLAndroidSimpleBufferQueueItf recorderBufferQueueItf;
+  /* Store input buffers. */
+  void ** input_buffer_array;
+  /* The capacity of the array.
+   * On capture only can be small (4).
+   * On full duplex is calculated to
+   * store 1 sec of data buffers. */
+  uint32_t input_array_capacity;
+  /* Current filled index of input buffer array.
+   * It is initiated to -1 indicating buffering
+   * have not started yet. */
+  int input_buffer_index;
+  /* Length of input buffer.*/
+  uint32_t input_buffer_length;
+  /* Input frame size */
+  uint32_t input_frame_size;
+  /* Device sampling rate. If user rate is not
+   * accepted an compatible rate is set. If it is
+   * accepted this is equal to params.rate. */
+  uint32_t input_device_rate;
+  /* Exchange input buffers between input
+   * and full duplex threads. */
+  array_queue * input_queue;
+  /* Silent input buffer used on full duplex. */
+  void * input_silent_buffer;
+  /* Number of input frames from the start of the stream*/
+  uint32_t input_total_frames;
+  /* Flag to stop the execution of user callback and
+   * close all working threads. Synchronized by
+   * stream::mutex lock. */
+  uint32_t shutdown;
+  /* Store user callback. */
   cubeb_data_callback data_callback;
+  /* Store state callback. */
   cubeb_state_callback state_callback;
+  /* User pointer for data & state callbacks*/
   void * user_ptr;
 
   cubeb_resampler * resampler;
   unsigned int inputrate;
-  unsigned int outputrate;
-  unsigned int latency;
+  unsigned int output_configured_rate;
+  unsigned int latency_frames;
   int64_t lastPosition;
   int64_t lastPositionTimeStamp;
   int64_t lastCompensativePosition;
 };
+
+/* Forward declaration. */
+static int opensl_stop_player(cubeb_stream * stm);
+static int opensl_stop_recorder(cubeb_stream * stm);
+
+static int
+opensl_get_draining(cubeb_stream * stm)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(&stm->mutex);
+  assert(r == EDEADLK && "get_draining deadlock");
+#endif
+  return stm->draining;
+}
+
+static void
+opensl_set_draining(cubeb_stream * stm, int value)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(&stm->mutex);
+  assert(r == EDEADLK && "set_draining deadlock");
+#endif
+  assert(value == 0 || value == 1);
+  stm->draining = value;
+}
+
+static uint32_t
+opensl_get_shutdown(cubeb_stream * stm)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(&stm->mutex);
+  assert(r == EDEADLK && "get_shutdown deadlock");
+#endif
+  return stm->shutdown;
+}
+
+static void
+opensl_set_shutdown(cubeb_stream * stm, uint32_t value)
+{
+#ifdef DEBUG
+  int r = pthread_mutex_trylock(&stm->mutex);
+  assert(r == EDEADLK && "set_shutdown deadlock");
+#endif
+  assert(value == 0 || value == 1);
+  stm->shutdown = value;
+}
 
 static void
 play_callback(SLPlayItf caller, void * user_ptr, SLuint32 event)
@@ -89,15 +213,46 @@ play_callback(SLPlayItf caller, void * user_ptr, SLuint32 event)
   switch (event) {
   case SL_PLAYEVENT_HEADATMARKER:
     pthread_mutex_lock(&stm->mutex);
-    draining = stm->draining;
+    draining = opensl_get_draining(stm);
     pthread_mutex_unlock(&stm->mutex);
     if (draining) {
       stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_DRAINED);
-      (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_PAUSED);
+      if (stm->play) {
+        int r = opensl_stop_player(stm);
+        assert(r == CUBEB_OK);
+      }
+      if (stm->recorderItf) {
+        int r = opensl_stop_recorder(stm);
+        assert(r == CUBEB_OK);
+      }
     }
     break;
   default:
     break;
+  }
+}
+
+static void
+recorder_marker_callback (SLRecordItf caller, void * pContext, SLuint32 event)
+{
+  cubeb_stream * stm = pContext;
+  assert(stm);
+
+  if (event == SL_RECORDEVENT_HEADATMARKER) {
+    pthread_mutex_lock(&stm->mutex);
+    int draining = opensl_get_draining(stm);
+    pthread_mutex_unlock(&stm->mutex);
+    if (draining) {
+      stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_DRAINED);
+      if (stm->recorderItf) {
+        int r = opensl_stop_recorder(stm);
+        assert(r == CUBEB_OK);
+      }
+      if (stm->play) {
+        int r = opensl_stop_player(stm);
+        assert(r == CUBEB_OK);
+      }
+    }
   }
 }
 
@@ -108,54 +263,294 @@ bufferqueue_callback(SLBufferQueueItf caller, void * user_ptr)
   assert(stm);
   SLBufferQueueState state;
   SLresult res;
+  long written = 0;
 
   res = (*stm->bufq)->GetState(stm->bufq, &state);
   assert(res == SL_RESULT_SUCCESS);
 
-  if (state.count > 1)
+  if (state.count > 1) {
     return;
+  }
 
-  SLuint32 i;
-  for (i = state.count; i < NBUFS; i++) {
-    uint8_t *buf = stm->queuebuf[stm->queuebuf_idx];
-    long written = 0;
-    pthread_mutex_lock(&stm->mutex);
-    int draining = stm->draining;
-    pthread_mutex_unlock(&stm->mutex);
-
-    if (!draining) {
-      written = cubeb_resampler_fill(stm->resampler,
-                                     NULL, NULL,
-                                     buf, stm->queuebuf_len / stm->framesize);
-      if (written < 0 || written * stm->framesize > stm->queuebuf_len) {
-        (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_PAUSED);
-        return;
-      }
-    }
-
-    // Keep sending silent data even in draining mode to prevent the audio
-    // back-end from being stopped automatically by OpenSL/ES.
-    memset(buf + written * stm->framesize, 0, stm->queuebuf_len - written * stm->framesize);
-    res = (*stm->bufq)->Enqueue(stm->bufq, buf, stm->queuebuf_len);
-    assert(res == SL_RESULT_SUCCESS);
-    stm->queuebuf_idx = (stm->queuebuf_idx + 1) % NBUFS;
-    if (written > 0) {
+  uint8_t *buf = stm->queuebuf[stm->queuebuf_idx];
+  written = 0;
+  pthread_mutex_lock(&stm->mutex);
+  int draining = opensl_get_draining(stm);
+  uint32_t shutdown = opensl_get_shutdown(stm);
+  pthread_mutex_unlock(&stm->mutex);
+  if (!draining && !shutdown) {
+    written = cubeb_resampler_fill(stm->resampler,
+                                   NULL, NULL,
+                                   buf, stm->queuebuf_len / stm->framesize);
+    LOG("bufferqueue_callback: resampler fill returned %ld frames", written);
+    if (written < 0 || written * stm->framesize > stm->queuebuf_len) {
       pthread_mutex_lock(&stm->mutex);
-      stm->written += written;
+      opensl_set_shutdown(stm, 1);
       pthread_mutex_unlock(&stm->mutex);
-    }
-
-    if (!draining && written * stm->framesize < stm->queuebuf_len) {
-      pthread_mutex_lock(&stm->mutex);
-      int64_t written_duration = INT64_C(1000) * stm->written * stm->framesize / stm->bytespersec;
-      stm->draining = 1;
-      pthread_mutex_unlock(&stm->mutex);
-      // Use SL_PLAYEVENT_HEADATMARKER event from slPlayCallback of SLPlayItf
-      // to make sure all the data has been processed.
-      (*stm->play)->SetMarkerPosition(stm->play, (SLmillisecond)written_duration);
+      opensl_stop_player(stm);
+      stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
       return;
     }
   }
+
+  // Keep sending silent data even in draining mode to prevent the audio
+  // back-end from being stopped automatically by OpenSL/ES.
+  assert(stm->queuebuf_len >= written * stm->framesize);
+  memset(buf + written * stm->framesize, 0, stm->queuebuf_len - written * stm->framesize);
+  res = (*stm->bufq)->Enqueue(stm->bufq, buf, stm->queuebuf_len);
+  assert(res == SL_RESULT_SUCCESS);
+  stm->queuebuf_idx = (stm->queuebuf_idx + 1) % stm->queuebuf_capacity;
+
+  if (written > 0) {
+    pthread_mutex_lock(&stm->mutex);
+    stm->written += written;
+    pthread_mutex_unlock(&stm->mutex);
+  }
+
+  if (!draining && written * stm->framesize < stm->queuebuf_len) {
+    LOG("bufferqueue_callback draining");
+    pthread_mutex_lock(&stm->mutex);
+    int64_t written_duration = INT64_C(1000) * stm->written * stm->framesize / stm->bytespersec;
+    opensl_set_draining(stm, 1);
+    pthread_mutex_unlock(&stm->mutex);
+    // Use SL_PLAYEVENT_HEADATMARKER event from slPlayCallback of SLPlayItf
+    // to make sure all the data has been processed.
+    (*stm->play)->SetMarkerPosition(stm->play, (SLmillisecond)written_duration);
+    return;
+  }
+}
+
+static int
+opensl_enqueue_recorder(cubeb_stream * stm, void ** last_filled_buffer)
+{
+  assert(stm);
+
+  int current_index = stm->input_buffer_index;
+  void * last_buffer = NULL;
+
+  if (current_index < 0) {
+    // This is the first enqueue
+    current_index = 0;
+  } else {
+    // The current index hold the last filled buffer get it before advance index.
+    last_buffer = stm->input_buffer_array[current_index];
+    // Advance to get next available buffer
+    current_index = (current_index + 1) % stm->input_array_capacity;
+  }
+  // enqueue next empty buffer to be filled by the recorder
+  SLresult res = (*stm->recorderBufferQueueItf)->Enqueue(stm->recorderBufferQueueItf,
+                                                         stm->input_buffer_array[current_index],
+                                                         stm->input_buffer_length);
+  if (res != SL_RESULT_SUCCESS ) {
+    LOG("Enqueue recorder failed. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+  // All good, update buffer and index.
+  stm->input_buffer_index = current_index;
+  if (last_filled_buffer) {
+    *last_filled_buffer = last_buffer;
+  }
+  return CUBEB_OK;
+}
+
+// input data callback
+void recorder_callback(SLAndroidSimpleBufferQueueItf bq, void * context)
+{
+  assert(context);
+  cubeb_stream * stm = context;
+  assert(stm->recorderBufferQueueItf);
+
+  pthread_mutex_lock(&stm->mutex);
+  uint32_t shutdown = opensl_get_shutdown(stm);
+  int draining = opensl_get_draining(stm);
+  pthread_mutex_unlock(&stm->mutex);
+
+  if (shutdown || draining) {
+    // According to the OpenSL ES 1.1 Specification, 8.14 SLBufferQueueItf
+    // page 184, on transition to the SL_RECORDSTATE_STOPPED state,
+    // the application should continue to enqueue buffers onto the queue
+    // to retrieve the residual recorded data in the system.
+    int r = opensl_enqueue_recorder(stm, NULL);
+    assert(r == CUBEB_OK);
+    return;
+  }
+
+  // Enqueue next available buffer and get the last filled buffer.
+  void * input_buffer = NULL;
+  int r = opensl_enqueue_recorder(stm, &input_buffer);
+  assert(r == CUBEB_OK);
+  assert(input_buffer);
+  // Fill resampler with last input
+  long input_frame_count = stm->input_buffer_length / stm->input_frame_size;
+  long got = cubeb_resampler_fill(stm->resampler,
+                                  input_buffer,
+                                  &input_frame_count,
+                                  NULL,
+                                  0);
+  // Error case
+  if (got < 0 || got > input_frame_count) {
+    pthread_mutex_lock(&stm->mutex);
+    opensl_set_shutdown(stm, 1);
+    pthread_mutex_unlock(&stm->mutex);
+    int r = opensl_stop_recorder(stm);
+    assert(r == CUBEB_OK);
+    stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
+  }
+
+  // Advance total stream frames
+  stm->input_total_frames += got;
+
+  if (got < input_frame_count) {
+    pthread_mutex_lock(&stm->mutex);
+    opensl_set_draining(stm, 1);
+    pthread_mutex_unlock(&stm->mutex);
+    int64_t duration = INT64_C(1000) * stm->input_total_frames / stm->input_device_rate;
+    (*stm->recorderItf)->SetMarkerPosition(stm->recorderItf, (SLmillisecond)duration);
+    return;
+  }
+}
+
+void recorder_fullduplex_callback(SLAndroidSimpleBufferQueueItf bq, void * context)
+{
+  assert(context);
+  cubeb_stream * stm = context;
+  assert(stm->recorderBufferQueueItf);
+
+  pthread_mutex_lock(&stm->mutex);
+  int draining = opensl_get_draining(stm);
+  uint32_t shutdown = opensl_get_shutdown(stm);
+  pthread_mutex_unlock(&stm->mutex);
+
+  if (shutdown || draining) {
+    /* On draining and shutdown the recorder should have been stoped from
+    *  the one set the flags. Accordint to the doc, on transition to
+    *  the SL_RECORDSTATE_STOPPED state, the application should
+    *  continue to enqueue buffers onto the queue to retrieve the residual
+    *  recorded data in the system. */
+    LOG("Input shutdown %d or drain %d", shutdown, draining);
+    int r = opensl_enqueue_recorder(stm, NULL);
+    assert(r == CUBEB_OK);
+    return;
+  }
+
+  // Enqueue next available buffer and get the last filled buffer.
+  void * input_buffer = NULL;
+  int r = opensl_enqueue_recorder(stm, &input_buffer);
+  assert(r == CUBEB_OK);
+  assert(input_buffer);
+
+  assert(stm->input_queue);
+  r = array_queue_push(stm->input_queue, input_buffer);
+  if (r == -1) {
+    LOG("Input queue is full, drop input ...");
+    return;
+  }
+
+  LOG("Input pushed in the queue, input array %zu, output array %zu",
+      array_queue_get_size(stm->input_queue),
+      array_queue_get_size(stm->output_queue));
+}
+
+static void
+player_fullduplex_callback(SLBufferQueueItf caller, void * user_ptr)
+{
+  TIMESTAMP("ENTER");
+  cubeb_stream * stm = user_ptr;
+  assert(stm);
+  SLresult res;
+
+  pthread_mutex_lock(&stm->mutex);
+  int draining = opensl_get_draining(stm);
+  uint32_t shutdown = opensl_get_shutdown(stm);
+  pthread_mutex_unlock(&stm->mutex);
+
+  // Get output
+  void * output_buffer = NULL;
+  pthread_mutex_lock(&stm->mutex);
+  output_buffer = stm->queuebuf[stm->queuebuf_idx];
+  // Advance the output buffer queue index
+  stm->queuebuf_idx = (stm->queuebuf_idx + 1) % stm->queuebuf_capacity;
+  pthread_mutex_unlock(&stm->mutex);
+
+  if (shutdown || draining) {
+    LOG("Shutdown/draining, send silent");
+    // Set silent on buffer
+    memset(output_buffer, 0, stm->queuebuf_len);
+
+    // Enqueue data in player buffer queue
+    res = (*stm->bufq)->Enqueue(stm->bufq,
+                                output_buffer,
+                                stm->queuebuf_len);
+    assert(res == SL_RESULT_SUCCESS);
+    return;
+  }
+
+  // Get input.
+  void * input_buffer = array_queue_pop(stm->input_queue);
+  long input_frame_count = stm->input_buffer_length / stm->input_frame_size;
+  long frames_needed = stm->queuebuf_len / stm->framesize;
+  if (!input_buffer) {
+    LOG("Input hole set silent input buffer");
+    input_buffer = stm->input_silent_buffer;
+  }
+
+  long written = 0;
+  // Trigger user callback through resampler
+  written = cubeb_resampler_fill(stm->resampler,
+                                 input_buffer,
+                                 &input_frame_count,
+                                 output_buffer,
+                                 frames_needed);
+
+  LOG("Fill: written %ld, frames_needed %ld, input array size %zu, output array size %zu",
+      written, frames_needed, array_queue_get_size(stm->input_queue),
+      array_queue_get_size(stm->output_queue));
+
+  if (written < 0 || written  > frames_needed) {
+    // Error case
+    pthread_mutex_lock(&stm->mutex);
+    opensl_set_shutdown(stm, 1);
+    pthread_mutex_unlock(&stm->mutex);
+    opensl_stop_player(stm);
+    opensl_stop_recorder(stm);
+    stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
+    memset(output_buffer, 0, stm->queuebuf_len);
+
+    // Enqueue data in player buffer queue
+    res = (*stm->bufq)->Enqueue(stm->bufq,
+                                output_buffer,
+                                stm->queuebuf_len);
+    assert(res == SL_RESULT_SUCCESS);
+    return;
+  }
+
+  // Advance total out written  frames counter
+  pthread_mutex_lock(&stm->mutex);
+  stm->written += written;
+  pthread_mutex_unlock(&stm->mutex);
+
+  if ( written < frames_needed) {
+    pthread_mutex_lock(&stm->mutex);
+    int64_t written_duration = INT64_C(1000) * stm->written * stm->framesize / stm->bytespersec;
+    opensl_set_draining(stm, 1);
+    pthread_mutex_unlock(&stm->mutex);
+
+    // Use SL_PLAYEVENT_HEADATMARKER event from slPlayCallback of SLPlayItf
+    // to make sure all the data has been processed.
+    (*stm->play)->SetMarkerPosition(stm->play, (SLmillisecond)written_duration);
+  }
+
+  // Keep sending silent data even in draining mode to prevent the audio
+  // back-end from being stopped automatically by OpenSL/ES.
+  memset(output_buffer + written * stm->framesize, 0,
+         stm->queuebuf_len - written * stm->framesize);
+
+  // Enqueue data in player buffer queue
+  res = (*stm->bufq)->Enqueue(stm->bufq,
+                              output_buffer,
+                              stm->queuebuf_len);
+  assert(res == SL_RESULT_SUCCESS);
+  TIMESTAMP("EXIT");
 }
 
 #if defined(__ANDROID__)
@@ -228,7 +623,7 @@ get_android_version(void)
   }
 
   int version = (int)strtol(version_string, NULL, 10);
-  LOG("%d", version);
+  LOG("Android version %d", version);
   return version;
 }
 #endif
@@ -475,7 +870,7 @@ opensl_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
   /* To get a fast track in Android's mixer, we need to be at the native
    * samplerate, which is device dependant. Some devices might be able to
    * resample when playing a fast track, but it's pretty rare. */
-  *latency_frames = NBUFS * primary_buffer_size;
+  *latency_frames = primary_buffer_size;
 
   dlclose(libmedia);
 
@@ -497,67 +892,212 @@ opensl_destroy(cubeb * ctx)
 static void opensl_stream_destroy(cubeb_stream * stm);
 
 static int
-opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name,
-                   cubeb_devid input_device,
-                   cubeb_stream_params * input_stream_params,
-                   cubeb_devid output_device,
-                   cubeb_stream_params * output_stream_params,
-                   unsigned int latency_frames,
-                   cubeb_data_callback data_callback, cubeb_state_callback state_callback,
-                   void * user_ptr)
+opensl_set_format(SLDataFormat_PCM * format, cubeb_stream_params * params)
 {
-  cubeb_stream * stm;
+  assert(format);
+  assert(params);
 
-  assert(ctx);
-  assert(!input_stream_params && "not supported");
-  if (input_device || output_device) {
-    /* Device selection not yet implemented. */
-    return CUBEB_ERROR_DEVICE_UNAVAILABLE;
-  }
-
-  *stream = NULL;
-
-  SLDataFormat_PCM format;
-
-  format.formatType = SL_DATAFORMAT_PCM;
-  format.numChannels = output_stream_params->channels;
+  format->formatType = SL_DATAFORMAT_PCM;
+  format->numChannels = params->channels;
   // samplesPerSec is in milliHertz
-  format.samplesPerSec = output_stream_params->rate * 1000;
-  format.bitsPerSample = SL_PCMSAMPLEFORMAT_FIXED_16;
-  format.containerSize = SL_PCMSAMPLEFORMAT_FIXED_16;
-  format.channelMask = output_stream_params->channels == 1 ?
-    SL_SPEAKER_FRONT_CENTER :
-    SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
+  format->samplesPerSec = params->rate * 1000;
+  format->bitsPerSample = SL_PCMSAMPLEFORMAT_FIXED_16;
+  format->containerSize = SL_PCMSAMPLEFORMAT_FIXED_16;
+  format->channelMask = params->channels == 1 ?
+                       SL_SPEAKER_FRONT_CENTER :
+                       SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
 
-  switch (output_stream_params->format) {
-  case CUBEB_SAMPLE_S16LE:
-    format.endianness = SL_BYTEORDER_LITTLEENDIAN;
-    break;
-  case CUBEB_SAMPLE_S16BE:
-    format.endianness = SL_BYTEORDER_BIGENDIAN;
-    break;
-  default:
+  switch (params->format) {
+    case CUBEB_SAMPLE_S16LE:
+      format->endianness = SL_BYTEORDER_LITTLEENDIAN;
+          break;
+    case CUBEB_SAMPLE_S16BE:
+      format->endianness = SL_BYTEORDER_BIGENDIAN;
+          break;
+    default:
+      return CUBEB_ERROR_INVALID_FORMAT;
+  }
+  return CUBEB_OK;
+}
+
+static int
+opensl_configure_capture(cubeb_stream * stm, cubeb_stream_params * params)
+{
+  assert(stm);
+  assert(params);
+
+  SLDataLocator_AndroidSimpleBufferQueue lDataLocatorOut;
+  lDataLocatorOut.locatorType = SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE;
+  lDataLocatorOut.numBuffers = NBUFS;
+
+  SLDataFormat_PCM lDataFormat;
+  int r = opensl_set_format(&lDataFormat, params);
+  if (r != CUBEB_OK) {
     return CUBEB_ERROR_INVALID_FORMAT;
   }
 
-  stm = calloc(1, sizeof(*stm));
+  /* For now set device rate to params rate. */
+  stm->input_device_rate = params->rate;
+
+  SLDataSink lDataSink;
+  lDataSink.pLocator = &lDataLocatorOut;
+  lDataSink.pFormat = &lDataFormat;
+
+  SLDataLocator_IODevice lDataLocatorIn;
+  lDataLocatorIn.locatorType = SL_DATALOCATOR_IODEVICE;
+  lDataLocatorIn.deviceType = SL_IODEVICE_AUDIOINPUT;
+  lDataLocatorIn.deviceID = SL_DEFAULTDEVICEID_AUDIOINPUT;
+  lDataLocatorIn.device = NULL;
+
+  SLDataSource lDataSource;
+  lDataSource.pLocator = &lDataLocatorIn;
+  lDataSource.pFormat = NULL;
+
+  const SLuint32 lSoundRecorderIIDCount = 2;
+  const SLInterfaceID lSoundRecorderIIDs[] = { SL_IID_RECORD, SL_IID_ANDROIDSIMPLEBUFFERQUEUE };
+  const SLboolean lSoundRecorderReqs[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+  // create the audio recorder abstract object
+  SLresult res = (*stm->context->eng)->CreateAudioRecorder(stm->context->eng,
+                                                           &stm->recorderObj,
+                                                           &lDataSource,
+                                                           &lDataSink,
+                                                           lSoundRecorderIIDCount,
+                                                           lSoundRecorderIIDs,
+                                                           lSoundRecorderReqs);
+  // Sample rate not supported. Try again with default sample rate!
+  if (res == SL_RESULT_CONTENT_UNSUPPORTED) {
+    if (stm->output_enabled && stm->output_configured_rate != 0) {
+      // Set the same with the player. Since there is no
+      // api for input device this is a safe choice.
+      stm->input_device_rate = stm->output_configured_rate;
+    } else  {
+      // The output preferred rate is used for input only scenario. This is
+      // the correct rate to use to get a fast track for input only.
+      r = opensl_get_preferred_sample_rate(stm->context, &stm->input_device_rate);
+      if (r != CUBEB_OK) {
+        // If everything else fail use a safe choice for Android.
+        stm->input_device_rate = DEFAULT_SAMPLE_RATE;
+      }
+    }
+    lDataFormat.samplesPerSec = stm->input_device_rate * 1000;
+    res = (*stm->context->eng)->CreateAudioRecorder(stm->context->eng,
+                                                    &stm->recorderObj,
+                                                    &lDataSource,
+                                                    &lDataSink,
+                                                    lSoundRecorderIIDCount,
+                                                    lSoundRecorderIIDs,
+                                                    lSoundRecorderReqs);
+
+    if (res != SL_RESULT_SUCCESS) {
+      LOG("Failed to create recorder. Error code: %lu", res);
+      return CUBEB_ERROR;
+    }
+  }
+
+  // realize the audio recorder
+  res = (*stm->recorderObj)->Realize(stm->recorderObj, SL_BOOLEAN_FALSE);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to realize recorder. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+  // get the record interface
+  res = (*stm->recorderObj)->GetInterface(stm->recorderObj, SL_IID_RECORD, &stm->recorderItf);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to get recorder interface. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+
+  res = (*stm->recorderItf)->RegisterCallback(stm->recorderItf, recorder_marker_callback, stm);
+  if (res != SL_RESULT_SUCCESS) {
+    opensl_stream_destroy(stm);
+    return CUBEB_ERROR;
+  }
+
+  (*stm->recorderItf)->SetMarkerPosition(stm->recorderItf, (SLmillisecond)0);
+
+  res = (*stm->recorderItf)->SetCallbackEventsMask(stm->recorderItf, (SLuint32)SL_RECORDEVENT_HEADATMARKER);
+  if (res != SL_RESULT_SUCCESS) {
+    opensl_stream_destroy(stm);
+    return CUBEB_ERROR;
+  }
+  // get the simple android buffer queue interface
+  res = (*stm->recorderObj)->GetInterface(stm->recorderObj,
+                                          SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
+                                          &stm->recorderBufferQueueItf);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to get recorder (android) buffer queue interface. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+
+  // register callback on record (input) buffer queue
+  slAndroidSimpleBufferQueueCallback rec_callback = recorder_callback;
+  if (stm->output_enabled) {
+    // Register full duplex callback instead.
+    rec_callback = recorder_fullduplex_callback;
+  }
+  res = (*stm->recorderBufferQueueItf)->RegisterCallback(stm->recorderBufferQueueItf,
+                                                         rec_callback,
+                                                         stm);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to register recorder buffer queue callback. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+
+  // Calculate length of input buffer according to requested latency
+  stm->input_frame_size = params->channels * sizeof(int16_t);
+  stm->input_buffer_length = (stm->input_frame_size * stm->latency_frames);
+
+  // Calculate the capacity of input array
+  stm->input_array_capacity = NBUFS;
+  if (stm->output_enabled) {
+    // Full duplex, update capacity to hold 1 sec of data
+    stm->input_array_capacity = 1 * stm->input_device_rate / stm->input_buffer_length;
+  }
+  // Allocate input array
+  stm->input_buffer_array = (void**)calloc(1, sizeof(void*)*stm->input_array_capacity);
+  // Buffering has not started yet.
+  stm->input_buffer_index = -1;
+  // Prepare input buffers
+  for(int i = 0; i < stm->input_array_capacity; ++i) {
+    stm->input_buffer_array[i] = calloc(1, stm->input_buffer_length);
+  }
+
+  // On full duplex allocate input queue and silent buffer
+  if (stm->output_enabled) {
+    stm->input_queue = array_queue_create(stm->input_array_capacity);
+    assert(stm->input_queue);
+    stm->input_silent_buffer = calloc(1, stm->input_buffer_length);
+    assert(stm->input_silent_buffer);
+  }
+
+  // Enqueue buffer to start rolling once recorder started
+  r = opensl_enqueue_recorder(stm, NULL);
+  if (r != CUBEB_OK) {
+    return r;
+  }
+
+  LOG("Cubeb stream init recorder success");
+
+  return CUBEB_OK;
+}
+
+static int
+opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
   assert(stm);
+  assert(params);
 
-  stm->context = ctx;
-  stm->data_callback = data_callback;
-  stm->state_callback = state_callback;
-  stm->user_ptr = user_ptr;
-
-  stm->inputrate = output_stream_params->rate;
-  stm->latency = latency_frames;
-  stm->stream_type = output_stream_params->stream_type;
-  stm->framesize = output_stream_params->channels * sizeof(int16_t);
+  stm->inputrate = params->rate;
+  stm->stream_type = params->stream_type;
+  stm->framesize = params->channels * sizeof(int16_t);
   stm->lastPosition = -1;
   stm->lastPositionTimeStamp = 0;
   stm->lastCompensativePosition = -1;
 
-  int r = pthread_mutex_init(&stm->mutex, NULL);
-  assert(r == 0);
+  SLDataFormat_PCM format;
+  int r = opensl_set_format(&format, params);
+  if (r != CUBEB_OK) {
+    return CUBEB_ERROR_INVALID_FORMAT;
+  }
 
   SLDataLocator_BufferQueue loc_bufq;
   loc_bufq.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
@@ -568,15 +1108,15 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
 
   SLDataLocator_OutputMix loc_outmix;
   loc_outmix.locatorType = SL_DATALOCATOR_OUTPUTMIX;
-  loc_outmix.outputMix = ctx->outmixObj;
+  loc_outmix.outputMix = stm->context->outmixObj;
   SLDataSink sink;
   sink.pLocator = &loc_outmix;
   sink.pFormat = NULL;
 
 #if defined(__ANDROID__)
-  const SLInterfaceID ids[] = {ctx->SL_IID_BUFFERQUEUE,
-                               ctx->SL_IID_VOLUME,
-                               ctx->SL_IID_ANDROIDCONFIGURATION};
+  const SLInterfaceID ids[] = {stm->context->SL_IID_BUFFERQUEUE,
+                               stm->context->SL_IID_VOLUME,
+                               stm->context->SL_IID_ANDROIDCONFIGURATION};
   const SLboolean req[] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 #else
   const SLInterfaceID ids[] = {ctx->SL_IID_BUFFERQUEUE, ctx->SL_IID_VOLUME};
@@ -584,35 +1124,46 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
 #endif
   assert(NELEMS(ids) == NELEMS(req));
 
+  unsigned int latency_frames = stm->latency_frames;
   uint32_t preferred_sampling_rate = stm->inputrate;
 #if defined(__ANDROID__)
   if (get_android_version() >= ANDROID_VERSION_MARSHMALLOW) {
     // Reset preferred samping rate to trigger fallback to native sampling rate.
     preferred_sampling_rate = 0;
-    if (opensl_get_min_latency(ctx, *output_stream_params, &latency_frames) != CUBEB_OK) {
+    if (opensl_get_min_latency(stm->context, *params, &latency_frames) != CUBEB_OK) {
       // Default to AudioFlinger's advertised fast track latency of 10ms.
       latency_frames = 440;
     }
-    stm->latency = latency_frames;
+    stm->latency_frames = latency_frames;
   }
 #endif
 
   SLresult res = SL_RESULT_CONTENT_UNSUPPORTED;
   if (preferred_sampling_rate) {
-    res = (*ctx->eng)->CreateAudioPlayer(ctx->eng, &stm->playerObj, &source,
-                                         &sink, NELEMS(ids), ids, req);
+    res = (*stm->context->eng)->CreateAudioPlayer(stm->context->eng,
+                                                  &stm->playerObj,
+                                                  &source,
+                                                  &sink,
+                                                  NELEMS(ids),
+                                                  ids,
+                                                  req);
   }
 
   // Sample rate not supported? Try again with primary sample rate!
   if (res == SL_RESULT_CONTENT_UNSUPPORTED) {
-    if (opensl_get_preferred_sample_rate(ctx, &preferred_sampling_rate)) {
-      opensl_stream_destroy(stm);
-      return CUBEB_ERROR;
+    if (opensl_get_preferred_sample_rate(stm->context, &preferred_sampling_rate)) {
+      // If fail default is used
+      preferred_sampling_rate = DEFAULT_SAMPLE_RATE;
     }
 
     format.samplesPerSec = preferred_sampling_rate * 1000;
-    res = (*ctx->eng)->CreateAudioPlayer(ctx->eng, &stm->playerObj,
-                                         &source, &sink, NELEMS(ids), ids, req);
+    res = (*stm->context->eng)->CreateAudioPlayer(stm->context->eng,
+                                                  &stm->playerObj,
+                                                  &source,
+                                                  &sink,
+                                                  NELEMS(ids),
+                                                  ids,
+                                                  req);
   }
 
   if (res != SL_RESULT_SUCCESS) {
@@ -620,42 +1171,39 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
     return CUBEB_ERROR;
   }
 
-  stm->outputrate = preferred_sampling_rate;
-  stm->bytespersec = stm->outputrate * stm->framesize;
-  stm->queuebuf_len = stm->framesize * latency_frames / NBUFS;
-  // round up to the next multiple of stm->framesize, if needed.
-  if (stm->queuebuf_len % stm->framesize) {
-    stm->queuebuf_len += stm->framesize - (stm->queuebuf_len % stm->framesize);
+  stm->output_configured_rate = preferred_sampling_rate;
+  stm->bytespersec = stm->output_configured_rate * stm->framesize;
+  stm->queuebuf_len = stm->framesize * latency_frames;
+
+  // Calculate the capacity of input array
+  stm->queuebuf_capacity = NBUFS;
+  if (stm->output_enabled) {
+    // Full duplex, update capacity to hold 1 sec of data
+    stm->queuebuf_capacity = 1 * stm->output_configured_rate / stm->queuebuf_len;
   }
-
-  cubeb_stream_params params = *output_stream_params;
-  params.rate = preferred_sampling_rate;
-
-  stm->resampler = cubeb_resampler_create(stm, NULL, &params,
-                                          output_stream_params->rate,
-                                          data_callback,
-                                          user_ptr,
-                                          CUBEB_RESAMPLER_QUALITY_DEFAULT);
-
-  if (!stm->resampler) {
-    opensl_stream_destroy(stm);
-    return CUBEB_ERROR;
-  }
-
-  int i;
-  for (i = 0; i < NBUFS; i++) {
-    stm->queuebuf[i] = malloc(stm->queuebuf_len);
+  // Allocate input array
+  stm->queuebuf = (void**)calloc(1, sizeof(void*) * stm->queuebuf_capacity);
+  for (int i = 0; i < stm->queuebuf_capacity; ++i) {
+    stm->queuebuf[i] = calloc(1, stm->queuebuf_len);
     assert(stm->queuebuf[i]);
   }
 
 #if defined(__ANDROID__)
-  SLuint32 stream_type = convert_stream_type_to_sl_stream(output_stream_params->stream_type);
+  SLuint32 stream_type = convert_stream_type_to_sl_stream(params->stream_type);
   if (stream_type != 0xFFFFFFFF) {
     SLAndroidConfigurationItf playerConfig;
     res = (*stm->playerObj)->GetInterface(stm->playerObj,
-                                          ctx->SL_IID_ANDROIDCONFIGURATION, &playerConfig);
+                                          stm->context->SL_IID_ANDROIDCONFIGURATION,
+                                          &playerConfig);
+    if (res != SL_RESULT_SUCCESS) {
+      opensl_stream_destroy(stm);
+      return CUBEB_ERROR;
+    }
+
     res = (*playerConfig)->SetConfiguration(playerConfig,
-                                            SL_ANDROID_KEY_STREAM_TYPE, &stream_type, sizeof(SLint32));
+                                            SL_ANDROID_KEY_STREAM_TYPE,
+                                            &stream_type,
+                                            sizeof(SLint32));
     if (res != SL_RESULT_SUCCESS) {
       opensl_stream_destroy(stm);
       return CUBEB_ERROR;
@@ -669,22 +1217,25 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
     return CUBEB_ERROR;
   }
 
-  res = (*stm->playerObj)->GetInterface(stm->playerObj, ctx->SL_IID_PLAY, &stm->play);
+  res = (*stm->playerObj)->GetInterface(stm->playerObj,
+                                        stm->context->SL_IID_PLAY,
+                                        &stm->play);
   if (res != SL_RESULT_SUCCESS) {
     opensl_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
-  res = (*stm->playerObj)->GetInterface(stm->playerObj, ctx->SL_IID_BUFFERQUEUE,
+  res = (*stm->playerObj)->GetInterface(stm->playerObj,
+                                        stm->context->SL_IID_BUFFERQUEUE,
                                         &stm->bufq);
   if (res != SL_RESULT_SUCCESS) {
     opensl_stream_destroy(stm);
     return CUBEB_ERROR;
   }
 
-  res = (*stm->playerObj)->GetInterface(stm->playerObj, ctx->SL_IID_VOLUME,
+  res = (*stm->playerObj)->GetInterface(stm->playerObj,
+                                        stm->context->SL_IID_VOLUME,
                                         &stm->volume);
-
   if (res != SL_RESULT_SUCCESS) {
     opensl_stream_destroy(stm);
     return CUBEB_ERROR;
@@ -705,10 +1256,20 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
     return CUBEB_ERROR;
   }
 
-  res = (*stm->bufq)->RegisterCallback(stm->bufq, bufferqueue_callback, stm);
+  slBufferQueueCallback player_callback = bufferqueue_callback;
+  if (stm->input_enabled) {
+    player_callback = player_fullduplex_callback;
+  }
+  res = (*stm->bufq)->RegisterCallback(stm->bufq, player_callback, stm);
   if (res != SL_RESULT_SUCCESS) {
     opensl_stream_destroy(stm);
     return CUBEB_ERROR;
+  }
+
+  if (stm->input_enabled) {
+    // Full duplex
+    stm->output_queue = array_queue_create(stm->queuebuf_capacity);
+    assert(stm->output_queue);
   }
 
   {
@@ -722,44 +1283,305 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name
     assert(res == SL_RESULT_SUCCESS);
   }
 
-  *stream = stm;
+  LOG("Cubeb stream init playback success");
   return CUBEB_OK;
 }
 
-static void
-opensl_stream_destroy(cubeb_stream * stm)
+static int
+opensl_validate_stream_param(cubeb_stream_params * stream_params)
 {
-  if (stm->playerObj)
-    (*stm->playerObj)->Destroy(stm->playerObj);
-  int i;
-  for (i = 0; i < NBUFS; i++) {
-    free(stm->queuebuf[i]);
+  if ((stream_params &&
+       (stream_params->channels < 1 || stream_params->channels > 32))) {
+    return CUBEB_ERROR_INVALID_FORMAT;
   }
-  pthread_mutex_destroy(&stm->mutex);
+  return CUBEB_OK;
+}
 
-  cubeb_resampler_destroy(stm->resampler);
+static int
+opensl_stream_init(cubeb * ctx, cubeb_stream ** stream, char const * stream_name,
+                   cubeb_devid input_device,
+                   cubeb_stream_params * input_stream_params,
+                   cubeb_devid output_device,
+                   cubeb_stream_params * output_stream_params,
+                   unsigned int latency_frames,
+                   cubeb_data_callback data_callback, cubeb_state_callback state_callback,
+                   void * user_ptr)
+{
+  cubeb_stream * stm;
 
-  free(stm);
+  assert(ctx);
+  if (input_device || output_device) {
+    LOG("Device selection is not supported in Android. The default will be used");
+  }
+
+  *stream = NULL;
+
+  int r = opensl_validate_stream_param(output_stream_params);
+  if(r != CUBEB_OK) {
+    LOG("Output stream params not valid");
+    return r;
+  }
+  r = opensl_validate_stream_param(input_stream_params);
+  if(r != CUBEB_OK) {
+    LOG("Input stream params not valid");
+    return r;
+  }
+
+  stm = calloc(1, sizeof(*stm));
+  assert(stm);
+
+  stm->context = ctx;
+  stm->data_callback = data_callback;
+  stm->state_callback = state_callback;
+  stm->user_ptr = user_ptr;
+  stm->latency_frames = latency_frames;
+  stm->input_enabled = (input_stream_params) ? 1 : 0;
+  stm->output_enabled = (output_stream_params) ? 1 : 0;
+  stm->shutdown = 1;
+
+#ifdef DEBUG
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_init(&attr);
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  r = pthread_mutex_init(&stm->mutex, &attr);
+  a
+#else
+  r = pthread_mutex_init(&stm->mutex, NULL);
+#endif
+  assert(r == 0);
+
+  if (output_stream_params) {
+    r = opensl_configure_playback(stm, output_stream_params);
+    if (r != CUBEB_OK) {
+      opensl_stream_destroy(stm);
+      return r;
+    }
+  }
+
+  if (input_stream_params) {
+    r = opensl_configure_capture(stm, input_stream_params);
+    if (r != CUBEB_OK) {
+      opensl_stream_destroy(stm);
+      return r;
+    }
+  }
+
+  /* Configure resampler*/
+  uint32_t target_sample_rate;
+  if (input_stream_params) {
+    target_sample_rate = input_stream_params->rate;
+  } else {
+    assert(output_stream_params);
+    target_sample_rate = output_stream_params->rate;
+  }
+
+  // Use the actual configured rates for input
+  // and output.
+  cubeb_stream_params input_params;
+  if (input_stream_params) {
+    input_params = *input_stream_params;
+    input_params.rate = stm->input_device_rate;
+  }
+  cubeb_stream_params output_params;
+  if (output_stream_params) {
+    output_params = *output_stream_params;
+    output_params.rate = stm->output_configured_rate;
+  }
+
+  stm->resampler = cubeb_resampler_create(stm,
+                                          input_stream_params ? &input_params : NULL,
+                                          output_stream_params ? &output_params : NULL,
+                                          target_sample_rate,
+                                          data_callback,
+                                          user_ptr,
+                                          CUBEB_RESAMPLER_QUALITY_DEFAULT);
+  if (!stm->resampler) {
+    LOG("Failed to create resampler");
+    opensl_stream_destroy(stm);
+    return CUBEB_ERROR;
+  }
+
+  *stream = stm;
+  LOG("Cubeb stream (%p) init success", stm);
+  return CUBEB_OK;
+}
+
+static int
+opensl_start_player(cubeb_stream * stm)
+{
+  assert(stm->playerObj);
+  SLuint32 playerState;
+  (*stm->playerObj)->GetState(stm->playerObj, &playerState);
+  if (playerState == SL_OBJECT_STATE_REALIZED) {
+    SLresult res = (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_PLAYING);
+    if(res != SL_RESULT_SUCCESS) {
+      LOG("Failed to start player. Error code: %lu", res);
+      return CUBEB_ERROR;
+    }
+  }
+  return CUBEB_OK;
+}
+
+static int
+opensl_start_recorder(cubeb_stream * stm)
+{
+  assert(stm->recorderObj);
+  SLuint32 recorderState;
+  (*stm->recorderObj)->GetState(stm->recorderObj, &recorderState);
+  if (recorderState == SL_OBJECT_STATE_REALIZED) {
+    SLresult res = (*stm->recorderItf)->SetRecordState(stm->recorderItf, SL_RECORDSTATE_RECORDING);
+    if(res != SL_RESULT_SUCCESS) {
+      LOG("Failed to start recorder. Error code: %lu", res);
+      return CUBEB_ERROR;
+    }
+  }
+  return CUBEB_OK;
 }
 
 static int
 opensl_stream_start(cubeb_stream * stm)
 {
-  SLresult res = (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_PLAYING);
-  if (res != SL_RESULT_SUCCESS)
-    return CUBEB_ERROR;
+  assert(stm);
+
+  pthread_mutex_lock(&stm->mutex);
+  opensl_set_shutdown(stm, 0);
+  opensl_set_draining(stm, 0);
+  pthread_mutex_unlock(&stm->mutex);
+
+  if (stm->playerObj) {
+    int r = opensl_start_player(stm);
+    if (r != CUBEB_OK) {
+      return r;
+    }
+  }
+
+  if (stm->recorderObj) {
+    int r = opensl_start_recorder(stm);
+    if (r != CUBEB_OK) {
+      return r;
+    }
+  }
+
   stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_STARTED);
+  LOG("Cubeb stream (%p) started", stm);
+  return CUBEB_OK;
+}
+
+static int
+opensl_stop_player(cubeb_stream * stm)
+{
+  assert(stm->playerObj);
+  assert(stm->shutdown || stm->draining);
+
+  SLresult res = (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_STOPPED);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to stop player. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+
+  res = (*stm->bufq)->Clear(stm->bufq);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to clear player buffer queue. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+  return CUBEB_OK;
+}
+
+static int
+opensl_stop_recorder(cubeb_stream * stm)
+{
+  assert(stm->recorderObj);
+  assert(stm->shutdown || stm->draining);
+
+  SLresult res = (*stm->recorderItf)->SetRecordState(stm->recorderItf, SL_RECORDSTATE_STOPPED);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to stop recorder. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+  res = (*stm->recorderBufferQueueItf)->Clear(stm->recorderBufferQueueItf);
+  if (res != SL_RESULT_SUCCESS) {
+    LOG("Failed to clear recorder buffer queue. Error code: %lu", res);
+    return CUBEB_ERROR;
+  }
+
+  if (stm->input_queue) {
+    // In full duplex send an silent buffer to unlock the thread
+    // waiting in the input queue (just in case)
+    array_queue_push(stm->input_queue, stm->input_silent_buffer);
+  }
   return CUBEB_OK;
 }
 
 static int
 opensl_stream_stop(cubeb_stream * stm)
 {
-  SLresult res = (*stm->play)->SetPlayState(stm->play, SL_PLAYSTATE_PAUSED);
-  if (res != SL_RESULT_SUCCESS)
-    return CUBEB_ERROR;
+  assert(stm);
+
+  pthread_mutex_lock(&stm->mutex);
+  opensl_set_shutdown(stm, 1);
+  pthread_mutex_unlock(&stm->mutex);
+
+  if (stm->playerObj) {
+    int r = opensl_stop_player(stm);
+    if (r != CUBEB_OK) {
+      return r;
+    }
+  }
+
+  if (stm->recorderObj) {
+    int r = opensl_stop_recorder(stm);
+    if (r != CUBEB_OK) {
+      return r;
+    }
+  }
+
   stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_STOPPED);
+  LOG("Cubeb stream (%p) stopped", stm);
   return CUBEB_OK;
+}
+
+static void
+opensl_stream_destroy(cubeb_stream * stm)
+{
+  assert(stm->draining || stm->shutdown);
+
+  if (stm->playerObj) {
+    (*stm->playerObj)->Destroy(stm->playerObj);
+    stm->playerObj = NULL;
+    stm->play = NULL;
+    stm->bufq = NULL;
+    for (int i = 0; i < stm->queuebuf_capacity; ++i) {
+      free(stm->queuebuf[i]);
+    }
+  }
+
+  if (stm->recorderObj) {
+    (*stm->recorderObj)->Destroy(stm->recorderObj);
+    stm->recorderObj = NULL;
+    stm->recorderItf = NULL;
+    stm->recorderBufferQueueItf = NULL;
+    for (int i = 0; i < stm->input_array_capacity; ++i) {
+      free(stm->input_buffer_array[i]);
+    }
+  }
+
+  if (stm->resampler) {
+    cubeb_resampler_destroy(stm->resampler);
+  }
+
+  if (stm->input_queue) {
+    array_queue_destroy(stm->input_queue);
+  }
+  free(stm->input_silent_buffer);
+
+  if (stm->output_queue) {
+    array_queue_destroy(stm->output_queue);
+  }
+
+  pthread_mutex_destroy(&stm->mutex);
+
+  LOG("Cubeb stream (%p) destroyed", stm);
+  free(stm);
 }
 
 static int
@@ -794,7 +1616,7 @@ opensl_stream_get_position(cubeb_stream * stm, uint64_t * position)
   }
 
   pthread_mutex_lock(&stm->mutex);
-  int64_t maximum_position = stm->written * (int64_t)stm->inputrate / stm->outputrate;
+  int64_t maximum_position = stm->written * (int64_t)stm->inputrate / stm->output_configured_rate;
   pthread_mutex_unlock(&stm->mutex);
   assert(maximum_position >= 0);
 
@@ -829,7 +1651,7 @@ opensl_stream_get_latency(cubeb_stream * stm, uint32_t * latency)
     return CUBEB_ERROR;
   }
 
-  *latency = stm->latency * stm->inputrate / 1000 + // OpenSL latency
+  *latency = stm->latency_frames + // OpenSL latency
     mixer_latency * stm->inputrate / 1000; // AudioFlinger latency
 
   return CUBEB_OK;

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -618,6 +618,9 @@ TEST(cubeb, drain)
 
   cubeb_stream_destroy(stream);
   cubeb_destroy(ctx);
+
+  got_drain = 0;
+  do_drain = 0;
 }
 
 TEST(cubeb, DISABLED_eos_during_prefill)


### PR DESCRIPTION
Full duplex functionality for OpenSL ES. The patch in the bottom is the same patch which backout in 99d6ae1 rebased to current version. The rest of the patches are all problems found during build, manual testing and try run. Latest try:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=cab4bbde79b65b872f0181b2076d49b3b8df231d
Latest autophone try:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=ae10057481627d78a7b47483adfc27768c985d79

Review @kinetiknz and/or @padenot ?
