### PR TITLE
Multiple channel support on OS X

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2720,14 +2720,13 @@ audiounit_get_channel_layout(bool preferred)
 
   // Get the channel layout
   UInt32 size = 0;
-  Boolean writable;
   rv = AudioUnitGetPropertyInfo(output_unit,
                                 preferred ? kAudioDevicePropertyPreferredChannelLayout :
                                             kAudioUnitProperty_AudioChannelLayout,
                                 kAudioUnitScope_Output,
                                 AU_OUT_BUS,
                                 &size,
-                                &writable);
+                                nullptr);
   if (rv != noErr) {
     if (preferred) {
       PRINT_ERROR_CODE("AudioUnitGetPropertyInfo/kAudioDevicePropertyPreferredChannelLayout", rv);

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1194,7 +1194,11 @@ audiounit_layout_init(AudioUnit * unit,
                            layout.get(),
                            layout.size());
   if (r != noErr) {
-    PRINT_ERROR_CODE("AudioUnitSetProperty/kAudioUnitProperty_AudioChannelLayout", r);
+    if (side == INPUT) {
+      PRINT_ERROR_CODE("AudioUnitSetProperty/input/kAudioUnitProperty_AudioChannelLayout", r);
+    } else {
+      PRINT_ERROR_CODE("AudioUnitSetProperty/output/kAudioUnitProperty_AudioChannelLayout", r);
+    }
     return CUBEB_ERROR;
   }
 
@@ -2718,28 +2722,36 @@ audiounit_get_channel_layout(bool preferred)
   UInt32 size = 0;
   Boolean writable;
   rv = AudioUnitGetPropertyInfo(output_unit,
-                                (preferred) ? kAudioDevicePropertyPreferredChannelLayout :
-                                              kAudioUnitProperty_AudioChannelLayout,
+                                preferred ? kAudioDevicePropertyPreferredChannelLayout :
+                                            kAudioUnitProperty_AudioChannelLayout,
                                 kAudioUnitScope_Output,
                                 AU_OUT_BUS,
                                 &size,
                                 &writable);
   if (rv != noErr) {
-    PRINT_ERROR_CODE("AudioUnitGetPropertyInfo/kAudioDevicePropertyPreferredChannelLayout||kAudioUnitProperty_AudioChannelLayout", rv);
+    if (preferred) {
+      PRINT_ERROR_CODE("AudioUnitGetPropertyInfo/kAudioDevicePropertyPreferredChannelLayout", rv);
+    } else {
+      PRINT_ERROR_CODE("AudioUnitGetPropertyInfo/kAudioUnitProperty_AudioChannelLayout", rv);
+    }
     return CUBEB_LAYOUT_UNDEFINED;
   }
   assert(size > 0);
 
   auto_channel_layout layout(size);
   rv = AudioUnitGetProperty(output_unit,
-                            (preferred) ? kAudioDevicePropertyPreferredChannelLayout :
-                                          kAudioUnitProperty_AudioChannelLayout,
+                            preferred ? kAudioDevicePropertyPreferredChannelLayout :
+                                        kAudioUnitProperty_AudioChannelLayout,
                             kAudioUnitScope_Output,
                             AU_OUT_BUS,
                             layout.get(),
                             &size);
   if (rv != noErr) {
-    PRINT_ERROR_CODE("AudioUnitGetProperty/kAudioDevicePropertyPreferredChannelLayout||kAudioUnitProperty_AudioChannelLayout", rv);
+    if (preferred) {
+      PRINT_ERROR_CODE("AudioUnitGetProperty/kAudioDevicePropertyPreferredChannelLayout", rv);
+    } else {
+      PRINT_ERROR_CODE("AudioUnitGetProperty/kAudioUnitProperty_AudioChannelLayout", rv);
+    }
     return CUBEB_LAYOUT_UNDEFINED;
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -22,6 +22,7 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
+#include "cubeb_mixer.h"
 #include "cubeb_panner.h"
 #if !TARGET_OS_IPHONE
 #include "cubeb_osx_run_loop.h"
@@ -56,6 +57,10 @@ void audiounit_stream_stop_internal(cubeb_stream * stm);
 void audiounit_stream_start_internal(cubeb_stream * stm);
 static void audiounit_close_stream(cubeb_stream *stm);
 static int audiounit_setup_stream(cubeb_stream *stm);
+static int audiounit_create_unit(AudioUnit * unit, bool is_input,
+                                 const cubeb_stream_params * /* stream_params */,
+                                 AudioDeviceID device);
+static cubeb_channel_layout audiounit_get_channel_layout(bool preferred);
 
 extern cubeb_ops const audiounit_ops;
 
@@ -194,6 +199,70 @@ bool has_output(cubeb_stream * stm)
 {
   return stm->output_stream_params.rate != 0;
 }
+
+// -----------------------------------------------------------------------------
+// The converstion from mask to layout should be moved to mixer.h or somewhere else
+// -----------------------------------------------------------------------------
+// DUAL_MONO(_LFE) is same as STEREO(_LFE).
+#define MASK_MONO         (1 << CHANNEL_MONO)
+#define MASK_MONO_LFE     (MASK_MONO | (1 << CHANNEL_LFE))
+#define MASK_STEREO       ((1 << CHANNEL_LEFT) | (1 << CHANNEL_RIGHT))
+#define MASK_STEREO_LFE   (MASK_STEREO | (1 << CHANNEL_LFE))
+#define MASK_3F           (MASK_STEREO | (1 << CHANNEL_CENTER))
+#define MASK_3F_LFE       (MASK_3F | (1 << CHANNEL_LFE))
+#define MASK_2F1          (MASK_STEREO | (1 << CHANNEL_RCENTER))
+#define MASK_2F1_LFE      (MASK_2F1 | (1 << CHANNEL_LFE))
+#define MASK_3F1          (MASK_3F | (1 << CHANNEL_RCENTER))
+#define MASK_3F1_LFE      (MASK_3F1 | (1 << CHANNEL_LFE))
+#define MASK_2F2          (MASK_STEREO | (1 << CHANNEL_LS) | (1 << CHANNEL_RS))
+#define MASK_2F2_LFE      (MASK_2F2 | (1 << CHANNEL_LFE))
+#define MASK_3F2          (MASK_2F2 | (1 << CHANNEL_CENTER))
+#define MASK_3F2_LFE      (MASK_3F2 | (1 << CHANNEL_LFE))
+#define MASK_3F3R_LFE     (MASK_3F2_LFE | (1 << CHANNEL_RCENTER))
+#define MASK_3F4_LFE      (MASK_3F2_LFE | (1 << CHANNEL_RLS) | (1 << CHANNEL_RRS))
+
+cubeb_channel_layout
+cubeb_get_channel_layout_by_mask(uint32_t mask)
+{
+  switch(mask) {
+    case MASK_MONO: return CUBEB_LAYOUT_MONO;
+    case MASK_MONO_LFE: return CUBEB_LAYOUT_MONO_LFE;
+    case MASK_STEREO: return CUBEB_LAYOUT_STEREO;
+    case MASK_STEREO_LFE: return CUBEB_LAYOUT_STEREO_LFE;
+    case MASK_3F: return CUBEB_LAYOUT_3F;
+    case MASK_3F_LFE: return CUBEB_LAYOUT_3F_LFE;
+    case MASK_2F1: return CUBEB_LAYOUT_2F1;
+    case MASK_2F1_LFE: return CUBEB_LAYOUT_2F1_LFE;
+    case MASK_3F1: return CUBEB_LAYOUT_3F1;
+    case MASK_3F1_LFE: return CUBEB_LAYOUT_3F1_LFE;
+    case MASK_2F2: return CUBEB_LAYOUT_2F2;
+    case MASK_2F2_LFE: return CUBEB_LAYOUT_2F2_LFE;
+    case MASK_3F2: return CUBEB_LAYOUT_3F2;
+    case MASK_3F2_LFE: return CUBEB_LAYOUT_3F2_LFE;
+    case MASK_3F3R_LFE: return CUBEB_LAYOUT_3F3R_LFE;
+    case MASK_3F4_LFE: return CUBEB_LAYOUT_3F4_LFE;
+    default: return CUBEB_LAYOUT_UNDEFINED;
+  }
+}
+
+cubeb_channel
+channel_label_to_cubeb_channel(UInt32 label)
+{
+  switch (label) {
+    case kAudioChannelLabel_Mono: return CHANNEL_MONO;
+    case kAudioChannelLabel_Left: return CHANNEL_LEFT;
+    case kAudioChannelLabel_Right: return CHANNEL_RIGHT;
+    case kAudioChannelLabel_Center: return CHANNEL_CENTER;
+    case kAudioChannelLabel_LFEScreen: return CHANNEL_LFE;
+    case kAudioChannelLabel_LeftSurround: return CHANNEL_LS;
+    case kAudioChannelLabel_RightSurround: return CHANNEL_RS;
+    case kAudioChannelLabel_RearSurroundLeft: return CHANNEL_RLS;
+    case kAudioChannelLabel_RearSurroundRight: return CHANNEL_RRS;
+    case kAudioChannelLabel_CenterSurround: return CHANNEL_RCENTER;
+    default: return CHANNEL_INVALID;
+  }
+}
+// -----------------------------------------------------------------------------
 
 #if TARGET_OS_IPHONE
 typedef UInt32 AudioDeviceID;
@@ -955,6 +1024,22 @@ audiounit_get_preferred_sample_rate(cubeb * /* ctx */, uint32_t * rate)
 
   *rate = static_cast<uint32_t>(fsamplerate);
 #endif
+  return CUBEB_OK;
+}
+
+static int
+audiounit_get_preferred_channel_layout(cubeb * /* ctx */, cubeb_channel_layout * layout)
+{
+  // The preferred layout is only returned when the connected sound device
+  // (e.g. ASUS Xonar U7), has preferred layout setting.
+  // For default output on Mac, there is no preferred channel layout,
+  // so it might return UNDEFINED.
+  // In that case, we should get the channel configuration directly.
+  *layout = audiounit_get_channel_layout(true);
+  if (*layout == CUBEB_LAYOUT_UNDEFINED) {
+    *layout = audiounit_get_channel_layout(false);
+  }
+
   return CUBEB_OK;
 }
 
@@ -2528,13 +2613,74 @@ int audiounit_register_device_collection_changed(cubeb * context,
   return (ret == noErr) ? CUBEB_OK : CUBEB_ERROR;
 }
 
+static cubeb_channel_layout
+audiounit_get_channel_layout(bool preferred)
+{
+  OSStatus rv = noErr;
+
+  // Get the default ouput unit
+  AudioUnit output_unit;
+  audiounit_create_unit(&output_unit, false, nullptr, 0);
+
+  // Get the channel layout
+  UInt32 size = 0;
+  Boolean writable;
+  rv = AudioUnitGetPropertyInfo(output_unit,
+                                (preferred) ? kAudioDevicePropertyPreferredChannelLayout :
+                                              kAudioUnitProperty_AudioChannelLayout,
+                                kAudioUnitScope_Output,
+                                AU_OUT_BUS,
+                                &size,
+                                &writable);
+  if (rv != noErr) {
+    PRINT_ERROR_CODE("AudioUnitGetPropertyInfo/kAudioDevicePropertyPreferredChannelLayout||kAudioUnitProperty_AudioChannelLayout", rv);
+    return CUBEB_LAYOUT_UNDEFINED;
+  }
+  assert(size > 0);
+
+  AudioChannelLayout* layout = reinterpret_cast<AudioChannelLayout*>(malloc(size));
+  rv = AudioUnitGetProperty(output_unit,
+                            (preferred) ? kAudioDevicePropertyPreferredChannelLayout :
+                                          kAudioUnitProperty_AudioChannelLayout,
+                            kAudioUnitScope_Output,
+                            AU_OUT_BUS,
+                            layout,
+                            &size);
+  if (rv != noErr) {
+    PRINT_ERROR_CODE("AudioUnitGetProperty/kAudioDevicePropertyPreferredChannelLayout||kAudioUnitProperty_AudioChannelLayout", rv);
+    return CUBEB_LAYOUT_UNDEFINED;
+  }
+
+  if (layout->mChannelLayoutTag != kAudioChannelLayoutTag_UseChannelDescriptions) {
+    // kAudioChannelLayoutTag_UseChannelBitmap
+    // kAudioChannelLayoutTag_Mono
+    // kAudioChannelLayoutTag_Stereo
+    // ....
+    LOG("Only handle UseChannelDescriptions for now.\n");
+    return CUBEB_LAYOUT_UNDEFINED;
+  }
+
+  UInt32 mask = 0;
+  for (UInt32 i = 0; i < layout->mNumberChannelDescriptions; ++i) {
+    cubeb_channel channel =
+      channel_label_to_cubeb_channel(layout->mChannelDescriptions[i].mChannelLabel);
+    if (channel == CHANNEL_INVALID) {
+      return CUBEB_LAYOUT_UNDEFINED;
+    }
+    mask |= 1 << channel;
+  }
+
+  free(layout);
+  return cubeb_get_channel_layout_by_mask(mask);
+}
+
 cubeb_ops const audiounit_ops = {
   /*.init =*/ audiounit_init,
   /*.get_backend_id =*/ audiounit_get_backend_id,
   /*.get_max_channel_count =*/ audiounit_get_max_channel_count,
   /*.get_min_latency =*/ audiounit_get_min_latency,
   /*.get_preferred_sample_rate =*/ audiounit_get_preferred_sample_rate,
-  /*.get_preferred_channel_layout =*/ nullptr,
+  /*.get_preferred_channel_layout =*/ audiounit_get_preferred_channel_layout,
   /*.enumerate_devices =*/ audiounit_enumerate_devices,
   /*.destroy =*/ audiounit_destroy,
   /*.stream_init =*/ audiounit_stream_init,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1489,7 +1489,7 @@ audiounit_configure_output(cubeb_stream * stm)
                            &output_hw_desc,
                            &size);
   if (r != noErr) {
-    PRINT_ERROR_CODE("AudioUnitGetProperty/output/tkAudioUnitProperty_StreamFormat", r);
+    PRINT_ERROR_CODE("AudioUnitGetProperty/output/kAudioUnitProperty_StreamFormat", r);
     return CUBEB_ERROR;
   }
   stm->output_hw_rate = output_hw_desc.mSampleRate;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -41,6 +41,8 @@ typedef UInt32  AudioFormatFlags;
 #define AU_OUT_BUS    0
 #define AU_IN_BUS     1
 
+#define fieldOffset(type, field) ((size_t) &((type *) 0)->field)
+
 #define PRINT_ERROR_CODE(str, r) do {                           \
     LOG("System call failed: %s (rv: %d)", str, (int) r);       \
   } while(0)
@@ -1176,8 +1178,7 @@ audiounit_layout_init(AudioUnit * unit,
   // For those layouts that can't be matched to coreaudio's predefined layout,
   // we use customized layout.
   if (layout.get()->mChannelLayoutTag == kAudioChannelLayoutTag_Unknown) {
-    size_t size = sizeof(AudioChannelLayout) +
-                  sizeof(AudioChannelDescription) * (stream_params->channels - 1);
+    size_t size = fieldOffset(AudioChannelLayout, mChannelDescriptions[stream_params->channels]);
     layout.reset(size);
     layout.get()->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
     layout.get()->mNumberChannelDescriptions = stream_params->channels;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1067,6 +1067,10 @@ audiounit_get_preferred_channel_layout(cubeb * /* ctx */, cubeb_channel_layout *
     *layout = audiounit_get_channel_layout(false);
   }
 
+  if (*layout == CUBEB_LAYOUT_UNDEFINED) {
+    return CUBEB_ERROR;
+  }
+
   return CUBEB_OK;
 }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -129,6 +129,7 @@ private:
   {
     if (layout) {
       free(layout);
+      layout = NULL;
     }
   }
 

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -9,6 +9,55 @@
 #include "cubeb-internal.h"
 #include "cubeb_mixer.h"
 
+// DUAL_MONO(_LFE) is same as STEREO(_LFE).
+#define MASK_MONO         (1 << CHANNEL_MONO)
+#define MASK_MONO_LFE     (MASK_MONO | (1 << CHANNEL_LFE))
+#define MASK_STEREO       ((1 << CHANNEL_LEFT) | (1 << CHANNEL_RIGHT))
+#define MASK_STEREO_LFE   (MASK_STEREO | (1 << CHANNEL_LFE))
+#define MASK_3F           (MASK_STEREO | (1 << CHANNEL_CENTER))
+#define MASK_3F_LFE       (MASK_3F | (1 << CHANNEL_LFE))
+#define MASK_2F1          (MASK_STEREO | (1 << CHANNEL_RCENTER))
+#define MASK_2F1_LFE      (MASK_2F1 | (1 << CHANNEL_LFE))
+#define MASK_3F1          (MASK_3F | (1 << CHANNEL_RCENTER))
+#define MASK_3F1_LFE      (MASK_3F1 | (1 << CHANNEL_LFE))
+#define MASK_2F2          (MASK_STEREO | (1 << CHANNEL_LS) | (1 << CHANNEL_RS))
+#define MASK_2F2_LFE      (MASK_2F2 | (1 << CHANNEL_LFE))
+#define MASK_3F2          (MASK_2F2 | (1 << CHANNEL_CENTER))
+#define MASK_3F2_LFE      (MASK_3F2 | (1 << CHANNEL_LFE))
+#define MASK_3F3R_LFE     (MASK_3F2_LFE | (1 << CHANNEL_RCENTER))
+#define MASK_3F4_LFE      (MASK_3F2_LFE | (1 << CHANNEL_RLS) | (1 << CHANNEL_RRS))
+
+cubeb_channel_layout cubeb_channel_map_to_layout(cubeb_channel_map const * channel_map)
+{
+  uint32_t channel_mask = 0;
+  for (uint8_t i = 0 ; i < channel_map->channels ; ++i) {
+    if (channel_map->map[i] == CHANNEL_INVALID) {
+      return CUBEB_LAYOUT_UNDEFINED;
+    }
+    channel_mask |= 1 << channel_map->map[i];
+  }
+
+  switch(channel_mask) {
+    case MASK_MONO: return CUBEB_LAYOUT_MONO;
+    case MASK_MONO_LFE: return CUBEB_LAYOUT_MONO_LFE;
+    case MASK_STEREO: return CUBEB_LAYOUT_STEREO;
+    case MASK_STEREO_LFE: return CUBEB_LAYOUT_STEREO_LFE;
+    case MASK_3F: return CUBEB_LAYOUT_3F;
+    case MASK_3F_LFE: return CUBEB_LAYOUT_3F_LFE;
+    case MASK_2F1: return CUBEB_LAYOUT_2F1;
+    case MASK_2F1_LFE: return CUBEB_LAYOUT_2F1_LFE;
+    case MASK_3F1: return CUBEB_LAYOUT_3F1;
+    case MASK_3F1_LFE: return CUBEB_LAYOUT_3F1_LFE;
+    case MASK_2F2: return CUBEB_LAYOUT_2F2;
+    case MASK_2F2_LFE: return CUBEB_LAYOUT_2F2_LFE;
+    case MASK_3F2: return CUBEB_LAYOUT_3F2;
+    case MASK_3F2_LFE: return CUBEB_LAYOUT_3F2_LFE;
+    case MASK_3F3R_LFE: return CUBEB_LAYOUT_3F3R_LFE;
+    case MASK_3F4_LFE: return CUBEB_LAYOUT_3F4_LFE;
+    default: return CUBEB_LAYOUT_UNDEFINED;
+  }
+}
+
 cubeb_layout_map const CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
   { "undefined",      0,  CUBEB_LAYOUT_UNDEFINED },
   { "dual mono",      2,  CUBEB_LAYOUT_DUAL_MONO },

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -52,6 +52,13 @@ static cubeb_channel const CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX]
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RLS, CHANNEL_RRS, CHANNEL_LS, CHANNEL_RS }  // 3F4_LFE
 };
 
