### PR TITLE
Using RAII helpers for cubeb context and stream in the test

### DIFF
--- a/test/common.h
+++ b/test/common.h
@@ -107,4 +107,18 @@ void print_log(const char * msg, ...)
   va_end(args);
 }
 
+struct cubeb_cleaner
+{
+  cubeb_cleaner(cubeb * context) : ctx(context) {}
+  ~cubeb_cleaner() { cubeb_destroy(ctx); }
+  cubeb * ctx;
+};
+
+struct cubeb_stream_cleaner
+{
+  cubeb_stream_cleaner(cubeb_stream * stream) : stm(stream) {}
+  ~cubeb_stream_cleaner() { cubeb_stream_destroy(stm); }
+  cubeb_stream * stm;
+};
+
 #endif /* TEST_COMMON */

--- a/test/common.h
+++ b/test/common.h
@@ -107,18 +107,4 @@ void print_log(const char * msg, ...)
   va_end(args);
 }
 
-struct cubeb_cleaner
-{
-  cubeb_cleaner(cubeb * context) : ctx(context) {}
-  ~cubeb_cleaner() { cubeb_destroy(ctx); }
-  cubeb * ctx;
-};
-
-struct cubeb_stream_cleaner
-{
-  cubeb_stream_cleaner(cubeb_stream * stream) : stm(stream) {}
-  ~cubeb_stream_cleaner() { cubeb_stream_destroy(stm); }
-  cubeb_stream * stm;
-};
-
 #endif /* TEST_COMMON */

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -75,20 +75,6 @@ long data_cb(cubeb_stream * /*stream*/, void * user, const void * /*inputbuffer*
   return nframes;
 }
 
-struct CubebCleaner
-{
-  CubebCleaner(cubeb* ctx_) : ctx(ctx_) {}
-  ~CubebCleaner() { cubeb_destroy(ctx); }
-  cubeb* ctx;
-};
-
-struct CubebStreamCleaner
-{
-  CubebStreamCleaner(cubeb_stream* ctx_) : ctx(ctx_) {}
-  ~CubebStreamCleaner() { cubeb_stream_destroy(ctx); }
-  cubeb_stream* ctx;
-};
-
 void state_cb_audio(cubeb_stream * /*stream*/, void * /*user*/, cubeb_state /*state*/)
 {
 }
@@ -124,7 +110,7 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
     fprintf(stderr, "Error initializing cubeb library\n");
     return r;
   }
-  CubebCleaner cleanup_cubeb_at_exit(ctx);
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
 
   const char * backend_id = cubeb_get_backend_id(ctx);
 
@@ -153,7 +139,7 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
     return r;
   }
 
-  CubebStreamCleaner cleanup_stream_at_exit(stream);
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
 
   cubeb_stream_start(stream);
   delay(200);
@@ -174,7 +160,7 @@ int run_panning_volume_test(int is_float)
     return r;
   }
 
-  CubebCleaner cleanup_cubeb_at_exit(ctx);
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
 
   const char * backend_id = cubeb_get_backend_id(ctx);
 
@@ -201,7 +187,7 @@ int run_panning_volume_test(int is_float)
     return r;
   }
 
-  CubebStreamCleaner cleanup_stream_at_exit(stream);
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
 
   fprintf(stderr, "Testing: volume\n");
   for(int i=0;i <= 4; ++i)

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <memory>
 #include <string.h>
 #include "cubeb/cubeb.h"
 #include "common.h"
@@ -110,7 +111,8 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
     fprintf(stderr, "Error initializing cubeb library\n");
     return r;
   }
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   const char * backend_id = cubeb_get_backend_id(ctx);
 
@@ -139,7 +141,8 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
     return r;
   }
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
   delay(200);
@@ -160,7 +163,8 @@ int run_panning_volume_test(int is_float)
     return r;
   }
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   const char * backend_id = cubeb_get_backend_id(ctx);
 
@@ -187,7 +191,8 @@ int run_panning_volume_test(int is_float)
     return r;
   }
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   fprintf(stderr, "Testing: volume\n");
   for(int i=0;i <= 4; ++i)

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -104,17 +104,14 @@ print_device_collection(cubeb_device_collection * collection, FILE * f)
     print_device_info(collection->device[i], f);
 }
 
-int run_enumerating_devices_test()
+TEST(cubeb, enumerate_devices)
 {
   int r;
   cubeb * ctx = NULL;
   cubeb_device_collection * collection = NULL;
 
   r = cubeb_init(&ctx, "Cubeb audio test", NULL);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb library\n");
-    return r;
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
@@ -126,12 +123,9 @@ int run_enumerating_devices_test()
   if (r == CUBEB_ERROR_NOT_SUPPORTED) {
     fprintf(stderr, "Device enumeration not supported"
                     " for this backend, skipping this test.\n");
-    return CUBEB_OK;
+    r = CUBEB_OK;
   }
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error enumerating devices %d\n", r);
-    return r;
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error enumerating devices " << r;
 
   fprintf(stdout, "Found %u input devices\n", collection->count);
   print_device_collection(collection, stdout);
@@ -141,19 +135,9 @@ int run_enumerating_devices_test()
           cubeb_get_backend_id(ctx));
 
   r = cubeb_enumerate_devices(ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error enumerating devices %d\n", r);
-    return r;
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error enumerating devices " << r;
 
   fprintf(stdout, "Found %u output devices\n", collection->count);
   print_device_collection(collection, stdout);
   cubeb_device_collection_destroy(collection);
-
-  return r;
-}
-
-TEST(cubeb, enumerate_devices)
-{
-  ASSERT_EQ(run_enumerating_devices_test(), CUBEB_OK);
 }

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common.h"
+#include <memory>
 #include "cubeb/cubeb.h"
 
 static void
