### PR TITLE
Fixes for two crashes

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1893,10 +1893,10 @@ int stream_start_one_side(cubeb_stream * stm, StreamDirection dir)
 
 int wasapi_stream_start(cubeb_stream * stm)
 {
+  auto_lock lock(stm->stream_reset_lock);
+
   XASSERT(stm && !stm->thread && !stm->shutdown_event);
   XASSERT(stm->output_client || stm->input_client);
-
-  auto_lock lock(stm->stream_reset_lock);
 
   stm->emergency_bailout = new std::atomic<bool>(false);
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -857,6 +857,11 @@ wasapi_stream_render_loop(LPVOID stream)
     LOG("Unable to use mmcss to bump the render thread priority: %lx", GetLastError());
   }
 
+  // This has already been nulled out, simply exit.
+  if (!emergency_bailout) {
+    is_playing = false;
+  }
+
   /* WaitForMultipleObjects timeout can trigger in cases where we don't want to
      treat it as a timeout, such as across a system sleep/wake cycle.  Trigger
      the timeout error handling only when the timeout_limit is reached, which is


### PR DESCRIPTION
1. Don't try to re-do an emergency bailout after having done one: we don't know whether the bool has been freed or not. This has been found in the field, https://bugzilla.mozilla.org/show_bug.cgi?id=1340291. This is rather rare. One day we'll have proper atomic refptr of atomic memory maybe... 
2. `stm->output_client` and `stm->input_client` should be accessed only when the lock has been taken. During a reconfigure, we null them out ([here](https://github.com/kinetiknz/cubeb/blob/master/src/cubeb_wasapi.cpp#L1797)). Simply taking the lock before doing the assert should be enough. This is very rare, captured in bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1340278