### PR TITLE
Allow buffering some input when using a noop resampler, and rename it because it's not strictly no-op anymore

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -35,29 +35,54 @@ to_speex_quality(cubeb_resampler_quality q)
   }
 }
 
-long noop_resampler::fill(void * input_buffer, long * input_frames_count,
-                          void * output_buffer, long output_frames)
+template<typename T>
+passthrough_resampler<T>::passthrough_resampler(cubeb_stream * s,
+                                                cubeb_data_callback cb,
+                                                void * ptr,
+                                                uint32_t input_channels)
+  : processor(input_channels)
+  , stream(s)
+  , data_callback(cb)
+  , user_ptr(ptr)
+{
+}
+
+template<typename T>
+long passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_count,
+                                    void * output_buffer, long output_frames)
 {
   if (input_buffer) {
     assert(input_frames_count);
   }
   assert((input_buffer && output_buffer &&
-         *input_frames_count >= output_frames) ||
+         *input_frames_count + static_cast<int>(samples_to_frames(internal_input_buffer.length())) >= output_frames) ||
          (!input_buffer && (!input_frames_count || *input_frames_count == 0)) ||
          (!output_buffer && output_frames == 0));
+
+  long rv;
 
   if (output_buffer == nullptr) {
     assert(input_buffer);
     output_frames = *input_frames_count;
   }
 
-  if (input_buffer && *input_frames_count != output_frames) {
-    assert(*input_frames_count > output_frames);
-    *input_frames_count = output_frames;
+
+  if (input_buffer) {
+    internal_input_buffer.push(static_cast<T*>(input_buffer),
+                               frames_to_samples(*input_frames_count));
+    assert(samples_to_frames(internal_input_buffer.length()) >=
+           static_cast<uint32_t>(output_frames));
   }
 
-  return data_callback(stream, user_ptr,
-                       input_buffer, output_buffer, output_frames);
+  rv = data_callback(stream, user_ptr, internal_input_buffer.data(),
+                     output_buffer, output_frames);
+
+  if (input_buffer) {
+    internal_input_buffer.pop(nullptr, frames_to_samples(output_frames));
+    printf("remaining frames in noop: %lu\n", samples_to_frames(internal_input_buffer.length()));
+  }
+
+  return rv;
 }
 
 template<typename T, typename InputProcessor, typename OutputProcessor>

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -56,30 +56,22 @@ long passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_cou
   }
   assert((input_buffer && output_buffer &&
          *input_frames_count + static_cast<int>(samples_to_frames(internal_input_buffer.length())) >= output_frames) ||
-         (!input_buffer && (!input_frames_count || *input_frames_count == 0)) ||
-         (!output_buffer && output_frames == 0));
-
-  long rv;
-
-  if (output_buffer == nullptr) {
-    assert(input_buffer);
-    output_frames = *input_frames_count;
-  }
-
+         (output_buffer && !input_buffer && (!input_frames_count || *input_frames_count == 0)) ||
+         (input_buffer && !output_buffer && output_frames == 0));
 
   if (input_buffer) {
+    if (!output_buffer) {
+      output_frames = *input_frames_count;
+    }
     internal_input_buffer.push(static_cast<T*>(input_buffer),
                                frames_to_samples(*input_frames_count));
-    assert(samples_to_frames(internal_input_buffer.length()) >=
-           static_cast<uint32_t>(output_frames));
   }
 
-  rv = data_callback(stream, user_ptr, internal_input_buffer.data(),
-                     output_buffer, output_frames);
+  long rv = data_callback(stream, user_ptr, internal_input_buffer.data(),
+                          output_buffer, output_frames);
 
   if (input_buffer) {
     internal_input_buffer.pop(nullptr, frames_to_samples(output_frames));
-    printf("remaining frames in noop: %lu\n", samples_to_frames(internal_input_buffer.length()));
   }
 
   return rv;

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -13,6 +13,13 @@
 #include <algorithm>
 #include <iostream>
 
+template<typename T, size_t N>
+constexpr size_t
+ARRAY_LENGTH(T(&)[N])
+{
+  return N;
+}
+
 /* Windows cmath USE_MATH_DEFINE thing... */
 const float PI = 3.14159265359f;
 
@@ -391,8 +398,11 @@ void test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
   dump("input.raw", state.input.data(), state.input.length());
   dump("output.raw", state.output.data(), state.output.length());
 
