### PR TITLE
Drop support for Windows versions lower than 7 (XP SP2 and Vista)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if(USE_WASAPI)
   target_sources(cubeb PRIVATE
     src/cubeb_wasapi.cpp)
   target_compile_definitions(cubeb PRIVATE USE_WASAPI)
+  target_link_libraries(cubeb PRIVATE avrt)
 endif()
 
 check_include_files("windows.h;mmsystem.h" USE_WINMM)

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -4,11 +4,7 @@
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
  */
-// Explicitly define NTDDI_VERSION rather than letting the value be derived
-// from _WIN32_WINNT because we depend on values defined for XP SP2 and WS03
-// SP1.
-#define _WIN32_WINNT 0x0502
-#define NTDDI_VERSION 0x05020100
+#define _WIN32_WINNT 0x0600
 #define NOMINMAX
 
 #include <initguid.h>

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -164,10 +164,6 @@ private:
   HRESULT result;
 };
 
-typedef HANDLE (WINAPI *set_mm_thread_characteristics_function)(
-                                      const char * TaskName, LPDWORD TaskIndex);
-typedef BOOL (WINAPI *revert_mm_thread_characteristics_function)(HANDLE handle);
-
 extern cubeb_ops const wasapi_ops;
 
 int wasapi_stream_stop(cubeb_stream * stm);
@@ -181,11 +177,6 @@ static std::unique_ptr<wchar_t const []> utf8_to_wstr(char const * str);
 
 struct cubeb {
   cubeb_ops const * ops = &wasapi_ops;
-  /* Library dynamically opened to increase the render thread priority, and
-     the two function pointers we need. */
-  HMODULE mmcss_module = nullptr;
-  set_mm_thread_characteristics_function set_mm_thread_characteristics = nullptr;
-  revert_mm_thread_characteristics_function revert_mm_thread_characteristics = nullptr;
 };
 
 class wasapi_endpoint_notification_client;
@@ -864,8 +855,7 @@ wasapi_stream_render_loop(LPVOID stream)
 
   /* We could consider using "Pro Audio" here for WebAudio and
      maybe WebRTC. */
-  mmcss_handle =
-    stm->context->set_mm_thread_characteristics("Audio", &mmcss_task_index);
+  mmcss_handle = AvSetMmThreadCharacteristicsA("Audio", &mmcss_task_index);
   if (!mmcss_handle) {
     /* This is not fatal, but we might glitch under heavy load. */
     LOG("Unable to use mmcss to bump the render thread priority: %lx", GetLastError());
@@ -967,23 +957,13 @@ wasapi_stream_render_loop(LPVOID stream)
   }
 
   if (mmcss_handle) {
-    stm->context->revert_mm_thread_characteristics(mmcss_handle);
+    AvRevertMmThreadCharacteristics(mmcss_handle);
   }
 
   return 0;
 }
 
 void wasapi_destroy(cubeb * context);
-
-HANDLE WINAPI set_mm_thread_characteristics_noop(const char *, LPDWORD mmcss_task_index)
-{
-  return (HANDLE)1;
-}
-
-BOOL WINAPI revert_mm_thread_characteristics_noop(HANDLE mmcss_handle)
-{
-  return true;
-}
 
 HRESULT register_notification_client(cubeb_stream * stm)
 {
@@ -1162,27 +1142,6 @@ int wasapi_init(cubeb ** context, char const * context_name)
 
   ctx->ops = &wasapi_ops;
 
-  ctx->mmcss_module = LoadLibraryA("Avrt.dll");
-
-  if (ctx->mmcss_module) {
-    ctx->set_mm_thread_characteristics =
-      (set_mm_thread_characteristics_function) GetProcAddress(
-          ctx->mmcss_module, "AvSetMmThreadCharacteristicsA");
-    ctx->revert_mm_thread_characteristics =
-      (revert_mm_thread_characteristics_function) GetProcAddress(
-          ctx->mmcss_module, "AvRevertMmThreadCharacteristics");
-    if (!(ctx->set_mm_thread_characteristics && ctx->revert_mm_thread_characteristics)) {
-      LOG("Could not load AvSetMmThreadCharacteristics or AvRevertMmThreadCharacteristics: %lx", GetLastError());
-      FreeLibrary(ctx->mmcss_module);
-    }
-  } else {
-    // This is not a fatal error, but we might end up glitching when
-    // the system is under high load.
-    LOG("Could not load Avrt.dll");
-    ctx->set_mm_thread_characteristics = &set_mm_thread_characteristics_noop;
-    ctx->revert_mm_thread_characteristics = &revert_mm_thread_characteristics_noop;
-  }
-
   *context = ctx;
 
   return CUBEB_OK;
@@ -1239,9 +1198,6 @@ bool stop_and_join_render_thread(cubeb_stream * stm)
 
 void wasapi_destroy(cubeb * context)
 {
-  if (context->mmcss_module) {
-    FreeLibrary(context->mmcss_module);
-  }
   delete context;
 }
 


### PR DESCRIPTION
Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1130266 is in effect, we no longer need to support XP SP2 and Vista.