### PR TITLE
Define KSAUDIO_SPEAKER_5/7POINT1_SURROUND if it doesn't exist

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -400,6 +400,17 @@ double stream_to_mix_samplerate_ratio(cubeb_stream_params & stream, cubeb_stream
 
 /* Convert the channel layout into the corresponding KSAUDIO_CHANNEL_CONFIG.
    See more: https://msdn.microsoft.com/en-us/library/windows/hardware/ff537083(v=vs.85).aspx */
+#ifndef KSAUDIO_SPEAKER_5POINT1_SURROUND
+#define KSAUDIO_SPEAKER_5POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | \
+                                          SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | \
+                                          SPEAKER_SIDE_LEFT  | SPEAKER_SIDE_RIGHT)
+#endif
+#ifndef KSAUDIO_SPEAKER_7POINT1_SURROUND
+#define KSAUDIO_SPEAKER_7POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | \
+                                          SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | \
+                                          SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT | \
+                                          SPEAKER_SIDE_LEFT | SPEAKER_SIDE_RIGHT)
+#endif
 #define MASK_DUAL_MONO      (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT)
 #define MASK_DUAL_MONO_LFE  (MASK_DUAL_MONO | SPEAKER_LOW_FREQUENCY)
 #define MASK_MONO           (KSAUDIO_SPEAKER_MONO)

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -4,6 +4,8 @@
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
  */
+#define NTDDI_VERSION 0x05020100
+#define _WIN32_WINNT 0x0502
 #define NOMINMAX
 
 #include <initguid.h>
@@ -400,17 +402,6 @@ double stream_to_mix_samplerate_ratio(cubeb_stream_params & stream, cubeb_stream
 
 /* Convert the channel layout into the corresponding KSAUDIO_CHANNEL_CONFIG.
    See more: https://msdn.microsoft.com/en-us/library/windows/hardware/ff537083(v=vs.85).aspx */
-#ifndef KSAUDIO_SPEAKER_5POINT1_SURROUND
-#define KSAUDIO_SPEAKER_5POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | \
-                                          SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | \
-                                          SPEAKER_SIDE_LEFT  | SPEAKER_SIDE_RIGHT)
-#endif
-#ifndef KSAUDIO_SPEAKER_7POINT1_SURROUND
-#define KSAUDIO_SPEAKER_7POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | \
-                                          SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | \
-                                          SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT | \
-                                          SPEAKER_SIDE_LEFT | SPEAKER_SIDE_RIGHT)
-#endif
 #define MASK_DUAL_MONO      (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT)
 #define MASK_DUAL_MONO_LFE  (MASK_DUAL_MONO | SPEAKER_LOW_FREQUENCY)
 #define MASK_MONO           (KSAUDIO_SPEAKER_MONO)


### PR DESCRIPTION
When I try to integrate the multiple channel support of cubeb on Windows, the error says: ```KSAUDIO_SPEAKER_5POINT1_SURROUND is not defined```, so I think it's better to define it in cubeb_wasapi.cpp itself.