### PR TITLE
Allow preferred layout returning undefined

### DIFF
--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -33,7 +33,7 @@ cubeb_layout_map const CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
 
 static int const CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
  // M | L | R | C | LS | RS | RLS | RC | RRS | LFE
-  { -1, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // UNSUPPORTED
+  { -1, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // UNDEFINED
   { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // DUAL_MONO
   { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,   2 }, // DUAL_MONO_LFE
   {  0, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // MONO

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -30,7 +30,7 @@ typedef enum {
 } cubeb_channel;
 
 static cubeb_channel const CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
-  { CHANNEL_INVALID },                                                                                            // UNSUPPORTED
+  { CHANNEL_INVALID },                                                                                            // UNDEFINED
   { CHANNEL_LEFT, CHANNEL_RIGHT },                                                                                // DUAL_MONO
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_LFE },                                                                   // DUAL_MONO_LFE
   { CHANNEL_MONO },                                                                                               // MONO

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -28,9 +28,6 @@ TEST(cubeb, latency)
 
   r = cubeb_get_preferred_channel_layout(ctx, &layout);
   ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);
-  if (r == CUBEB_OK) {
-    ASSERT_NE(layout, CUBEB_LAYOUT_UNDEFINED);
-  }
 
   cubeb_stream_params params = {
     CUBEB_SAMPLE_FLOAT32NE,

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -91,7 +91,7 @@ void
 downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
   if (in_layout == CUBEB_LAYOUT_UNDEFINED) {
-    return; // Only possible output layout would be UNSUPPORTED.
+    return; // Only possible output layout would be UNDEFINED.
   }
 
   cubeb_stream_params in_params = {


### PR DESCRIPTION
- Allow ```cubeb_get_preferred_channel_layout``` returning CUBEB_LAYOUT_UNDEFINED
- Fix typo