### PR TITLE
WASAPI: make callback_input return !stm->draining

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -757,7 +757,7 @@ refill_callback_duplex(cubeb_stream * stm)
 bool
 refill_callback_input(cubeb_stream * stm)
 {
-  bool rv, consumed_all_buffer;
+  bool rv;
 
   XASSERT(has_input(stm) && !has_output(stm));
 
@@ -780,11 +780,10 @@ refill_callback_input(cubeb_stream * stm)
                      0);
 
   XASSERT(read >= 0);
-  consumed_all_buffer = (unsigned long) read == stm->linear_input_buffer.length();
 
   stm->linear_input_buffer.clear();
 
-  return consumed_all_buffer;
+  return !stm->draining;
 }
 
 bool


### PR DESCRIPTION
Fixes #262: Capture stream freezes on WASAPI when resampling.

The previous behavior would return false (and thus stop all future
callbacks) if the user didn't process all frames in linear_input_buffer.
This could erroneously happen when the resampler held back frames for
the next batch (e.g. 448 input frames at 44.1 KHz upsampled to 48 KHz,
which doesn't have a perfect integer scale), so the user callback didn't
have access to all of the current linear input frames.

The refill() function already handles the case where the user callback
returns less than the number of frames passed in (by settings
stm->draining), so this commit changes the callback_input() return value
to defer to that.