### PR TITLE
Get channel mapping when AudioChannelLayout's tag is not UseChannelDescriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(USE_AUDIOUNIT)
     src/cubeb_audiounit.cpp
     src/cubeb_osx_run_loop.cpp)
   target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT)
-  target_link_libraries(cubeb PRIVATE "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
+  target_link_libraries(cubeb PRIVATE "-framework AudioToolbox" "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
 endif()
 
 check_include_files(pulse/pulseaudio.h USE_PULSE)


### PR DESCRIPTION
For now, we can only read the channel layout when AudioChannelLayout's tag is ```kAudioChannelLayoutTag_UseChannelDescriptions```. We should get the layout mapping no matter what tag value is.