### PR TITLE
Fix crash while switching device

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1881,8 +1881,6 @@ void close_wasapi_stream(cubeb_stream * stm)
   stm->resampler.reset();
 
   stm->mix_buffer.clear();
-  stm->mixing.reset();
-  stm->linear_input_buffer.reset();
 }
 
 void wasapi_stream_destroy(cubeb_stream * stm)
@@ -1902,6 +1900,11 @@ void wasapi_stream_destroy(cubeb_stream * stm)
   CloseHandle(stm->reconfigure_event);
   CloseHandle(stm->refill_event);
   CloseHandle(stm->input_available_event);
+
+  // The variables intialized in wasapi_stream_init,
+  // must be destroyed in wasapi_stream_destroy.
+  stm->mixing.reset();
+  stm->linear_input_buffer.reset();
 
   {
     auto_lock lock(stm->stream_reset_lock);


### PR DESCRIPTION
The ```close_wasapi_stream``` and ```setup_wasapi_stream``` will be fired on a device change. Originally, we initialized ```stm->mixing``` in ```wasapi_stream_init``` and destroy them in ```close_wasapi_stream```. Thus, the ```stm->mixing``` will be **nulled** upon device is changed, while the stream is still playing, and the crash happens when we use a nulled ```stm->mixing``` to up/downmix audio.
