### PR TITLE
wasapi: Implement S16NE-format streams

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -318,15 +318,24 @@ cubeb_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_n
     return r;
   }
 
-  return context->ops->stream_init(context, stream, stream_name,
-                                   input_device,
-                                   input_stream_params,
-                                   output_device,
-                                   output_stream_params,
-                                   latency,
-                                   data_callback,
-                                   state_callback,
-                                   user_ptr);
+  r = context->ops->stream_init(context, stream, stream_name,
+                                input_device,
+                                input_stream_params,
+                                output_device,
+                                output_stream_params,
+                                latency,
+                                data_callback,
+                                state_callback,
+                                user_ptr);
+
+  if (r == CUBEB_ERROR_INVALID_FORMAT) {
+    LOG("Invalid format, %p %p %d %d",
+        output_stream_params, input_stream_params,
+        output_stream_params && output_stream_params->format,
+        input_stream_params && input_stream_params->format);
+  }
+
+  return r;
 }
 
 void

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -468,6 +468,14 @@ cubeb_downmix_short(short * const in, long inframes, short * out,
   cubeb_downmix(in, inframes, out, in_channels, out_channels, in_layout, out_layout);
 }
 
+
+void
+cubeb_upmix_short(short * const in, long inframes, short * out,
+                  unsigned int in_channels, unsigned int out_channels)
+{
+  cubeb_upmix(in, inframes, out, in_channels, out_channels);
+}
+
 void
 cubeb_upmix_float(float * const in, long inframes, float * out,
                   unsigned int in_channels, unsigned int out_channels)

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -446,6 +446,12 @@ cubeb_should_downmix(cubeb_stream_params const * stream, cubeb_stream_params con
            mixer->layout == CUBEB_LAYOUT_3F1_LFE));
 }
 
+bool
+cubeb_should_mix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer)
+{
+  return cubeb_should_upmix(stream, mixer) || cubeb_should_downmix(stream, mixer);
+}
+
 void
 cubeb_downmix_float(float * const in, long inframes, float * out,
                     unsigned int in_channels, unsigned int out_channels,

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -63,6 +63,8 @@ bool cubeb_should_upmix(cubeb_stream_params const * stream, cubeb_stream_params 
 
 bool cubeb_should_downmix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);
 
+bool cubeb_should_mix(cubeb_stream_params const * stream, cubeb_stream_params const * mixer);
+
 void cubeb_downmix_float(float * const in, long inframes, float * out,
                          unsigned int in_channels, unsigned int out_channels,
                          cubeb_channel_layout in_layout, cubeb_channel_layout out_layout);

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -76,6 +76,11 @@ void cubeb_downmix_short(short * const in, long inframes, short * out,
 void cubeb_upmix_float(float * const in, long inframes, float * out,
                        unsigned int in_channels, unsigned int out_channels);
 
+void cubeb_upmix_short(short * const in, long inframes, short * out,
+                       unsigned int in_channels, unsigned int out_channels);
+
+
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -259,6 +259,54 @@ private:
   size_t length_;
 };
 
+struct auto_array_wrapper {
+  virtual void push(void * elements, size_t length) = 0;
+  virtual size_t length() = 0;
+  virtual void push_silence(size_t length) = 0;
+  virtual bool pop(size_t length) = 0;
+  virtual void * data() = 0;
+  virtual void clear() = 0;
+  virtual ~auto_array_wrapper() {}
+};
+
+template <typename T>
+struct auto_array_wrapper_impl : public auto_array_wrapper {
+  explicit auto_array_wrapper_impl(uint32_t size)
+    : ar(size)
+  {}
+
+  void push(void * elements, size_t length) override {
+    ar.push(static_cast<T *>(elements), length);
+  }
+
+  size_t length() override {
+    return ar.length();
+  }
+
+  void push_silence(size_t length) override {
+    ar.push_silence(length);
+  }
+
+  bool pop(size_t length) override {
+    return ar.pop(nullptr, length);
+  }
+
+  void * data() override {
+    return ar.data();
+  }
+
+  void clear() override {
+    ar.clear();
+  }
+
+  ~auto_array_wrapper_impl() {
+    ar.clear();
+  }
+
+private:
+  auto_array<T> ar;
+};
+
 using auto_lock = std::lock_guard<owned_critical_section>;
 
 #endif /* CUBEB_UTILS */

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -124,6 +124,11 @@ public:
     return data_;
   }
 
