### PR TITLE
Only compile and run 'test_overload_callback' when compiling in WASAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,10 +193,12 @@ target_include_directories(test_duplex PRIVATE ${gtest_SOURCE_DIR}/include)
 target_link_libraries(test_duplex PRIVATE cubeb gtest_main)
 add_test(duplex test_duplex)
 
+if (USE_WASAPI)
 add_executable(test_overload_callback test/test_overload_callback.cpp)
 target_include_directories(test_overload_callback PRIVATE ${gtest_SOURCE_DIR}/include)
 target_link_libraries(test_overload_callback PRIVATE cubeb gtest_main)
 add_test(overload_callback test_overload_callback)
+endif()
 
 add_executable(test_latency test/test_latency.cpp)
 target_include_directories(test_latency PRIVATE ${gtest_SOURCE_DIR}/include)


### PR DESCRIPTION
This was really written with WASAPI in mind, to test the emergency boolean. That said, we'd better implement overflow and underflow detection at some point, for all backends.

This fixes #264.