### PR TITLE
Move jack_init below pulse_init in cubeb.c.

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -108,11 +108,11 @@ int
 cubeb_init(cubeb ** context, char const * context_name)
 {
   int (* init[])(cubeb **, char const *) = {
-#if defined(USE_JACK)
-    jack_init,
-#endif
 #if defined(USE_PULSE)
     pulse_init,
+#endif
+#if defined(USE_JACK)
+    jack_init,
 #endif
 #if defined(USE_ALSA)
     alsa_init,


### PR DESCRIPTION
Gecko only officially supports the PulseAudio backend, so it makes sense to
prefer that over JACK and ALSA, which are supported by contributors.

This is a partial fix for issues like [BMO #1331526](https://bugzilla.mozilla.org/show_bug.cgi?id=1331526).  A better long term fix
would allow overriding the backend selection with requests for a specific
backend.