### PR TITLE
audiounit: add synchronization in cubeb destroy (Bug 1344580)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1212,7 +1212,7 @@ audiounit_destroy(cubeb * ctx)
   {
     auto_lock lock(ctx->mutex);
     /* Unregister the callback if necessary. */
-    if(ctx->collection_changed_callback) {
+    if (ctx->collection_changed_callback) {
       audiounit_remove_device_listener(ctx);
     }
   }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1209,10 +1209,12 @@ audiounit_destroy(cubeb * ctx)
     LOG("(%p) API misuse, %d streams active when context destroyed!", ctx, ctx->active_streams.load());
   }
 
-  /* Unregister the callback if necessary. */
-  if(ctx->collection_changed_callback) {
+  {
     auto_lock lock(ctx->mutex);
-    audiounit_remove_device_listener(ctx);
+    /* Unregister the callback if necessary. */
+    if(ctx->collection_changed_callback) {
+      audiounit_remove_device_listener(ctx);
+    }
   }
 
   delete ctx;


### PR DESCRIPTION
I am not able to repro the crash but I believe this patch will solve it. The truth is that we do not solve the root cause that would be not to call cubeb_destroy before every stream is stopped and destroyed (bug 1083664). In any case this patch fixes other cases like to destroy during device switch. 

Try link:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=1f819e60bed151b4ed84536aefc1c8c076b21cab
