### PR TITLE
cubeb_sndio: Fix leak in sndio_stream_init() failure case

### DIFF
--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -217,6 +217,8 @@ sndio_stream_init(cubeb * context,
     wpar.le = SIO_LE_NATIVE;
     break;
   default:
+    sio_close(s->hdl);
+    free(s);
     DPR("sndio_stream_init() unsupported format\n");
     return CUBEB_ERROR_INVALID_FORMAT;
   }


### PR DESCRIPTION
Fairly unlikely to happen, but may as well cover all bases anyways.