### PR TITLE
Allow using a different release assert function in cubeb.

### DIFF
--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -9,6 +9,7 @@
 
 #include "cubeb/cubeb.h"
 #include "cubeb_log.h"
+#include "cubeb_assert.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -27,9 +28,6 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif
-
-/* Crash the caller.  */
-void cubeb_crash() CLANG_ANALYZER_NORETURN;
 
 #if defined(__cplusplus)
 }
@@ -84,12 +82,5 @@ struct cubeb_ops {
                                              cubeb_device_collection_changed_callback callback,
                                              void * user_ptr);
 };
-
-#define XASSERT(expr) do {                                                     \
-    if (!(expr)) {                                                             \
-      fprintf(stderr, "%s:%d - fatal error: %s\n", __FILE__, __LINE__, #expr); \
-      cubeb_crash();                                                           \
-    }                                                                          \
-  } while (0)
 
 #endif /* CUBEB_INTERNAL_0eb56756_4e20_4404_a76d_42bf88cd15a5 */

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -570,9 +570,3 @@ int cubeb_set_log_callback(cubeb_log_level log_level,
   return CUBEB_OK;
 }
 
-void
-cubeb_crash()
-{
-  abort();
-  *((volatile int *) NULL) = 0;
-}

--- a/src/cubeb_assert.h
+++ b/src/cubeb_assert.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#ifndef CUBEB_ASSERT
+#define CUBEB_ASSERT
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * This allow using an external release assert method. This file should only
+ * export a function or macro called XASSERT that aborts the program.
+ */
+
+#define XASSERT(expr) do {                                                     \
+    if (!(expr)) {                                                             \
+      fprintf(stderr, "%s:%d - fatal error: %s\n", __FILE__, __LINE__, #expr); \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#endif


### PR DESCRIPTION
See [bug 1332937](https://bugzilla.mozilla.org/show_bug.cgi?id=1332937), where the crash reporter is not called.

This allow using `MOZILLA_RELEASE_ASSERT` or something like that, and integrate with the crash reporter.

@kinetiknz, do you remember why we have both a null-dereference AND a call to `abort` in `cubeb_crash` ?