### PR TITLE
Getting correct size of allocated AudioChannelLayout array

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -147,10 +147,11 @@ public:
   {
   }
 
-  auto_channel_layout(size_t size)
-    : layout(reinterpret_cast<AudioChannelLayout*>(malloc(size)))
+  auto_channel_layout(size_t s)
+    : layout(reinterpret_cast<AudioChannelLayout*>(malloc(s)))
   {
-    memset(layout, 0, size);
+    sz = s;
+    memset(layout, 0, sz);
   }
 
   ~auto_channel_layout()
@@ -158,11 +159,12 @@ public:
     release();
   }
 
-  void reset(size_t size)
+  void reset(size_t s)
   {
     release();
-    layout = reinterpret_cast<AudioChannelLayout*>(malloc(size));
-    memset(layout, 0, size);
+    sz = s;
+    layout = reinterpret_cast<AudioChannelLayout*>(malloc(sz));
+    memset(layout, 0, sz);
   }
 
   AudioChannelLayout* get()
@@ -172,7 +174,7 @@ public:
 
   size_t size()
   {
-    return sizeof(*layout);
+    return sz;
   }
 
 private:
@@ -180,11 +182,13 @@ private:
   {
     if (layout) {
       free(layout);
+      sz = 0;
       layout = NULL;
     }
   }
 
   AudioChannelLayout * layout;
+  size_t sz;
 };
 
 enum io_side {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -148,10 +148,10 @@ public:
   }
 
   auto_channel_layout(size_t s)
-    : layout(reinterpret_cast<AudioChannelLayout*>(malloc(s)))
+    : sz(s)
+    , layout((AudioChannelLayout*) calloc(1, sz))
   {
-    sz = s;
-    memset(layout, 0, sz);
+    assert(layout);
   }
 
   ~auto_channel_layout()
@@ -163,8 +163,8 @@ public:
   {
     release();
     sz = s;
-    layout = reinterpret_cast<AudioChannelLayout*>(malloc(sz));
-    memset(layout, 0, sz);
+    layout = (AudioChannelLayout*) calloc(1, sz);
+    assert(layout);
   }
 
   AudioChannelLayout* get()
@@ -183,12 +183,12 @@ private:
     if (layout) {
       free(layout);
       sz = 0;
-      layout = NULL;
+      layout = nullptr;
     }
   }
 
-  AudioChannelLayout * layout;
   size_t sz;
+  AudioChannelLayout * layout;
 };
 
 enum io_side {


### PR DESCRIPTION
Instead of ```sizeof(*layout)```, we should keep track of the size for using malloc.