### PR TITLE
Using gtest style's error message in cubeb

### DIFF
--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -84,10 +84,7 @@ TEST(cubeb, duplex)
   uint32_t latency_frames = 0;
 
   r = cubeb_init(&ctx, "Cubeb duplex example", NULL);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb library\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
@@ -109,19 +106,12 @@ TEST(cubeb, duplex)
   output_params.layout = CUBEB_LAYOUT_STEREO;
 
   r = cubeb_get_min_latency(ctx, output_params, &latency_frames);
-
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Could not get minimal latency\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Could not get minimal latency";
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb duplex",
                         NULL, &input_params, NULL, &output_params,
                         latency_frames, data_cb_duplex, state_cb_duplex, &stream_state);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb stream\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
 
   std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
     cleanup_stream_at_exit(stream, cubeb_stream_destroy);

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -61,13 +61,13 @@ void state_cb_duplex(cubeb_stream * stream, void * /*user*/, cubeb_state state)
 
   switch (state) {
   case CUBEB_STATE_STARTED:
-    printf("stream started\n"); break;
+    fprintf(stderr, "stream started\n"); break;
   case CUBEB_STATE_STOPPED:
-    printf("stream stopped\n"); break;
+    fprintf(stderr, "stream stopped\n"); break;
   case CUBEB_STATE_DRAINED:
-    printf("stream drained\n"); break;
+    fprintf(stderr, "stream drained\n"); break;
   default:
-    printf("unknown stream state %d\n", state);
+    fprintf(stderr, "unknown stream state %d\n", state);
   }
 
   return;

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -153,7 +153,7 @@ downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_l
         out_layout >= CUBEB_LAYOUT_MONO && out_layout <= CUBEB_LAYOUT_2F2_LFE) {
       auto & downmix_results = DOWNMIX_3F2_RESULTS[in_layout - CUBEB_LAYOUT_3F2][out_layout - CUBEB_LAYOUT_MONO];
       fprintf(stderr, "[3f2] Expect: %lf, Get: %lf\n", downmix_results[index], out[index]);
-      ASSERT_EQ(out[index], downmix_results[index]);
+      ASSERT_EQ(downmix_results[index], out[index]);
       continue;
     }
 
@@ -161,13 +161,13 @@ downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_l
     if (out_layout_mask & in_layout_mask) {
       uint32_t mask = 1 << CHANNEL_INDEX_TO_ORDER[out_layout][index];
       fprintf(stderr, "[map channels] Expect: %lf, Get: %lf\n", (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[index]);
-      ASSERT_EQ(out[index], (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0);
+      ASSERT_EQ((mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[index]);
       continue;
     }
 
     // downmix_fallback
     fprintf(stderr, "[fallback] Expect: %lf, Get: %lf\n", audio_inputs[in_layout].data[index], out[index]);
-    ASSERT_EQ(out[index], audio_inputs[in_layout].data[index]);
+    ASSERT_EQ(audio_inputs[in_layout].data[index], out[index]);
   }
 }
 

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -78,10 +78,7 @@ TEST(cubeb, record)
   user_state_record stream_state = { false };
 
   r = cubeb_init(&ctx, "Cubeb record example", NULL);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb library\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
@@ -99,10 +96,7 @@ TEST(cubeb, record)
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb record (mono)", NULL, &params, NULL, nullptr,
                         4096, data_cb_record, state_cb_record, &stream_state);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb stream\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
 
   std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
     cleanup_stream_at_exit(stream, cubeb_stream_destroy);

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -54,13 +54,13 @@ void state_cb_record(cubeb_stream * stream, void * /*user*/, cubeb_state state)
 
   switch (state) {
   case CUBEB_STATE_STARTED:
-    printf("stream started\n"); break;
+    fprintf(stderr, "stream started\n"); break;
   case CUBEB_STATE_STOPPED:
-    printf("stream stopped\n"); break;
+    fprintf(stderr, "stream stopped\n"); break;
   case CUBEB_STATE_DRAINED:
-    printf("stream drained\n"); break;
+    fprintf(stderr, "stream drained\n"); break;
   default:
-    printf("unknown stream state %d\n", state);
+    fprintf(stderr, "unknown stream state %d\n", state);
   }
 
   return;
