### PR TITLE
audiounit: Set layout in output argument.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1224,7 +1224,8 @@ audiounit_get_preferred_channel_layout(cubeb * ctx, cubeb_channel_layout * layou
     // If we already have at least one cubeb stream, then the current channel
     // layout must be updated. We can return it directly.
     if (ctx->active_streams) {
-      return ctx->layout;
+      *layout = ctx->layout;
+      return CUBEB_OK;
     }
 
     // If there is no existed stream, then we create a default ouput unit and


### PR DESCRIPTION
Layout is set in the output parameter and return CUBEB_OK. Accidentally we returned the layout itself. 