### PR TITLE
audiounit: Prefer a bare function pointer over std::function.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -158,9 +158,9 @@ struct mixing_wrapper {
 template <typename T>
 struct mixing_impl : public mixing_wrapper {
 
-  typedef std::function<void(T * const, long, T *,
-                             unsigned int, unsigned int,
-                             cubeb_channel_layout, cubeb_channel_layout)> downmix_func;
+  typedef void (*downmix_func)(T * const, long, T *,
+                               unsigned int, unsigned int,
+                               cubeb_channel_layout, cubeb_channel_layout);
 
   mixing_impl(downmix_func dmfunc) {
     downmix_wrapper = dmfunc;


### PR DESCRIPTION
This addresses [BMO bug #1339537](https://bugzilla.mozilla.org/show_bug.cgi?id=1339537#c16), which aims to ban passing structs containing
alignas members by value.  The analysis for this is tripped up by libc++'s
implementation of std::function.

Since we're the only place in Gecko hitting this, and have no real need for
std::function here, the simplest solution is to switch to a bare function
pointer.