@@ -116,7 +116,8 @@ int run_enumerating_devices_test()
     return r;
   }
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   fprintf(stdout, "Enumerating input devices for backend %s\n",
       cubeb_get_backend_id(ctx));

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -88,6 +88,8 @@ TEST(cubeb, duplex)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+
   /* This test needs an available input device, skip it if this host does not
    * have one. */
   if (!has_available_input_device(ctx)) {
@@ -119,12 +121,11 @@ TEST(cubeb, duplex)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+
   cubeb_stream_start(stream);
   delay(500);
   cubeb_stream_stop(stream);
-
-  cubeb_stream_destroy(stream);
-  cubeb_destroy(ctx);
 
   ASSERT_TRUE(stream_state.seen_audio);
 }

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <memory>
 #include "cubeb/cubeb.h"
 #include "common.h"
 
@@ -88,7 +89,8 @@ TEST(cubeb, duplex)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   /* This test needs an available input device, skip it if this host does not
    * have one. */
@@ -121,7 +123,8 @@ TEST(cubeb, duplex)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
   delay(500);

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 #include <stdlib.h>
-#include "common.h"
+#include <memory>
 #include "cubeb/cubeb.h"
 
 TEST(cubeb, latency)
@@ -15,7 +15,8 @@ TEST(cubeb, latency)
   r = cubeb_init(&ctx, "Cubeb audio test", NULL);
   ASSERT_EQ(r, CUBEB_OK);
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   r = cubeb_get_max_channel_count(ctx, &max_channels);
   ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include <stdlib.h>
+#include "common.h"
 #include "cubeb/cubeb.h"
 
 TEST(cubeb, latency)
@@ -13,6 +14,8 @@ TEST(cubeb, latency)
 
   r = cubeb_init(&ctx, "Cubeb audio test", NULL);
   ASSERT_EQ(r, CUBEB_OK);
+
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
 
   r = cubeb_get_max_channel_count(ctx, &max_channels);
   ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED);
@@ -44,6 +47,4 @@ TEST(cubeb, latency)
   if (r == CUBEB_OK) {
     ASSERT_GT(latency_frames, 0u);
   }
-
-  cubeb_destroy(ctx);
 }

--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -64,6 +64,8 @@ TEST(cubeb, overload_callback)
   r = cubeb_init(&ctx, "Cubeb callback overload", NULL);
   ASSERT_EQ(r, CUBEB_OK);
 
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+
   output_params.format = STREAM_FORMAT;
   output_params.rate = 48000;
   output_params.channels = 2;
@@ -77,13 +79,12 @@ TEST(cubeb, overload_callback)
                         latency_frames, data_cb, state_cb, NULL);
   ASSERT_EQ(r, CUBEB_OK);
 
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+
   cubeb_stream_start(stream);
   delay(500);
   // This causes the callback to sleep for a large number of seconds.
   load_callback = true;
   delay(500);
   cubeb_stream_stop(stream);
-
-  cubeb_stream_destroy(stream);
-  cubeb_destroy(ctx);
 }

--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <memory>
 #include <atomic>
 #include "cubeb/cubeb.h"
 #include "common.h"
@@ -64,7 +65,8 @@ TEST(cubeb, overload_callback)
   r = cubeb_init(&ctx, "Cubeb callback overload", NULL);
   ASSERT_EQ(r, CUBEB_OK);
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   output_params.format = STREAM_FORMAT;
   output_params.rate = 48000;
@@ -79,7 +81,8 @@ TEST(cubeb, overload_callback)
                         latency_frames, data_cb, state_cb, NULL);
   ASSERT_EQ(r, CUBEB_OK);
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
   delay(500);

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -82,6 +82,8 @@ TEST(cubeb, record)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+
   /* This test needs an available input device, skip it if this host does not
    * have one. */
   if (!has_available_input_device(ctx)) {
@@ -100,12 +102,11 @@ TEST(cubeb, record)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+
   cubeb_stream_start(stream);
   delay(500);
   cubeb_stream_stop(stream);
-
-  cubeb_stream_destroy(stream);
-  cubeb_destroy(ctx);
 
 #ifdef __linux__
   // user callback does not arrive in Linux, silence the error

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <memory>
 #include "cubeb/cubeb.h"
 #include "common.h"
 
@@ -82,7 +83,8 @@ TEST(cubeb, record)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   /* This test needs an available input device, skip it if this host does not
    * have one. */
@@ -102,7 +104,8 @@ TEST(cubeb, record)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
   delay(500);

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <memory>
 #include <limits.h>
 #include "cubeb/cubeb.h"
 #include "common.h"
@@ -107,7 +108,8 @@ TEST(cubeb, tone)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   params.format = STREAM_FORMAT;
   params.rate = SAMPLE_FREQUENCY;
@@ -128,7 +130,8 @@ TEST(cubeb, tone)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
-  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+  std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
+    cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
   delay(500);

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -107,6 +107,8 @@ TEST(cubeb, tone)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_cleaner cleanup_cubeb_at_exit(ctx);
+
   params.format = STREAM_FORMAT;
   params.rate = SAMPLE_FREQUENCY;
   params.channels = 1;
@@ -126,12 +128,11 @@ TEST(cubeb, tone)
     ASSERT_EQ(r, CUBEB_OK);
   }
 
+  cubeb_stream_cleaner cleanup_stream_at_exit(stream);
+
   cubeb_stream_start(stream);
   delay(500);
   cubeb_stream_stop(stream);
-
-  cubeb_stream_destroy(stream);
-  cubeb_destroy(ctx);
 
   ASSERT_TRUE(user_data->position);
 


### PR DESCRIPTION
Apply RAII helpers for cubeb context and stream in most test cases but leaving test_sanity for explicit flow control.