-  ASSERT_TRUE(array_fuzzy_equal(state.input, expected_resampled_input, epsilon<T>(input_rate/target_rate)));
-  ASSERT_TRUE(array_fuzzy_equal(state.output, expected_resampled_output, epsilon<T>(output_rate/target_rate)));
+ // This is disabled because the latency estimation in the resampler code is
+ // slightly off so we can generate expected vectors.
+ // See https://github.com/kinetiknz/cubeb/issues/93
+ // ASSERT_TRUE(array_fuzzy_equal(state.input, expected_resampled_input, epsilon<T>(input_rate/target_rate)));
+ // ASSERT_TRUE(array_fuzzy_equal(state.output, expected_resampled_output, epsilon<T>(output_rate/target_rate)));
 
   cubeb_resampler_destroy(resampler);
 }
@@ -416,9 +426,6 @@ TEST(cubeb, resampler_one_way)
   }
 }
 
-// This is disabled because the latency estimation in the resampler code is
-// slightly off so we can generate expected vectors.
-// See https://github.com/kinetiknz/cubeb/issues/93
 TEST(cubeb, DISABLED_resampler_duplex)
 {
   for (uint32_t input_channels = 1; input_channels <= max_channels; input_channels++) {
@@ -536,3 +543,196 @@ TEST(cubeb, resampler_drain)
   cubeb_resampler_destroy(resampler);
 }
 
+// gtest does not support using ASSERT_EQ and friend in a function that returns
+// a value.
+void check_output(const void * input_buffer, void * output_buffer, long frame_count)
+{
+  ASSERT_EQ(input_buffer, nullptr);
+  ASSERT_EQ(frame_count, 256);
+  ASSERT_TRUE(!!output_buffer);
+}
+
+long cb_noop_resampler_output(cubeb_stream * /*stm*/, void * /*user_ptr*/,
+                              const void * input_buffer,
+                              void * output_buffer, long frame_count)
+{
+  check_output(input_buffer, output_buffer, frame_count);
+  return frame_count;
+}
+
+TEST(cubeb, resampler_noop_output_only)
+{
+  // Test that the noop resampler works when there is only an output stream.
+  cubeb_stream_params output_params;
+
+  output_params.channels = 2;
+  output_params.rate = 44100;
+  output_params.format = CUBEB_SAMPLE_FLOAT32NE;
+  int target_rate = output_params.rate;
+
+  cubeb_resampler * resampler =
+    cubeb_resampler_create((cubeb_stream*)nullptr, nullptr, &output_params,
+                           target_rate, cb_noop_resampler_output, nullptr,
+                           CUBEB_RESAMPLER_QUALITY_VOIP);
+
+  float output_buffer[output_params.channels * 256];
+
+  long got;
+  for (uint32_t i = 0; i < 30; i++) {
+    got = cubeb_resampler_fill(resampler, nullptr, nullptr, output_buffer, 256);
+    ASSERT_EQ(got, 256);
+  }
+}
+
+// gtest does not support using ASSERT_EQ and friend in a function that returns
+// a value.
+void check_input(const void * input_buffer, void * output_buffer, long frame_count)
+{
+  ASSERT_EQ(output_buffer, nullptr);
+  ASSERT_EQ(frame_count, 256);
+  ASSERT_TRUE(!!input_buffer);
+}
+
+long cb_noop_resampler_input(cubeb_stream * /*stm*/, void * /*user_ptr*/,
+                             const void * input_buffer,
+                             void * output_buffer, long frame_count)
+{
+  check_input(input_buffer, output_buffer, frame_count);
+  return frame_count;
+}
+
+TEST(cubeb, resampler_noop_input_only)
+{
+  // Test that the noop resampler works when there is only an output stream.
+  cubeb_stream_params input_params;
+
+  input_params.channels = 2;
+  input_params.rate = 44100;
+  input_params.format = CUBEB_SAMPLE_FLOAT32NE;
+  int target_rate = input_params.rate;
+
+  cubeb_resampler * resampler =
+    cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, nullptr,
+                           target_rate, cb_noop_resampler_input, nullptr,
+                           CUBEB_RESAMPLER_QUALITY_VOIP);
+
+  float input_buffer[input_params.channels * 256];
+
+  long got;
+  for (uint32_t i = 0; i < 30; i++) {
+    long int frames = 256;
+    got = cubeb_resampler_fill(resampler, input_buffer, &frames, nullptr, 0);
+    ASSERT_EQ(got, 256);
+  }
+}
+
+template<typename T>
+long seq(T* array, long start, long count)
+{
+  for(int i = 0; i < count; i++) {
+    array[i] = static_cast<T>(start + i);
+  }
+  return start + count;
+}
+
+template<typename T>
+void is_seq(T * array, int stride, long count, long expected_start)
+{
+  for (long i = 0; i < count * stride; i+=stride) {
+    for (int j = stride; j < stride; j++) {
+      ASSERT_EQ(array[i + j], expected_start + count);
+    }
+  }
+}
+
+// gtest does not support using ASSERT_EQ and friend in a function that returns
+// a value.
+template<typename T>
+void check_duplex(const T * input_buffer,
+                  T * output_buffer, long frame_count)
+{
+  ASSERT_EQ(frame_count, 256);
+  ASSERT_TRUE(!!output_buffer);
+  ASSERT_TRUE(!!input_buffer);
+
+  for (int i = 0; i < frame_count; i++) {
+    // output is two channels, input is one channel, we upmix.
+    output_buffer[i] = output_buffer[i+1] = input_buffer[i];
+  }
+}
+
+long cb_noop_resampler_duplex(cubeb_stream * /*stm*/, void * /*user_ptr*/,
+                              const void * input_buffer,
+                              void * output_buffer, long frame_count)
+{
+  check_duplex<float>(static_cast<const float*>(input_buffer), static_cast<float*>(output_buffer), frame_count);
+  return frame_count;
+}
+
+
+TEST(cubeb, resampler_noop_duplex_callback_reordering)
+{
+  // Test that when pre-buffering on resampler creation, we can survive an input
+  // callback being delayed.
+
+  cubeb_stream_params input_params;
+  cubeb_stream_params output_params;
+
+  const int input_channels = 1;
+  const int output_channels = 1;
+
+  input_params.channels = input_channels;
+  input_params.rate = 44100;
+  input_params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  output_params.channels = output_channels;
+  output_params.rate = input_params.rate;
+  output_params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  int target_rate = input_params.rate;
+
+  cubeb_resampler * resampler =
+    cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, &output_params,
+                           target_rate, cb_noop_resampler_duplex, nullptr,
+                           CUBEB_RESAMPLER_QUALITY_VOIP);
+
+  const long BUF_BASE_SIZE = 256;
+  float input_buffer_prebuffer[input_channels * BUF_BASE_SIZE * 2];
+  float input_buffer_normal[input_channels * BUF_BASE_SIZE];
+  float output_buffer[output_channels * BUF_BASE_SIZE];
+
+  long got;
+  long seq_idx = 0;
+
+  long prebuffer_frames = ARRAY_LENGTH(input_buffer_prebuffer) / input_params.channels;
+  seq_idx = seq(input_buffer_prebuffer, seq_idx,
+                prebuffer_frames);
+
+  got = cubeb_resampler_fill(resampler, input_buffer_prebuffer, &prebuffer_frames,
+                             output_buffer, BUF_BASE_SIZE);
+
+  ASSERT_EQ(prebuffer_frames, static_cast<long>(ARRAY_LENGTH(input_buffer_prebuffer) / input_params.channels));
+  ASSERT_EQ(got, BUF_BASE_SIZE);
+
+  for (uint32_t i = 0; i < 300; i++) {
+    long int frames = BUF_BASE_SIZE;
+    // Simulate that sometimes, we don't have the input callback on time
+    if (i != 0 && (i % 100) == 0) {
+      long zero = 0;
+      got = cubeb_resampler_fill(resampler, input_buffer_normal /* unused here */,
+                                 &zero, output_buffer, BUF_BASE_SIZE);
+    } else if (i != 0 && (i % 100) == 1) {
+      // if this is the case, the on the next iteration, we'll have twice the
+      // amount of input frames
+      seq_idx = seq(input_buffer_prebuffer, seq_idx, BUF_BASE_SIZE * 2);
+      frames = 2 * BUF_BASE_SIZE;
+      got = cubeb_resampler_fill(resampler, input_buffer_prebuffer, &frames, output_buffer, BUF_BASE_SIZE);
+    } else {
+       // normal case
+      seq_idx = seq(input_buffer_normal, seq_idx, BUF_BASE_SIZE);
+      long normal_input_frame_count = 256;
+      got = cubeb_resampler_fill(resampler, input_buffer_normal, &normal_input_frame_count, output_buffer, BUF_BASE_SIZE);
+    }
+    ASSERT_EQ(got, BUF_BASE_SIZE);
+  }
+}

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -618,7 +618,7 @@ TEST(cubeb, resampler_noop_input_only)
                            target_rate, cb_noop_resampler_input, nullptr,
                            CUBEB_RESAMPLER_QUALITY_VOIP);
 