@@ -69,7 +69,7 @@ void state_cb_record(cubeb_stream * stream, void * /*user*/, cubeb_state state)
 TEST(cubeb, record)
 {
   if (cubeb_set_log_callback(CUBEB_LOG_DISABLED, nullptr /*print_log*/) != CUBEB_OK) {
-    printf("Set log callback failed\n");
+    fprintf(stderr, "Set log callback failed\n");
   }
   cubeb *ctx;
   cubeb_stream *stream;
@@ -113,7 +113,7 @@ TEST(cubeb, record)
 
 #ifdef __linux__
   // user callback does not arrive in Linux, silence the error
-  printf("Check is disabled in Linux\n");
+  fprintf(stderr, "Check is disabled in Linux\n");
 #else
   ASSERT_TRUE(stream_state.seen_audio);
 #endif

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -410,7 +410,7 @@ TEST(cubeb, resampler_one_way)
     for (uint32_t source_rate = 0; source_rate < array_size(sample_rates); source_rate++) {
       for (uint32_t dest_rate = 0; dest_rate < array_size(sample_rates); dest_rate++) {
         for (uint32_t chunk_duration = min_chunks; chunk_duration < max_chunks; chunk_duration+=chunk_increment) {
-          printf("one_way: channels: %d, source_rate: %d, dest_rate: %d, chunk_duration: %d\n",
+          fprintf(stderr, "one_way: channels: %d, source_rate: %d, dest_rate: %d, chunk_duration: %d\n",
                   channels, sample_rates[source_rate], sample_rates[dest_rate], chunk_duration);
           test_resampler_one_way<float>(channels, sample_rates[source_rate],
                                         sample_rates[dest_rate], chunk_duration);
@@ -428,7 +428,7 @@ TEST(cubeb, DISABLED_resampler_duplex)
         for (uint32_t source_rate_output = 0; source_rate_output < array_size(sample_rates); source_rate_output++) {
           for (uint32_t dest_rate = 0; dest_rate < array_size(sample_rates); dest_rate++) {
             for (uint32_t chunk_duration = min_chunks; chunk_duration < max_chunks; chunk_duration+=chunk_increment) {
-              printf("input channels:%d output_channels:%d input_rate:%d "
+              fprintf(stderr, "input channels:%d output_channels:%d input_rate:%d "
                      "output_rate:%d target_rate:%d chunk_ms:%d\n",
                      input_channels, output_channels,
                      sample_rates[source_rate_input],
@@ -453,7 +453,7 @@ TEST(cubeb, resampler_delay_line)
   for (uint32_t channel = 1; channel <= 2; channel++) {
     for (uint32_t delay_frames = 4; delay_frames <= 40; delay_frames+=chunk_increment) {
       for (uint32_t chunk_size = 10; chunk_size <= 30; chunk_size++) {
-       printf("channel: %d, delay_frames: %d, chunk_size: %d\n",
+       fprintf(stderr, "channel: %d, delay_frames: %d, chunk_size: %d\n",
               channel, delay_frames, chunk_size);
         test_delay_lines(delay_frames, channel, chunk_size);
       }

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -28,7 +28,7 @@
 int is_windows_7()
 {
 #ifdef __MINGW32__
-  printf("Warning: this test was built with MinGW.\n"
+  fprintf(stderr, "Warning: this test was built with MinGW.\n"
          "MinGW does not contain necessary version checking infrastructure. Claiming to be Windows 7, even if we're not.\n");
   return 1;
 #endif

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -82,13 +82,13 @@ void state_cb_tone(cubeb_stream *stream, void *user, cubeb_state state)
 
   switch (state) {
   case CUBEB_STATE_STARTED:
-    printf("stream started\n"); break;
+    fprintf(stderr, "stream started\n"); break;
   case CUBEB_STATE_STOPPED:
-    printf("stream stopped\n"); break;
+    fprintf(stderr, "stream stopped\n"); break;
   case CUBEB_STATE_DRAINED:
-    printf("stream drained\n"); break;
+    fprintf(stderr, "stream drained\n"); break;
   default:
-    printf("unknown stream state %d\n", state);
+    fprintf(stderr, "unknown stream state %d\n", state);
   }
 
   return;

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -103,10 +103,7 @@ TEST(cubeb, tone)
   int r;
 
   r = cubeb_init(&ctx, "Cubeb tone example", NULL);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb library\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
@@ -117,18 +114,13 @@ TEST(cubeb, tone)
   params.layout = CUBEB_LAYOUT_MONO;
 
   user_data = (struct cb_user_data *) malloc(sizeof(*user_data));
-  if (user_data == NULL) {
-    fprintf(stderr, "Error allocating user data\n");
-    FAIL();
-  }
+  ASSERT_NE(user_data, nullptr) << "Error allocating user data";
+
   user_data->position = 0;
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb tone (mono)", NULL, NULL, NULL, &params,
                         4096, data_cb_tone, state_cb_tone, user_data);
-  if (r != CUBEB_OK) {
-    fprintf(stderr, "Error initializing cubeb stream\n");
-    ASSERT_EQ(r, CUBEB_OK);
-  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
 
   std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
     cleanup_stream_at_exit(stream, cubeb_stream_destroy);

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -99,7 +99,6 @@ TEST(cubeb, tone)
   cubeb *ctx;
   cubeb_stream *stream;
   cubeb_stream_params params;
-  struct cb_user_data *user_data;
   int r;
 
   r = cubeb_init(&ctx, "Cubeb tone example", NULL);
@@ -113,13 +112,14 @@ TEST(cubeb, tone)
   params.channels = 1;
   params.layout = CUBEB_LAYOUT_MONO;
 
-  user_data = (struct cb_user_data *) malloc(sizeof(*user_data));
-  ASSERT_NE(user_data, nullptr) << "Error allocating user data";
+  std::unique_ptr<struct cb_user_data, decltype(&free)>
+    user_data((struct cb_user_data *)calloc(1, sizeof(struct cb_user_data)), free);
+  ASSERT_TRUE(!!user_data) << "Error allocating user data";
 
   user_data->position = 0;
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb tone (mono)", NULL, NULL, NULL, &params,
-                        4096, data_cb_tone, state_cb_tone, user_data);
+                        4096, data_cb_tone, state_cb_tone, user_data.get());
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
 
   std::unique_ptr<cubeb_stream, decltype(&cubeb_stream_destroy)>
@@ -130,6 +130,4 @@ TEST(cubeb, tone)
   cubeb_stream_stop(stream);
 
   ASSERT_TRUE(user_data->position);
-
-  free(user_data);
 }


### PR DESCRIPTION
- Perfer ```fprintf(stderr, ...)``` instead of ```printf(...)```
- Turn the error message into gtest's style

We have many patterns like the following:
```
if (r != CUBEB_OK) {
    fprintf(stderr, "Error initializing cubeb stream\n");
    ASSERT_EQ(r, CUBEB_OK);
}
```
We should replace them by:
```
ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
```