### PR TITLE
audiounit: Avoid AudioCore dealock in stream init (Bug 1317234)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1514,6 +1514,7 @@ audiounit_stream_init(cubeb * context,
     stm->output_device = reinterpret_cast<uintptr_t>(output_device);
   }
 
+  auto_lock context_locl(context->mutex);
   /* Silently clamp the latency down to the platform default, because we
    * synthetize the clock from the callbacks, and we want the clock to update
    * often. */
@@ -1568,6 +1569,7 @@ audiounit_stream_destroy(cubeb_stream * stm)
 {
   stm->shutdown = true;
 
+  auto_lock context_locl(stm->context->mutex);
   audiounit_stream_stop_internal(stm);
 
   {
@@ -1608,6 +1610,7 @@ audiounit_stream_start(cubeb_stream * stm)
   stm->shutdown = false;
   stm->draining = false;
 
+  auto_lock context_locl(stm->context->mutex);
   audiounit_stream_start_internal(stm);
 
   stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_STARTED);
@@ -1635,6 +1638,7 @@ audiounit_stream_stop(cubeb_stream * stm)
 {
   stm->shutdown = true;
 
+  auto_lock context_locl(stm->context->mutex);
   audiounit_stream_stop_internal(stm);
 
   stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_STOPPED);


### PR DESCRIPTION
AudioCore is prompt to deadlock sporadically. In order to avoid that the following enhancements took place: 

- I added synchronization on stream init/start/stop/destroy.
- Avoid to set property from notification callback.
- Re init stream through a asynchronous dispatch queue.
- Wait after setting buffer size for the change to take effect.

Also some refactoring took place.

Try run on the top of latest commit:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=205781e0ae4e04011fb27d0cdbf8f900b5e00b62

Please find more info about the deadlock on the corresponding bug: 
https://bugzilla.mozilla.org/show_bug.cgi?id=1317234