### PR TITLE
audiounit: volume and datasource fixes on reinit

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -615,7 +615,10 @@ audiounit_reinit_stream(cubeb_stream * stm)
   {
     auto_lock lock(stm->mutex);
     float volume = 0.0;
-    int vol_rv = audiounit_stream_get_volume(stm, &volume);
+    int vol_rv = CUBEB_ERROR;
+    if (has_output(stm)) {
+      vol_rv = audiounit_stream_get_volume(stm, &volume);
+    }
 
     audiounit_close_stream(stm);
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -680,11 +680,8 @@ audiounit_property_listener_callback(AudioObjectID /* id */, UInt32 address_coun
         break;
       case kAudioDevicePropertyDataSource: {
           LOG("Event[%u] - mSelector == kAudioHardwarePropertyDataSource", (unsigned int) i);
-          if (has_output(stm)) {
-              stm->output_device = 0;
-          }
+          return noErr;
         }
-        break;
       default:
         LOG("Event[%u] - mSelector == Unexpected Event id %d, return", (unsigned int) i, addresses[i].mSelector);
         return noErr;


### PR DESCRIPTION
1. Make sure there is an ouput unit when request volume on reinit. This prevent an assert on input only methods.

2. Don't reinit on datasource event. By testing I realized that the platform is able to handle the case more efficient than the manual reinit. The device ids of input and/or output remain the same. 