### PR TITLE
Bug 1349527 - Remove an extra +1 in cubeb_log_message::cubeb_log_message()

### DIFF
--- a/src/cubeb_log.cpp
+++ b/src/cubeb_log.cpp
@@ -47,7 +47,7 @@ public:
       return;
     }
     PodCopy(storage, str, length);
-    storage[length + 1] = '\0';
+    storage[length] = '\0';
   }
   char const * get() {
     return storage;


### PR DESCRIPTION
Fix an out-of-bounds write by removing and extra +1 which was causing a \0
to be written out of |storage| in edge cases.

Patch by @BurningMind.