### PR TITLE
Replace assert by gtest's assertion

### DIFF
--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -37,7 +37,7 @@ long data_cb(cubeb_stream * stream, void * user, const void * inputbuffer, void 
 
 void state_cb(cubeb_stream * stream, void * /*user*/, cubeb_state state)
 {
-  assert(stream);
+  ASSERT_TRUE(!!stream);
 
   switch (state) {
   case CUBEB_STATE_STARTED:
@@ -45,11 +45,11 @@ void state_cb(cubeb_stream * stream, void * /*user*/, cubeb_state state)
   case CUBEB_STATE_STOPPED:
     printf("stream stopped\n"); break;
   case CUBEB_STATE_DRAINED:
-    assert(false && "this test is not supposed to drain"); break;
+    FAIL() << "this test is not supposed to drain"; break;
   case CUBEB_STATE_ERROR:
     printf("stream error\n"); break;
   default:
-    assert(false && "this test is not supposed to have a weird state"); break;
+    FAIL() << "this test is not supposed to have a weird state"; break;
   }
 }
 

--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -28,9 +28,9 @@ std::atomic<bool> load_callback{ false };
 long data_cb(cubeb_stream * stream, void * user, const void * inputbuffer, void * outputbuffer, long nframes)
 {
   if (load_callback) {
-    printf("Sleeping...\n");
+    fprintf(stderr, "Sleeping...\n");
     delay(100000);
-    printf("Sleeping done\n");
+    fprintf(stderr, "Sleeping done\n");
   }
   return nframes;
 }
@@ -41,13 +41,13 @@ void state_cb(cubeb_stream * stream, void * /*user*/, cubeb_state state)
 
   switch (state) {
   case CUBEB_STATE_STARTED:
-    printf("stream started\n"); break;
+    fprintf(stderr, "stream started\n"); break;
   case CUBEB_STATE_STOPPED:
-    printf("stream stopped\n"); break;
+    fprintf(stderr, "stream stopped\n"); break;
   case CUBEB_STATE_DRAINED:
     FAIL() << "this test is not supposed to drain"; break;
   case CUBEB_STATE_ERROR:
-    printf("stream error\n"); break;
+    fprintf(stderr, "stream error\n"); break;
   default:
     FAIL() << "this test is not supposed to have a weird state"; break;
   }


### PR DESCRIPTION
It's better to use
- gtest's assertion than c style assert in gtest
- ```fprintf(stderr, ...)``` than ```printf(...)```