### PR TITLE
In cubeb_wasapi.cpp, when a device has been invalidated, clear out the device pointer before trying again with the next device.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1479,6 +1479,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
       if (devid && hr == AUDCLNT_E_DEVICE_INVALIDATED) {
         LOG("Trying again with the default %s audio device.", DIRECTION_NAME);
         devid = nullptr;
+        device = nullptr;
         try_again = true;
       } else {
         return CUBEB_ERROR;


### PR DESCRIPTION
Fix for Gecko bug 1343972.