### PR TITLE
Enable multichannel recording if it's hardware-supported

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1556,11 +1556,6 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
    * use the default setting retrieved from the stream format of the audio
    * engine's internal processing by GetMixFormat. */
   if (mix_format->nChannels > 2) {
-    /* Currently, we only support mono and stereo for capture stream. */
-    if (direction == eCapture) {
-      XASSERT(false && "Multichannel recording is not supported.");
-    }
-
     handle_channel_layout(stm, mix_format, stream_params);
   }
 


### PR DESCRIPTION
The ```mix_format``` returned from ```IAudioClient::GetMixFormat``` is the hardware-supported format for the stream, so we should not crash the stream on purpose if the user's audio sound card supports N-channel recording, where N > 2.

If we intend to crash a N-channel recording stream, we should check ```stream_params->channels``` instead of ```mix_format->nChannels```.