### PR TITLE
Audiounit drift with c920 webcam (Bug 1329190)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -54,6 +54,11 @@ const char * DISPATCH_QUEUE_LABEL = "org.mozilla.cubeb";
 #endif
 #define ALOGV(msg, ...) dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{LOGV(msg, ##__VA_ARGS__);})
 
+#ifdef ALOG
+#undef ALOG
+#endif
+#define ALOG(msg, ...) dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{LOG(msg, ##__VA_ARGS__);})
+
 /* Testing empirically, some headsets report a minimal latency that is very
  * low, but this does not work in practice. Lie and say the minimum is 256
  * frames. */
@@ -490,17 +495,17 @@ audiounit_output_callback(void * user_ptr,
   stm->output_callback_in_a_row++;
 
   ALOGV("(%p) output: buffers %u, size %u, channels %u, frames %u.",
-       stm,
-       (unsigned int) outBufferList->mNumberBuffers,
-       (unsigned int) outBufferList->mBuffers[0].mDataByteSize,
-       (unsigned int) outBufferList->mBuffers[0].mNumberChannels,
-       (unsigned int) output_frames);
+        stm,
+        (unsigned int) outBufferList->mNumberBuffers,
+        (unsigned int) outBufferList->mBuffers[0].mDataByteSize,
+        (unsigned int) outBufferList->mBuffers[0].mNumberChannels,
+        (unsigned int) output_frames);
 
   long input_frames = 0;
   void * output_buffer = NULL, * input_buffer = NULL;
 
   if (stm->shutdown) {
-    LOG("(%p) output shutdown.", stm);
+    ALOG("(%p) output shutdown.", stm);
     audiounit_make_silent(&outBufferList->mBuffers[0]);
     return noErr;
   }
@@ -524,8 +529,8 @@ audiounit_output_callback(void * user_ptr,
     if (is_extra_input_needed(stm)) {
       uint32_t min_input_frames = min_input_frames_required(stm);
       stm->input_linear_buffer->push_silence(min_input_frames * stm->input_desc.mChannelsPerFrame);
-      LOG("(%p) %s pushed %u frames of input silence.", stm, stm->frames_read == 0 ? "Input hasn't started," :
-          stm->switching_device ? "Device switching," : "Drop out,", min_input_frames);
+      ALOG("(%p) %s pushed %u frames of input silence.", stm, stm->frames_read == 0 ? "Input hasn't started," :
+           stm->switching_device ? "Device switching," : "Drop out,", min_input_frames);
     }
     // The input buffer
     input_buffer = stm->input_linear_buffer->data();

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -49,6 +49,11 @@ typedef UInt32  AudioFormatFlags;
 
 const char * DISPATCH_QUEUE_LABEL = "org.mozilla.cubeb";
 
+#ifdef ALOGV
+#undef ALOGV
+#endif
+#define ALOGV(msg, ...) dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{LOGV(msg, ##__VA_ARGS__);})
+
 /* Testing empirically, some headsets report a minimal latency that is very
  * low, but this does not work in practice. Lie and say the minimum is 256
  * frames. */

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -898,6 +898,16 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
     if (r != noErr) {
       return CUBEB_ERROR;
     }
+
+    /* Event to notify when the input is going away. */
+    AudioDeviceID dev = stm->input_device ? stm->input_device :
+                        audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_INPUT);
+    r = audiounit_remove_listener(stm, dev, kAudioDevicePropertyDeviceIsAlive,
+                                  kAudioObjectPropertyScopeGlobal, &audiounit_property_listener_callback);
+    if (r != noErr) {
+      PRINT_ERROR_CODE("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDeviceIsAlive", r);
+      return CUBEB_ERROR;
+    }
   }
   return CUBEB_OK;
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -416,7 +416,7 @@ audiounit_input_callback(void * user_ptr,
   assert(AU_IN_BUS == bus);
 
   if (stm->shutdown) {
-    LOG("(%p) input shutdown", stm);
+    ALOG("(%p) input shutdown", stm);
     return noErr;
   }
 
@@ -722,6 +722,9 @@ audiounit_property_listener_callback(AudioObjectID /* id */, UInt32 address_coun
       case kAudioDevicePropertyDataSource:
         LOG("Event[%u] - mSelector == kAudioHardwarePropertyDataSource", (unsigned int) i);
         break;
+      default:
+        LOG("Event[%u] - mSelector == Unexpected Event id %d, return", (unsigned int) i, addresses[i].mSelector);
+        return noErr;
     }
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -237,7 +237,7 @@ struct cubeb_stream {
   std::atomic<uint64_t> frames_played{ 0 };
   uint64_t frames_queued = 0;
   std::atomic<int64_t> frames_read{ 0 };
-  std::atomic<bool> shutdown{ false };
+  std::atomic<bool> shutdown{ true };
   std::atomic<bool> draining{ false };
   /* Latency requested by the user. */
   uint32_t latency_frames = 0;

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -179,7 +179,7 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   /* process the input, and present exactly `output_frames_needed` in the
   * callback. */
   input_processor->input(input_buffer, *input_frames_count);
-  resampled_input = input_processor->output(resampled_frame_count);
+  resampled_input = input_processor->output(resampled_frame_count, (size_t*)input_frames_count);
 
   long got = data_callback(stream, user_ptr,
                            resampled_input, nullptr, resampled_frame_count);
@@ -226,7 +226,7 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
     * callback. */
     input_processor->input(in_buffer, *input_frames_count);
     resampled_input =
-      input_processor->output(output_frames_before_processing);
+      input_processor->output(output_frames_before_processing, (size_t*)input_frames_count);
   } else {
     resampled_input = nullptr;
   }

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -238,8 +238,8 @@ public:
 
     /* This shifts back any unresampled samples to the beginning of the input
        buffer. */
+    resampling_in_buffer.pop(nullptr, frames_to_samples(in_len));
     *input_frames_used = in_len;
-    resampling_in_buffer.clear();
 
     return resampling_out_buffer.data();
   }

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -222,7 +222,7 @@ public:
 
   /** Returns a buffer containing exactly `output_frame_count` resampled frames.
     * The consumer should not hold onto the pointer. */
