### PR TITLE
Add debugging info for setting channel layout

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1278,6 +1278,7 @@ audiounit_set_channel_layout(AudioUnit unit,
   OSStatus r;
   size_t size = sizeof(AudioChannelLayout);
   auto layout = make_sized_audio_channel_layout(size);
+  assert(!layout->mChannelLayoutTag);
 
   switch (stream_params->layout) {
     case CUBEB_LAYOUT_DUAL_MONO:
@@ -1315,11 +1316,15 @@ audiounit_set_channel_layout(AudioUnit unit,
   if (layout->mChannelLayoutTag == kAudioChannelLayoutTag_Unknown) {
     size = offsetof(AudioChannelLayout, mChannelDescriptions[stream_params->channels]);
     layout = make_sized_audio_channel_layout(size);
+    assert(!layout->mChannelLayoutTag);
+    assert(!layout->mNumberChannelDescriptions);
     layout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
     layout->mNumberChannelDescriptions = stream_params->channels;
     for (UInt32 i = 0 ; i < stream_params->channels ; ++i) {
+      assert(!layout->mChannelDescriptions[i].mChannelLabel);
       layout->mChannelDescriptions[i].mChannelLabel =
         cubeb_channel_to_channel_label(CHANNEL_INDEX_TO_ORDER[stream_params->layout][i]);
+      assert(!layout->mChannelDescriptions[i].mChannelFlags);
       layout->mChannelDescriptions[i].mChannelFlags = kAudioChannelFlags_AllOff;
     }
   }

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -231,6 +231,8 @@ TEST(cubeb, run_channel_rate_test)
     3,
     4,
     6,
+    7,
+    8,
   };
 
   int freq_values[] = {


### PR DESCRIPTION
To make sure we don't use the memory beyond our allocation, it's better to check the index of ```mChannelDescriptions``` and ```mChannelLayoutTag``` are initialized before assigning data.

Also, we need to check cubeb can work with 8 channels input.