### PR TITLE
audiounit: make input_callback read correct number of frames handled

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -442,13 +442,10 @@ audiounit_input_callback(void * user_ptr,
                                         &total_input_frames,
                                         NULL,
                                         0);
+  assert(outframes >= 0);
+
   // Reset input buffer
   stm->input_linear_buffer->clear();
-
-  if (outframes < 0 || (UInt32) outframes != input_frames) {
-    stm->shutdown = true;
-    return noErr;
-  }
 
   return noErr;
 }


### PR DESCRIPTION
Same thing as #262/#263, but for the CoreAudio backend.

Might be a useful to change the definition of `cubeb_resampler_fill` at some point to make clear what the number of frames handled should be compared against.