### PR TITLE
Downmix audio on OSX

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -197,12 +197,12 @@ struct mixing_wrapper {
 template <typename T>
 struct mixing_impl : public mixing_wrapper {
 
-  using downmix_func_ptr = void (*)(T * const, long, T *,
-                                    unsigned int, unsigned int,
-                                    cubeb_channel_layout, cubeb_channel_layout);
+  typedef std::function<void(T * const, long, T *,
+                             unsigned int, unsigned int,
+                             cubeb_channel_layout, cubeb_channel_layout)> downmix_func;
 
-  mixing_impl(downmix_func_ptr dfptr) {
-    downmix_wrapper = dfptr;
+  mixing_impl(downmix_func dmfunc) {
+    downmix_wrapper = dmfunc;
   }
 
   ~mixing_impl() {}
@@ -215,14 +215,11 @@ struct mixing_impl : public mixing_wrapper {
     T* out = static_cast<T *>(output_buffer);
     // By using same buffer for downmixing input and output, we allow downmixing
     // from 5.0/1 to 1.0/1, 2.0/1/2, 3.0/1, 4.0/1. Do nothing on other cases.
-    (*downmix_wrapper)(out, output_frames, out,
-                       output_channels, using_channels,
-                       output_layout, mixing_layout);
+    downmix_wrapper(out, output_frames, out, output_channels, using_channels,
+                    output_layout, mixing_layout);
   }
 
-  /* Function pointer for downmixing and remapping */
-  void (*downmix_wrapper)(T * const, long, T *, unsigned int, unsigned int,
-                          cubeb_channel_layout, cubeb_channel_layout);
+  downmix_func downmix_wrapper;
 };
 
 enum io_side {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -208,13 +208,9 @@ struct mixing_impl : public mixing_wrapper {
   using downmix_func_ptr = void (*)(T * const, long, T *,
                                     unsigned int, unsigned int,
                                     cubeb_channel_layout, cubeb_channel_layout);
-  using remap_func_ptr = bool (*)(T const * const, unsigned long, T *,
-                                  cubeb_channel_layout, cubeb_channel_layout);
 
-  mixing_impl(downmix_func_ptr dfptr, remap_func_ptr rfptr) {
+  mixing_impl(downmix_func_ptr dfptr) {
     downmix_wrapper = dfptr;
-    remap_wrapper = rfptr;
-    // If we allocate the mixed buffer here, what is its size ?
   }
 
   ~mixing_impl() {}
@@ -224,27 +220,17 @@ struct mixing_impl : public mixing_wrapper {
                cubeb_channel_layout mixing_layout) override {
     uint32_t output_channels = CUBEB_CHANNEL_LAYOUT_MAPS[output_layout].channels;
     uint32_t using_channels = CUBEB_CHANNEL_LAYOUT_MAPS[mixing_layout].channels;
-    buffer = std::vector<T>(using_channels * output_frames);
     T* out = static_cast<T *>(output_buffer);
-    (*downmix_wrapper)(out, output_frames, buffer.data(),
+    // By using same buffer for downmixing input and output, we allow downmixing
+    // from 5.0/1 to 1.0/1, 2.0/1/2, 3.0/1, 4.0/1. Do nothing on other cases.
+    (*downmix_wrapper)(out, output_frames, out,
                        output_channels, using_channels,
                        output_layout, mixing_layout);
-
-    // The mixed buffer returned from downmixing is shrunk by its channel counts.
-    // Although the extra channels beyonds the channels that the audio device
-    // can provide will be dropped, we still need to feed the unused channel
-    // buffer to the backend for processing. Thus, we need to assign the
-    // mixed buffer's data to the original output buffer.
-    (*remap_wrapper)(buffer.data(), output_frames, out, mixing_layout, output_layout);
   }
 
-  /* Mixed buffer */
-  std::vector<T> buffer;
   /* Function pointer for downmixing and remapping */
   void (*downmix_wrapper)(T * const, long, T *, unsigned int, unsigned int,
                           cubeb_channel_layout, cubeb_channel_layout);
-  bool (*remap_wrapper)(T const * const, unsigned long, T *,
-                        cubeb_channel_layout, cubeb_channel_layout);
 };
 
 enum io_side {
@@ -1249,9 +1235,9 @@ void
 audiounit_init_mixed_buffer(cubeb_stream * stm)
 {
   if (stm->output_desc.mFormatFlags & kAudioFormatFlagIsFloat) {
-    stm->mixing.reset(new mixing_impl<float>(&cubeb_downmix_float, &mix_remap_float));
+    stm->mixing.reset(new mixing_impl<float>(&cubeb_downmix_float));
   } else { // stm->output_desc.mFormatFlags & kAudioFormatFlagIsSignedInteger
-    stm->mixing.reset(new mixing_impl<short>(&cubeb_downmix_short, &mix_remap_short));
+    stm->mixing.reset(new mixing_impl<short>(&cubeb_downmix_short));
   }
 }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -483,6 +483,64 @@ is_extra_input_needed(cubeb_stream * stm)
          stm->available_input_frames < minimum_resampling_input_frames(stm);
 }
 
+template <typename T>
+void
+audiounit_copy_through_mixed_buffer_to_output(T* output_buffer,
+                                              long output_frames,
+                                              T* mixed_buffer,
+                                              UInt32 output_channels,
+                                              UInt32 mixed_channels)
+{
+  for (long i = 0, o = 0 ; i < output_frames ; ++i, o += output_channels) {
+    for (UInt32 c = 0 ; c < mixed_channels ; ++c) {
+      output_buffer[o + c] = mixed_buffer[i * mixed_channels + c];
+    }
+  }
+}
+
+void
+audiounit_mix_output_buffer(cubeb_stream * stm,
+                            void * output_buffer,
+                            long output_frames)
+{
+  // The audio rendering mechanism on OS X will drop the extra channels beyond
+  // the channels that audio device can provide, so we need to downmix the
+  // audio data by ourselves to keep all the information.
+
+  cubeb_channel_layout usedLayout = audiounit_get_channel_layout(false);
+  cubeb_stream_params mixed_params = {
+    stm->output_stream_params.format,
+    stm->output_stream_params.rate,
+    CUBEB_CHANNEL_LAYOUT_MAPS[usedLayout].channels,
+    usedLayout
+  };
+
+  // We only handle downmixing for now.
+  if (cubeb_should_downmix(&stm->output_stream_params, &mixed_params)) {
+    if (stm->output_desc.mFormatFlags & kAudioFormatFlagIsFloat) {
+      std::vector<float> mixed_buffer(mixed_params.channels * output_frames);
+      float* out = (float *)output_buffer;
+      cubeb_downmix_float(out, output_frames, mixed_buffer.data(),
+                          stm->output_stream_params.channels, mixed_params.channels,
+                          stm->output_stream_params.layout, mixed_params.layout);
+      audiounit_copy_through_mixed_buffer_to_output(out, output_frames,
+                                                    mixed_buffer.data(),
+                                                    stm->output_stream_params.channels,
+                                                    mixed_params.channels);
+    } else if (stm->output_desc.mFormatFlags & kAudioFormatFlagIsSignedInteger) {
+      std::vector<short> mixed_buffer(mixed_params.channels * output_frames);
+      short* out = (short *)output_buffer;
+      cubeb_downmix_short(out, output_frames, mixed_buffer.data(),
+                          stm->output_stream_params.channels, mixed_params.channels,
+                          stm->output_stream_params.layout, mixed_params.layout);
+      audiounit_copy_through_mixed_buffer_to_output(out, output_frames,
+                                                    mixed_buffer.data(),
+                                                    stm->output_stream_params.channels,
+                                                    mixed_params.channels);
+    }
+  }
+}
+
 static OSStatus
 audiounit_output_callback(void * user_ptr,
                           AudioUnitRenderActionFlags * /* flags */,
@@ -581,6 +639,10 @@ audiounit_output_callback(void * user_ptr,
       cubeb_pan_stereo_buffer_int((short*)output_buffer, outframes, panning);
     }
   }
+
+  /* Mixing */
+  audiounit_mix_output_buffer(stm, output_buffer, output_frames);
+
   return noErr;
 }
 

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -388,18 +388,18 @@ cubeb_downmix_float(float * const in, long inframes, float * out,
 }
 
 void
-cubeb_upmix_float(float * const in, long inframes, float * out,
-                  unsigned int in_channels, unsigned int out_channels)
-{
-  cubeb_upmix(in, inframes, out, in_channels, out_channels);
-}
-
-void
 cubeb_downmix_short(short * const in, long inframes, short * out,
                     unsigned int in_channels, unsigned int out_channels,
                     cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
   cubeb_downmix(in, inframes, out, in_channels, out_channels, in_layout, out_layout);
+}
+
+void
+cubeb_upmix_float(float * const in, long inframes, float * out,
+                  unsigned int in_channels, unsigned int out_channels)
+{
+  cubeb_upmix(in, inframes, out, in_channels, out_channels);
 }
 
 bool

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -395,3 +395,11 @@ cubeb_upmix_float(float * const in, long inframes, float * out,
 {
   cubeb_upmix(in, inframes, out, in_channels, out_channels);
 }
+
+void
+cubeb_downmix_short(short * const in, long inframes, short * out,
+                    unsigned int in_channels, unsigned int out_channels,
+                    cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  cubeb_downmix(in, inframes, out, in_channels, out_channels, in_layout, out_layout);
+}

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -81,7 +81,7 @@ cubeb_layout_map const CUBEB_CHANNEL_LAYOUT_MAPS[CUBEB_LAYOUT_MAX] = {
 };
 
 static int const CHANNEL_ORDER_TO_INDEX[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
- // M | L | R | C | LS | RS | RLS | RC | RRS | LFE
+//  M | L | R | C | LS | RS | RLS | RC | RRS | LFE
   { -1, -1, -1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // UNDEFINED
   { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,  -1 }, // DUAL_MONO
   { -1,  0,  1, -1,  -1,  -1,   -1,  -1,   -1,   2 }, // DUAL_MONO_LFE
@@ -256,8 +256,7 @@ mix_remap(T const * const in, unsigned long inframes, T * out, cubeb_channel_lay
     return false;
   }
 
-  long out_index = 0;
-  for (unsigned long i = 0; i < inframes * in_channels; i += in_channels) {
+  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
     for (unsigned int j = 0; j < out_channels; ++j) {
       cubeb_channel channel = CHANNEL_INDEX_TO_ORDER[out_layout][j];
       uint32_t channel_mask = 1 << channel;
@@ -270,7 +269,6 @@ mix_remap(T const * const in, unsigned long inframes, T * out, cubeb_channel_lay
         out[out_index + j] = 0;
       }
     }
-    out_index += out_channels;
   }
 
   return true;

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -401,3 +401,15 @@ cubeb_downmix_short(short * const in, long inframes, short * out,
 {
   cubeb_downmix(in, inframes, out, in_channels, out_channels, in_layout, out_layout);
 }
+
+bool
+mix_remap_float(float const * const in, unsigned long inframes, float * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  return mix_remap(in, inframes, out, in_layout, out_layout);
+}
+
+bool
+mix_remap_short(short const * const in, unsigned long inframes, short * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  return mix_remap(in, inframes, out, in_layout, out_layout);
+}

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -198,76 +198,37 @@ static float const DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANN
   }
 };
 
-/* Convert audio data from 3F2(-LFE) to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs. */
-#if !defined(USE_AUDIOUNIT)
+// Convert audio data from 3F2(-LFE) to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs.
+//
 // ITU-R BS.775-3[1] provides spec for downmixing 3F2 data to 1F, 2F, 3F, 2F1,
 // 3F1, 2F2 data. We simply add LFE to its defined matrix. If both the input
-// and output have LFE channel, then we pass it's data. If only input has LFE,
-// then we drop it. If only output has LFE, then we append 0 to its channel.
+// and output have LFE channel, then we pass it's data. If only input or output
+// has LFE, then we either drop it or append 0 to the LFE channel.
 //
-// Example: Downmixing from 3F2-LFE to stereo:
-//
+// Fig. 1:
 // |<-------------- 1 -------------->|<-------------- 2 -------------->|
 // +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
 // | L0 | R0 | C0 | LFE0 | LS0 | RS0 | L1 | R1 | C1 | LFE1 | LS1 | RS1 | ...
 // +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
 //
-//   | Downmix
-//   v
-//
+// Fig. 2:
 // |<-- 1 -->|<-- 2 -->|
 // +----+----+----+----+
 // | L0 | R0 | L1 | R1 | ...
 // +----+----+----+----+
 //
-// where L0 = L0 + 0.707 * (C0 + LS0), R0 = R0 + 0.707 * (C0 + RS0),
-//       L1 = L1 + 0.707 * (C1 + LS1), R1 = R1 + 0.707 * (C1 + RS1), ...
+// The figures above shows an example for downmixing from 3F2-LFE(Fig. 1) to
+// to stereo(Fig. 2), where L0 = L0 + 0.707 * (C0 + LS0),
+// R0 = R0 + 0.707 * (C0 + RS0), L1 = L1 + 0.707 * (C1 + LS1),
+// R1 = R1 + 0.707 * (C1 + RS1), ...
 //
-template<typename T>
-bool
-downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
-{
-  if ((in_layout != CUBEB_LAYOUT_3F2 && in_layout != CUBEB_LAYOUT_3F2_LFE) ||
-      out_layout < CUBEB_LAYOUT_MONO || out_layout > CUBEB_LAYOUT_2F2_LFE) {
-    return false;
-  }
-
-  unsigned int in_channels = CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels;
-  unsigned int out_channels = CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels;
-
-  // Conversion from 3F2 to 2F2-LFE or 3F1-LFE is allowed, so we use '<=' instead of '<'.
-  assert(out_channels <= in_channels);
-
-  auto & downmix_matrix = DOWNMIX_MATRIX_3F2_LFE[out_layout - CUBEB_LAYOUT_MONO]; // The matrix is started from mono.
-  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
-    for (unsigned int j = 0; j < out_channels; ++j) {
-      T sample = 0;
-      for (unsigned int k = 0 ; k < INPUT_CHANNEL_NUM ; ++k) {
-        // 3F2-LFE has 6 channels: L, R, C, LFE, LS, RS, while 3F2 has only 5
-        // channels: L, R, C, LS, RS. Thus, we need to append 0 to LFE(index 3)
-        // to simulate a 3F2-LFE data when input layout is 3F2.
-        T data = (in_layout == CUBEB_LAYOUT_3F2_LFE) ? in[i + k] : (k == 3) ? 0 : in[i + ((k < 3) ? k : k - 1)];
-        sample += downmix_matrix[j][k] * data;
-      }
-      out[out_index + j] = sample;
-    }
-  }
-
-  return true;
-}
-#else
-// This is an in-place version downmixing only for OSX.
-//
+// Nevertheless, the downmixing method is a little bit different on OSX.
 // The audio rendering mechanism on OS X will drop the extra channels beyond
-// the channels that audio device can provide. To keep all information,
-// we need to downmix the audio data by ourselves.
-//
-// The trick here is that OSX allows us to set the layout containing other
-// channels that the output device can NOT provide. Therefore, OSX expects we
-// will fill the buffer for playing sound by the layout we set, so there are
-// some will-be-dropped data in the buffer. For example, if we set layout to
-// 3F2-LFE for a stereo device and we fill the buffer with data for left, right,
-// center, low frequency effects, left surround, right surround channels,
+// the channels that audio device can provide. The trick here is that OSX allows
+// us to set the layout containing other channels that the output device can
+// NOT provide. For example, setting 3F2-LFE layout to a stereo device is fine.
+// Therefore, OSX expects we fill the buffer for playing sound by the defined
+// layout, so there are some will-be-dropped data in the buffer:
 //
 // +---+---+---+-----+----+----+
 // | L | R | C | LFE | LS | RS | ...
@@ -275,44 +236,20 @@ downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_l
 //           ^    ^    ^    ^
 //           The data for these four channels will be dropped!
 //
-// then the data for non-stereo channels will be ignored. To keep all the sounds,
-// we need to downmix the audio into the following format:
+// To keep all the information, we need to downmix the data before it's dropped.
+// The figure below shows an example for downmixing from 3F2-LFE(Fig. 1)
+// to stereo(Fig. 3) on OSX, where the LO, R0, L1, R0 are same as above.
 //
-//           |<--   gap   -->|
-// +----+----+---+---+---+---+
-// | L' | R' | x | x | x | x | ...
-// +----+----+---+---+---+---+
-//             ^   ^   ^   ^
-//             Useless channel data ...
-//
-// where L' = L + 0.707 * (C + LS) and R' = R + 0.707 * (C + RS).
-//
-// Generally, we will change the buffer data like the following figure:
-//
-// |<-------------- 1 -------------->|<-------------- 2 -------------->|
-// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
-// | L0 | R0 | C0 | LFE0 | LS0 | RS0 | L1 | R1 | C1 | LFE1 | LS1 | RS1 | ...
-// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
-//
-//    | Downmix
-//    v
-//
+// Fig. 3:
 // |<---------- 1 ---------->|<---------- 2 ---------->|
 // +----+----+---+---+---+---+----+----+---+---+---+---+
 // | L0 | R0 | x | x | x | x | L1 | R1 | x | x | x | x | ...
 // +----+----+---+---+---+---+----+----+---+---+---+---+
-//           |<--   gap   -->|         |<--   gap   -->|
-//
-// where L0 = L0 + 0.707 * (C0 + LS0), R0 = R0 + 0.707 * (C0 + RS0),
-//       L1 = L1 + 0.707 * (C1 + LS1), R1 = R1 + 0.707 * (C1 + RS1), ...
-//
+//           |<--  dummy  -->|         |<--  dummy  -->|
 template<typename T>
 bool
 downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
 {
-  // Avoid allocating buffers in audio callback, so we reuse the same buffer.
-  assert(in == out);
-
   if ((in_layout != CUBEB_LAYOUT_3F2 && in_layout != CUBEB_LAYOUT_3F2_LFE) ||
       out_layout < CUBEB_LAYOUT_MONO || out_layout > CUBEB_LAYOUT_2F2_LFE) {
     return false;
@@ -325,9 +262,8 @@ downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_l
   assert(out_channels <= in_channels);
 
   auto & downmix_matrix = DOWNMIX_MATRIX_3F2_LFE[out_layout - CUBEB_LAYOUT_MONO]; // The matrix is started from mono.
-  // The difference between this method and the normal version is that we use
-  // "out_index += in_channels" instead of "out_index += out_channels".
-  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += in_channels) {
+  unsigned long out_index = 0;
+  for (unsigned long i = 0 ; i < inframes * in_channels; i += in_channels) {
     for (unsigned int j = 0; j < out_channels; ++j) {
       T sample = 0;
       for (unsigned int k = 0 ; k < INPUT_CHANNEL_NUM ; ++k) {
@@ -339,11 +275,15 @@ downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_l
       }
       out[out_index + j] = sample;
     }
+#if defined(USE_AUDIOUNIT)
+    out_index += in_channels;
+#else
+    out_index += out_channels;
+#endif
   }
 
   return true;
 }
-#endif
 
 /* Map the audio data by channel name. */
 template<class T>
@@ -428,7 +368,7 @@ cubeb_downmix(T const * const in, long inframes, T * out,
       return;
     }
 
-  // We only support downmix from audio 5.1 for now.
+  // We only support downmix for audio 5.1 currently.
 #if defined(USE_AUDIOUNIT)
   return;
 #endif

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -199,6 +199,30 @@ static float const DOWNMIX_MATRIX_3F2_LFE[SUPPORTED_LAYOUT_NUM][MAX_OUTPUT_CHANN
 };
 
 /* Convert audio data from 3F2(-LFE) to 1F, 2F, 3F, 2F1, 3F1, 2F2 and their LFEs. */
+#if !defined(USE_AUDIOUNIT)
+// ITU-R BS.775-3[1] provides spec for downmixing 3F2 data to 1F, 2F, 3F, 2F1,
+// 3F1, 2F2 data. We simply add LFE to its defined matrix. If both the input
+// and output have LFE channel, then we pass it's data. If only input has LFE,
+// then we drop it. If only output has LFE, then we append 0 to its channel.
+//
+// Example: Downmixing from 3F2-LFE to stereo:
+//
+// |<-------------- 1 -------------->|<-------------- 2 -------------->|
+// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
+// | L0 | R0 | C0 | LFE0 | LS0 | RS0 | L1 | R1 | C1 | LFE1 | LS1 | RS1 | ...
+// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
+//
+//   | Downmix
+//   v
+//
+// |<-- 1 -->|<-- 2 -->|
+// +----+----+----+----+
+// | L0 | R0 | L1 | R1 | ...
+// +----+----+----+----+
+//
+// where L0 = L0 + 0.707 * (C0 + LS0), R0 = R0 + 0.707 * (C0 + RS0),
+//       L1 = L1 + 0.707 * (C1 + LS1), R1 = R1 + 0.707 * (C1 + RS1), ...
+//
 template<typename T>
 bool
 downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
@@ -214,14 +238,8 @@ downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_l
   // Conversion from 3F2 to 2F2-LFE or 3F1-LFE is allowed, so we use '<=' instead of '<'.
   assert(out_channels <= in_channels);
 
-  // If the output buffer is same as input, then we calculate the mixed audio
-  // data from the related buffers, and put the result back to the buffer at the
-  // corresponding channel position. The unused channel buffers will stay same.
-  bool resizing = (in != out);
-
-  unsigned long out_index = 0;
   auto & downmix_matrix = DOWNMIX_MATRIX_3F2_LFE[out_layout - CUBEB_LAYOUT_MONO]; // The matrix is started from mono.
-  for (unsigned long i = 0; i < inframes * in_channels; i += in_channels) {
+  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
     for (unsigned int j = 0; j < out_channels; ++j) {
       T sample = 0;
       for (unsigned int k = 0 ; k < INPUT_CHANNEL_NUM ; ++k) {
@@ -233,11 +251,99 @@ downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_l
       }
       out[out_index + j] = sample;
     }
-    out_index += resizing ? out_channels : in_channels;
   }
 
   return true;
 }
+#else
+// This is an in-place version downmixing only for OSX.
+//
+// The audio rendering mechanism on OS X will drop the extra channels beyond
+// the channels that audio device can provide. To keep all information,
+// we need to downmix the audio data by ourselves.
+//
+// The trick here is that OSX allows us to set the layout containing other
+// channels that the output device can NOT provide. Therefore, OSX expects we
+// will fill the buffer for playing sound by the layout we set, so there are
+// some will-be-dropped data in the buffer. For example, if we set layout to
+// 3F2-LFE for a stereo device and we fill the buffer with data for left, right,
+// center, low frequency effects, left surround, right surround channels,
+//
+// +---+---+---+-----+----+----+
+// | L | R | C | LFE | LS | RS | ...
+// +---+---+---+-----+----+----+
+//           ^    ^    ^    ^
+//           The data for these four channels will be dropped!
+//
+// then the data for non-stereo channels will be ignored. To keep all the sounds,
+// we need to downmix the audio into the following format:
+//
+//           |<--   gap   -->|
+// +----+----+---+---+---+---+
+// | L' | R' | x | x | x | x | ...
+// +----+----+---+---+---+---+
+//             ^   ^   ^   ^
+//             Useless channel data ...
+//
+// where L' = L + 0.707 * (C + LS) and R' = R + 0.707 * (C + RS).
+//
+// Generally, we will change the buffer data like the following figure:
+//
+// |<-------------- 1 -------------->|<-------------- 2 -------------->|
+// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
+// | L0 | R0 | C0 | LFE0 | LS0 | RS0 | L1 | R1 | C1 | LFE1 | LS1 | RS1 | ...
+// +----+----+----+------+-----+-----+----+----+----+------+-----+-----+
+//
+//    | Downmix
+//    v
+//
+// |<---------- 1 ---------->|<---------- 2 ---------->|
+// +----+----+---+---+---+---+----+----+---+---+---+---+
+// | L0 | R0 | x | x | x | x | L1 | R1 | x | x | x | x | ...
+// +----+----+---+---+---+---+----+----+---+---+---+---+
+//           |<--   gap   -->|         |<--   gap   -->|
+//
+// where L0 = L0 + 0.707 * (C0 + LS0), R0 = R0 + 0.707 * (C0 + RS0),
+//       L1 = L1 + 0.707 * (C1 + LS1), R1 = R1 + 0.707 * (C1 + RS1), ...
+//
+template<typename T>
+bool
+downmix_3f2(T const * const in, unsigned long inframes, T * out, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)
+{
+  // Avoid allocating buffers in audio callback, so we reuse the same buffer.
+  assert(in == out);
+
+  if ((in_layout != CUBEB_LAYOUT_3F2 && in_layout != CUBEB_LAYOUT_3F2_LFE) ||
+      out_layout < CUBEB_LAYOUT_MONO || out_layout > CUBEB_LAYOUT_2F2_LFE) {
+    return false;
+  }
+
+  unsigned int in_channels = CUBEB_CHANNEL_LAYOUT_MAPS[in_layout].channels;
+  unsigned int out_channels = CUBEB_CHANNEL_LAYOUT_MAPS[out_layout].channels;
+
+  // Conversion from 3F2 to 2F2-LFE or 3F1-LFE is allowed, so we use '<=' instead of '<'.
+  assert(out_channels <= in_channels);
+
+  auto & downmix_matrix = DOWNMIX_MATRIX_3F2_LFE[out_layout - CUBEB_LAYOUT_MONO]; // The matrix is started from mono.
+  // The difference between this method and the normal version is that we use
+  // "out_index += in_channels" instead of "out_index += out_channels".
+  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += in_channels) {
+    for (unsigned int j = 0; j < out_channels; ++j) {
+      T sample = 0;
+      for (unsigned int k = 0 ; k < INPUT_CHANNEL_NUM ; ++k) {
+        // 3F2-LFE has 6 channels: L, R, C, LFE, LS, RS, while 3F2 has only 5
+        // channels: L, R, C, LS, RS. Thus, we need to append 0 to LFE(index 3)
+        // to simulate a 3F2-LFE data when input layout is 3F2.
+        T data = (in_layout == CUBEB_LAYOUT_3F2_LFE) ? in[i + k] : (k == 3) ? 0 : in[i + ((k < 3) ? k : k - 1)];
+        sample += downmix_matrix[j][k] * data;
+      }
+      out[out_index + j] = sample;
+    }
+  }
+
+  return true;
+}
+#endif
 
 /* Map the audio data by channel name. */
 template<class T>

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -70,6 +70,10 @@ void cubeb_downmix_float(float * const in, long inframes, float * out,
 void cubeb_upmix_float(float * const in, long inframes, float * out,
                        unsigned int in_channels, unsigned int out_channels);
 
+void cubeb_downmix_short(short * const in, long inframes, short * out,
+                         unsigned int in_channels, unsigned int out_channels,
+                         cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -67,12 +67,12 @@ void cubeb_downmix_float(float * const in, long inframes, float * out,
                          unsigned int in_channels, unsigned int out_channels,
                          cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
 
-void cubeb_upmix_float(float * const in, long inframes, float * out,
-                       unsigned int in_channels, unsigned int out_channels);
-
 void cubeb_downmix_short(short * const in, long inframes, short * out,
                          unsigned int in_channels, unsigned int out_channels,
                          cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
+
+void cubeb_upmix_float(float * const in, long inframes, float * out,
+                       unsigned int in_channels, unsigned int out_channels);
 
 bool mix_remap_float(float const * const in, unsigned long inframes, float * out,
                      cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -74,6 +74,12 @@ void cubeb_downmix_short(short * const in, long inframes, short * out,
                          unsigned int in_channels, unsigned int out_channels,
                          cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
 
+bool mix_remap_float(float const * const in, unsigned long inframes, float * out,
+                     cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
+
+bool mix_remap_short(short const * const in, unsigned long inframes, short * out,
+                     cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -74,12 +74,6 @@ void cubeb_downmix_short(short * const in, long inframes, short * out,
 void cubeb_upmix_float(float * const in, long inframes, float * out,
                        unsigned int in_channels, unsigned int out_channels);
 
-bool mix_remap_float(float const * const in, unsigned long inframes, float * out,
-                     cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
-
-bool mix_remap_short(short const * const in, unsigned long inframes, short * out,
-                     cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);
-
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
The audio rendering mechanism on OS X will drop the extra channels beyond the channels that audio device can provide. To keep all information, we need to downmix the audio data by ourselves.