+  T * end() const
+  {
+    return data_ + length_;
+  }
+
   const T& at(size_t index) const
   {
     assert(index < length_ && "out of range");
@@ -265,12 +270,17 @@ struct auto_array_wrapper {
   virtual void push_silence(size_t length) = 0;
   virtual bool pop(size_t length) = 0;
   virtual void * data() = 0;
+  virtual void * end() = 0;
   virtual void clear() = 0;
+  virtual bool reserve(size_t capacity) = 0;
+  virtual void set_length(size_t length) = 0;
   virtual ~auto_array_wrapper() {}
 };
 
 template <typename T>
 struct auto_array_wrapper_impl : public auto_array_wrapper {
+  auto_array_wrapper_impl() {}
+
   explicit auto_array_wrapper_impl(uint32_t size)
     : ar(size)
   {}
@@ -295,8 +305,20 @@ struct auto_array_wrapper_impl : public auto_array_wrapper {
     return ar.data();
   }
 
+  void * end() override {
+    return ar.end();
+  }
+
   void clear() override {
     ar.clear();
+  }
+
+  bool reserve(size_t capacity) override {
+    return ar.reserve(capacity);
+  }
+
+  void set_length(size_t length) override {
+    ar.set_length(length);
   }
 
   ~auto_array_wrapper_impl() {

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1771,10 +1771,6 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   if ((output_stream_params && output_stream_params->format != CUBEB_SAMPLE_FLOAT32NE) ||
       (input_stream_params && input_stream_params->format != CUBEB_SAMPLE_FLOAT32NE)) {
-    LOG("Invalid format, %p %p %d %d",
-        output_stream_params, input_stream_params,
-        output_stream_params && output_stream_params->format,
-        input_stream_params && input_stream_params->format);
     return CUBEB_ERROR_INVALID_FORMAT;
   }
 

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -87,12 +87,6 @@ int supports_float32(string backend_id)
     && backend_id != "audiotrack";
 }
 
-/* The WASAPI backend only supports float. */
-int supports_int16(string backend_id)
-{
-  return backend_id != "wasapi";
-}
-
 /* Some backends don't have code to deal with more than mono or stereo. */
 int supports_channel_count(string backend_id, int nchannels)
 {
@@ -117,7 +111,6 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
   const char * backend_id = cubeb_get_backend_id(ctx);
 
   if ((is_float && !supports_float32(backend_id)) ||
-      (!is_float && !supports_int16(backend_id)) ||
       !supports_channel_count(backend_id, num_channels)) {
     /* don't treat this as a test failure. */
     return CUBEB_OK;
@@ -168,8 +161,7 @@ int run_panning_volume_test(int is_float)
 
   const char * backend_id = cubeb_get_backend_id(ctx);
 
-  if ((is_float && !supports_float32(backend_id)) ||
-      (!is_float && !supports_int16(backend_id))) {
+  if ((is_float && !supports_float32(backend_id))) {
     /* don't treat this as a test failure. */
     return CUBEB_OK;
   }

--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -18,11 +18,7 @@
 #include "common.h"
 
 #define SAMPLE_FREQUENCY 48000
-#if (defined(_WIN32) || defined(__WIN32__))
-#define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
-#else
 #define STREAM_FORMAT CUBEB_SAMPLE_S16LE
-#endif
 
 std::atomic<bool> load_callback{ false };
 

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -19,11 +19,7 @@
 #define STREAM_LATENCY 100 * STREAM_RATE / 1000
 #define STREAM_CHANNELS 1
 #define STREAM_LAYOUT CUBEB_LAYOUT_MONO
-#if (defined(_WIN32) || defined(__WIN32__))
-#define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
-#else
 #define STREAM_FORMAT CUBEB_SAMPLE_S16LE
-#endif
 
 int is_windows_7()
 {
@@ -61,11 +57,7 @@ test_data_callback(cubeb_stream * stm, void * user_ptr, const void * /*inputbuff
 {
   EXPECT_TRUE(stm && user_ptr == &dummy && outputbuffer && nframes > 0);
   assert(outputbuffer);
-#if (defined(_WIN32) || defined(__WIN32__))
-  memset(outputbuffer, 0, nframes * sizeof(float));
-#else
   memset(outputbuffer, 0, nframes * sizeof(short));
-#endif
 
   total_frames_written += nframes;
   if (delay_callback) {
@@ -545,11 +537,7 @@ test_drain_data_callback(cubeb_stream * stm, void * user_ptr, const void * /*inp
   }
   /* once drain has started, callback must never be called again */
   EXPECT_TRUE(do_drain != 2);
-#if (defined(_WIN32) || defined(__WIN32__))
-  memset(outputbuffer, 0, nframes * sizeof(float));
-#else
   memset(outputbuffer, 0, nframes * sizeof(short));
-#endif
   total_frames_written += nframes;
   return nframes;
 }

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -19,11 +19,7 @@
 #include "common.h"
 
 #define SAMPLE_FREQUENCY 48000
-#if (defined(_WIN32) || defined(__WIN32__))
-#define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
-#else
 #define STREAM_FORMAT CUBEB_SAMPLE_S16LE
-#endif
 
 /* store the phase of the generated waveform */
 struct cb_user_data {
@@ -33,11 +29,7 @@ struct cb_user_data {
 long data_cb_tone(cubeb_stream *stream, void *user, const void* /*inputbuffer*/, void *outputbuffer, long nframes)
 {
   struct cb_user_data *u = (struct cb_user_data *)user;
-#if (defined(_WIN32) || defined(__WIN32__))
-  float *b = (float *)outputbuffer;
-#else
   short *b = (short *)outputbuffer;
-#endif
   float t1, t2;
   int i;
 
@@ -49,21 +41,12 @@ long data_cb_tone(cubeb_stream *stream, void *user, const void* /*inputbuffer*/,
     /* North American dial tone */
     t1 = sin(2*M_PI*(i + u->position)*350/SAMPLE_FREQUENCY);
     t2 = sin(2*M_PI*(i + u->position)*440/SAMPLE_FREQUENCY);
-#if (defined(_WIN32) || defined(__WIN32__))
-    b[i]  = 0.5 * t1;
-    b[i] += 0.5 * t2;
-#else
     b[i]  = (SHRT_MAX / 2) * t1;
     b[i] += (SHRT_MAX / 2) * t2;
-#endif
     /* European dial tone */
     /*
     t1 = sin(2*M_PI*(i + u->position)*425/SAMPLE_FREQUENCY);
-#if (defined(_WIN32) || defined(__WIN32__))
-    b[i] = t1;
-#else
     b[i]  = SHRT_MAX * t1;
-#endif
     */
   }
   /* remember our phase to avoid clicking on buffer transitions */


### PR DESCRIPTION
Brings the WASAPI backend up to parity with the other backends, making it easier to write cross-platform code for S16 audio. I tried to base my approach off of the AudioUnit backend (in fact, `auto_array_wrapper` is now in cubeb_utils and used by both) and a little bit from the Jack backend (the `bytes_per_sample` member).

The official documentation is (purposefully?) obtuse as to when S16 is a supported format, but it seems to hint that it's always available in non-exclusive  mode, and the rest of the internet seems to believe that that's true.