### PR TITLE
Fix erroneous usage of PTHREAD_MUTEX_INITIALIZER

### DIFF
--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -245,7 +245,7 @@ sndio_stream_init(cubeb * context,
   s->data_cb = data_callback;
   s->state_cb = state_callback;
   s->arg = user_ptr;
-  s->mtx = PTHREAD_MUTEX_INITIALIZER;
+  s->mtx = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
   s->rdpos = s->wrpos = 0;
   if (output_stream_params->format == CUBEB_SAMPLE_FLOAT32LE) {
     s->conv = 1;


### PR DESCRIPTION
(see: http://stackoverflow.com/questions/17864095/c-pthread-mutex-expected-expression-before)
I got the following error on my Debian testing box:

In file included from /home/ace/projects/cubeb/src/cubeb_sndio.c:9:0:
/home/ace/projects/cubeb/src/cubeb_sndio.c: In function ‘sndio_stream_init’:
/home/ace/projects/cubeb/src/cubeb_sndio.c:248:12: error: expected expression before ‘{’ token
   s->mtx = PTHREAD_MUTEX_INITIALIZER;
            ^
CMakeFiles/cubeb.dir/build.make:230: recipe for target 'CMakeFiles/cubeb.dir/src/cubeb_sndio.c.o' failed