-  float input_buffer[input_params.channels * 256];
+  float input_buffer[input_channels * 256];
 
   long got;
   for (uint32_t i = 0; i < 30; i++) {
@@ -705,6 +705,7 @@ TEST(cubeb, resampler_noop_duplex_callback_reordering)
 
   long got;
   long seq_idx = 0;
+  long output_seq_idx = 0;
 
   long prebuffer_frames = ARRAY_LENGTH(input_buffer_prebuffer) / input_params.channels;
   seq_idx = seq(input_buffer_prebuffer, seq_idx,
@@ -734,6 +735,8 @@ TEST(cubeb, resampler_noop_duplex_callback_reordering)
       seq_idx = seq(input_buffer_normal, seq_idx, BUF_BASE_SIZE);
       long normal_input_frame_count = 256;
       got = cubeb_resampler_fill(resampler, input_buffer_normal, &normal_input_frame_count, output_buffer, BUF_BASE_SIZE);
+      is_seq(output_buffer, 2, BUF_BASE_SIZE, output_seq_idx);
+      output_seq_idx += BUF_BASE_SIZE;
     }
     ASSERT_EQ(got, BUF_BASE_SIZE);
   }

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -565,7 +565,8 @@ TEST(cubeb, resampler_noop_output_only)
   // Test that the noop resampler works when there is only an output stream.
   cubeb_stream_params output_params;
 
