### PR TITLE
Make cubeb work with high channel count devices

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -225,7 +225,7 @@ channel_label_to_cubeb_channel(UInt32 label)
     case kAudioChannelLabel_RearSurroundLeft: return CHANNEL_RLS;
     case kAudioChannelLabel_RearSurroundRight: return CHANNEL_RRS;
     case kAudioChannelLabel_CenterSurround: return CHANNEL_RCENTER;
-    case kAudioChannelLayoutTag_Unknown: return CHANNEL_UNMAPPED;
+    case kAudioChannelLabel_Unknown: return CHANNEL_UNMAPPED;
     default: return CHANNEL_INVALID;
   }
 }
@@ -244,7 +244,7 @@ cubeb_channel_to_channel_label(cubeb_channel channel)
     case CHANNEL_RLS: return kAudioChannelLabel_RearSurroundLeft;
     case CHANNEL_RRS: return kAudioChannelLabel_RearSurroundRight;
     case CHANNEL_RCENTER: return kAudioChannelLabel_CenterSurround;
-    case CHANNEL_UNMAPPED: return kAudioChannelLayoutTag_Unknown;
+    case CHANNEL_UNMAPPED: return kAudioChannelLabel_Unknown;
     default: return kAudioChannelLabel_Unknown;
   }
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -225,6 +225,7 @@ channel_label_to_cubeb_channel(UInt32 label)
     case kAudioChannelLabel_RearSurroundLeft: return CHANNEL_RLS;
     case kAudioChannelLabel_RearSurroundRight: return CHANNEL_RRS;
     case kAudioChannelLabel_CenterSurround: return CHANNEL_RCENTER;
+    case kAudioChannelLayoutTag_Unknown: return CHANNEL_UNMAPPED;
     default: return CHANNEL_INVALID;
   }
 }
@@ -243,6 +244,7 @@ cubeb_channel_to_channel_label(cubeb_channel channel)
     case CHANNEL_RLS: return kAudioChannelLabel_RearSurroundLeft;
     case CHANNEL_RRS: return kAudioChannelLabel_RearSurroundRight;
     case CHANNEL_RCENTER: return kAudioChannelLabel_CenterSurround;
+    case CHANNEL_UNMAPPED: return kAudioChannelLayoutTag_Unknown;
     default: return kAudioChannelLabel_Unknown;
   }
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1088,6 +1088,12 @@ audiounit_convert_channel_layout(AudioChannelLayout * layout)
     return CUBEB_LAYOUT_UNDEFINED;
   }
 
+  // This devices has more channels that we can support, bail out.
+  if (layout->mNumberChannelDescriptions >= CHANNEL_MAX) {
+    LOG("Audio device has more than %d channels, bailing out.", CHANNEL_MAX);
+    return CUBEB_LAYOUT_UNDEFINED;
+  }
+
   cubeb_channel_map cm;
   cm.channels = layout->mNumberChannelDescriptions;
   for (UInt32 i = 0; i < layout->mNumberChannelDescriptions; ++i) {

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -31,7 +31,8 @@ cubeb_channel_layout cubeb_channel_map_to_layout(cubeb_channel_map const * chann
 {
   uint32_t channel_mask = 0;
   for (uint8_t i = 0 ; i < channel_map->channels ; ++i) {
-    if (channel_map->map[i] == CHANNEL_INVALID) {
+    if (channel_map->map[i] == CHANNEL_INVALID ||
+        channel_map->map[i] == CHANNEL_UNMAPPED) {
       return CUBEB_LAYOUT_UNDEFINED;
     }
     channel_mask |= 1 << channel_map->map[i];

--- a/src/cubeb_mixer.h
+++ b/src/cubeb_mixer.h
@@ -27,7 +27,8 @@ typedef enum {
   CHANNEL_RCENTER,
   CHANNEL_RRS,
   CHANNEL_LFE,
-  CHANNEL_MAX // Max number of supported channels.
+  CHANNEL_UNMAPPED,
+  CHANNEL_MAX = 256 // Max number of supported channels.
 } cubeb_channel;
 
 static cubeb_channel const CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX] = {
@@ -50,6 +51,8 @@ static cubeb_channel const CHANNEL_INDEX_TO_ORDER[CUBEB_LAYOUT_MAX][CHANNEL_MAX]
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_LS, CHANNEL_RS },                           // 3F2_LFE
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RCENTER, CHANNEL_LS, CHANNEL_RS },          // 3F3R_LFE
   { CHANNEL_LEFT, CHANNEL_RIGHT, CHANNEL_CENTER, CHANNEL_LFE, CHANNEL_RLS, CHANNEL_RRS, CHANNEL_LS, CHANNEL_RS }  // 3F4_LFE
+  // When more channels are present, the stream is considered unmapped to a
+  // particular speaker set.
 };
 
 typedef struct {


### PR DESCRIPTION
Without this, trying to play audio on a device that has more than 8 output channels trashes some memory and crashes.

With this patch we can use [SoundFlower](https://github.com/mattingalls/Soundflower/releases) to test multi-channel support, and to do nice things like, generating audio in a fake input device, recording the output device using another program test, etc. 

@ChunMinChang, want to have a look ? I plan to do the same for Windows after this, reading the code, it must have the same issue. I will have my windows machine next week, though.