-  T * output(size_t output_frame_count)
+  T * output(size_t output_frame_count, size_t * input_frames_used)
   {
     if (resampling_out_buffer.capacity() < frames_to_samples(output_frame_count)) {
       resampling_out_buffer.reserve(frames_to_samples(output_frame_count));
@@ -238,7 +238,8 @@ public:
 
     /* This shifts back any unresampled samples to the beginning of the input
        buffer. */
-    resampling_in_buffer.pop(nullptr, frames_to_samples(in_len));
+    *input_frames_used = in_len;
+    resampling_in_buffer.clear();
 
     return resampling_out_buffer.data();
   }
@@ -376,7 +377,7 @@ public:
    * @parameter frames_needed the number of frames to be returned.
    * @return a buffer containing the delayed frames. The consumer should not
    * hold onto the pointer. */
-  T * output(uint32_t frames_needed)
+  T * output(uint32_t frames_needed, size_t * input_frames_used)
   {
     if (delay_output_buffer.capacity() < frames_to_samples(frames_needed)) {
       delay_output_buffer.reserve(frames_to_samples(frames_needed));
@@ -386,6 +387,7 @@ public:
     delay_output_buffer.push(delay_input_buffer.data(),
                              frames_to_samples(frames_needed));
     delay_input_buffer.pop(nullptr, frames_to_samples(frames_needed));
+    *input_frames_used = frames_needed;
 
     return delay_output_buffer.data();
   }


### PR DESCRIPTION
This patch is solving a build up latency when c920 webcam is used as external audio input. The problem occurs after some time (~10 mins) by getting extra output callbacks, consequently, extra silence in pushed in the input that creates the delay. In order to solve that I did the followings:
- Change the resampler not to store any remaining input frame, instead, return the number of the used frames. 
- Change audiounit backend to save the remaining input and use them in the following cycles. Moreover extra silence is pushed, if only the input is not enough and not when there are more output callbacks than expected. This does not allow the latency to grow.

Finally, in order to study the case I created and used 2 convenient log macros for normal and verbose async logging. This can be done easily with dispatch queues.

On going try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=4aa24728339713ed18b2ef07881bcbb8d124ae0b