### PR TITLE
pulse: Complete pulse_stream_set_panning implementation.

### DIFF
--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -230,7 +230,7 @@ int run_panning_volume_test(int is_float)
   fprintf(stderr, "Testing: panning\n");
   for(int i=-4;i <= 4; ++i)
   {
-    fprintf(stderr, "Panning: %.2f%%\n", i/4.0f);
+    fprintf(stderr, "Panning: %.2f\n", i/4.0f);
 
     cubeb_stream_set_panning(stream, i/4.0f);
     cubeb_stream_start(stream);


### PR DESCRIPTION
The existing implementation called pa_cvolume_set_balance on an
uninitialized pa_cvolume (which triggered a Valgrind warning) and then
forgot to apply the result to the sink input.

This is https://bugzilla.mozilla.org/show_bug.cgi?id=1319623

r? @achronop 