+typedef struct {
+  unsigned int channels;
+  cubeb_channel map[CHANNEL_MAX];
+} cubeb_channel_map;
+
+cubeb_channel_layout cubeb_channel_map_to_layout(cubeb_channel_map const * channel_map);
+
 bool cubeb_should_upmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);
 
 bool cubeb_should_downmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -525,55 +525,15 @@ layout_to_channel_map(cubeb_channel_layout layout, pa_channel_map * cm)
   }
 }
 
-// DUAL_MONO(_LFE) is same as STEREO(_LFE).
-#define MASK_MONO         (1 << CHANNEL_MONO)
-#define MASK_MONO_LFE     (MASK_MONO | (1 << CHANNEL_LFE))
-#define MASK_STEREO       ((1 << CHANNEL_LEFT) | (1 << CHANNEL_RIGHT))
-#define MASK_STEREO_LFE   (MASK_STEREO | (1 << CHANNEL_LFE))
-#define MASK_3F           (MASK_STEREO | (1 << CHANNEL_CENTER))
-#define MASK_3F_LFE       (MASK_3F | (1 << CHANNEL_LFE))
-#define MASK_2F1          (MASK_STEREO | (1 << CHANNEL_RCENTER))
-#define MASK_2F1_LFE      (MASK_2F1 | (1 << CHANNEL_LFE))
-#define MASK_3F1          (MASK_3F | (1 << CHANNEL_RCENTER))
-#define MASK_3F1_LFE      (MASK_3F1 | (1 << CHANNEL_LFE))
-#define MASK_2F2          (MASK_STEREO | (1 << CHANNEL_LS) | (1 << CHANNEL_RS))
-#define MASK_2F2_LFE      (MASK_2F2 | (1 << CHANNEL_LFE))
-#define MASK_3F2          (MASK_2F2 | (1 << CHANNEL_CENTER))
-#define MASK_3F2_LFE      (MASK_3F2 | (1 << CHANNEL_LFE))
-#define MASK_3F3R_LFE     (MASK_3F2_LFE | (1 << CHANNEL_RCENTER))
-#define MASK_3F4_LFE      (MASK_3F2_LFE | (1 << CHANNEL_RLS) | (1 << CHANNEL_RRS))
-
 static cubeb_channel_layout
 channel_map_to_layout(pa_channel_map * cm)
 {
-  uint32_t channel_mask = 0;
-  for (uint8_t i = 0 ; i < cm->channels ; ++i) {
-    cubeb_channel channel = pa_channel_to_cubeb_channel(cm->map[i]);
-    if (channel == CHANNEL_INVALID) {
-      return CUBEB_LAYOUT_UNDEFINED;
-    }
-    channel_mask |= 1 << channel;
+  cubeb_channel_map cubeb_map;
+  cubeb_map.channels = cm->channels;
+  for (uint32_t i = 0 ; i < cm->channels ; ++i) {
+    cubeb_map.map[i] = pa_channel_to_cubeb_channel(cm->map[i]);
   }
-
-  switch(channel_mask) {
-    case MASK_MONO: return CUBEB_LAYOUT_MONO;
-    case MASK_MONO_LFE: return CUBEB_LAYOUT_MONO_LFE;
-    case MASK_STEREO: return CUBEB_LAYOUT_STEREO;
-    case MASK_STEREO_LFE: return CUBEB_LAYOUT_STEREO_LFE;
-    case MASK_3F: return CUBEB_LAYOUT_3F;
-    case MASK_3F_LFE: return CUBEB_LAYOUT_3F_LFE;
-    case MASK_2F1: return CUBEB_LAYOUT_2F1;
-    case MASK_2F1_LFE: return CUBEB_LAYOUT_2F1_LFE;
-    case MASK_3F1: return CUBEB_LAYOUT_3F1;
-    case MASK_3F1_LFE: return CUBEB_LAYOUT_3F1_LFE;
-    case MASK_2F2: return CUBEB_LAYOUT_2F2;
-    case MASK_2F2_LFE: return CUBEB_LAYOUT_2F2_LFE;
-    case MASK_3F2: return CUBEB_LAYOUT_3F2;
-    case MASK_3F2_LFE: return CUBEB_LAYOUT_3F2_LFE;
-    case MASK_3F3R_LFE: return CUBEB_LAYOUT_3F3R_LFE;
-    case MASK_3F4_LFE: return CUBEB_LAYOUT_3F4_LFE;
-    default: return CUBEB_LAYOUT_UNDEFINED;
-  }
+  return cubeb_channel_map_to_layout(&cubeb_map);
 }
 
 static void pulse_context_destroy(cubeb * ctx);

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -27,6 +27,8 @@ TEST(cubeb, latency)
   }
 
   r = cubeb_get_preferred_channel_layout(ctx, &layout);
+  ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED ||
+              (r == CUBEB_ERROR && layout == CUBEB_LAYOUT_UNDEFINED));
 
   cubeb_stream_params params = {
     CUBEB_SAMPLE_FLOAT32NE,

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -27,7 +27,6 @@ TEST(cubeb, latency)
   }
 
   r = cubeb_get_preferred_channel_layout(ctx, &layout);
-  ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);
 
   cubeb_stream_params params = {
     CUBEB_SAMPLE_FLOAT32NE,


### PR DESCRIPTION
This is the implementation for audio 5.1 support on OS X. It only support the output side. If we also need to implement the input side, I'll add later.