-  output_params.channels = 2;
+  const size_t output_channels = 2;
+  output_params.channels = output_channels;
   output_params.rate = 44100;
   output_params.format = CUBEB_SAMPLE_FLOAT32NE;
   int target_rate = output_params.rate;
@@ -575,7 +576,7 @@ TEST(cubeb, resampler_noop_output_only)
                            target_rate, cb_noop_resampler_output, nullptr,
                            CUBEB_RESAMPLER_QUALITY_VOIP);
 
-  float output_buffer[output_params.channels * 256];
+  float output_buffer[output_channels * 256];
 
   long got;
   for (uint32_t i = 0; i < 30; i++) {
@@ -606,7 +607,8 @@ TEST(cubeb, resampler_noop_input_only)
   // Test that the noop resampler works when there is only an output stream.
   cubeb_stream_params input_params;
 
-  input_params.channels = 2;
+  const size_t input_channels = 2;
+  input_params.channels = input_channels;
   input_params.rate = 44100;
   input_params.format = CUBEB_SAMPLE_FLOAT32NE;
   int target_rate = input_params.rate;

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -658,8 +658,9 @@ void check_duplex(const T * input_buffer,
                   T * output_buffer, long frame_count)
 {
   ASSERT_EQ(frame_count, 256);
-  ASSERT_TRUE(!!output_buffer);
-  ASSERT_TRUE(!!input_buffer);
+  // Silence scan-build warning.
+  ASSERT_TRUE(!!output_buffer); assert(output_buffer);
+  ASSERT_TRUE(!!input_buffer); assert(input_buffer);
 
   int output_index = 0;
   for (int i = 0; i < frame_count; i++) {


### PR DESCRIPTION
@achronop and I have witnessed a number of scenarios where sometimes, instead of getting an input callback before the output callback, we have no input data when we want to render, and then right after, we get an input callback with double the amount of frames. This happens on OSX and Windows. 

Because we delay the input side by a few buffers, this works fine when resampling happens. When using a no-op resampler, because we simply forward the call to the user callback, data getting lost.

This adds a buffer in the no-op path (renamed for the occasion), and handles this case, adjusting the assert. Also, a number of tests that would have caught this are added, and another test case that simulates the scenario described above has been added.