### PR TITLE
Return an error if stopping a WASAPI stream fails.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1993,6 +1993,10 @@ int wasapi_stream_stop(cubeb_stream * stm)
       delete stm->emergency_bailout.load();
       stm->emergency_bailout = nullptr;
     }
+  } else {
+    // If we could not join the thread, put the stream in error.
+    stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
+    return CUBEB_ERROR;
   }
 
   return CUBEB_OK;


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1358868#c4 for the rational behind this.