### PR TITLE
Push destroy fns to backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(cubeb
   src/cubeb_resampler.cpp
   src/cubeb_panner.cpp
   src/cubeb_log.cpp
+  src/cubeb_utils.c
    $<TARGET_OBJECTS:speex>)
 target_include_directories(cubeb PUBLIC include)
 target_include_directories(cubeb PRIVATE src)

--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -615,10 +615,12 @@ CUBEB_EXPORT int cubeb_enumerate_devices(cubeb * context,
                                          cubeb_device_collection ** collection);
 
 /** Destroy a cubeb_device_collection, and its `cubeb_device_info`.
+    @param context
     @param collection collection to destroy
     @retval CUBEB_OK
     @retval CUBEB_ERROR_INVALID_PARAMETER if collection is an invalid pointer */
-CUBEB_EXPORT int cubeb_device_collection_destroy(cubeb_device_collection * collection);
+CUBEB_EXPORT int cubeb_device_collection_destroy(cubeb * context,
+                                                 cubeb_device_collection * collection);
 
 /** Registers a callback which is called when the system detects
     a new device or a device is removed.

--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -330,9 +330,10 @@ typedef enum {
 } cubeb_device_pref;
 
 /** This structure holds the characteristics
- *  of an input or output audio device. It can be obtained using
- *  `cubeb_enumerate_devices`, and must be destroyed using
- *  `cubeb_device_info_destroy`. */
+ *  of an input or output audio device. It is obtained using
+ *  `cubeb_enumerate_devices`, which returns these structures via
+ *  `cubeb_device_collection` and must be destroyed via
+ *  `cubeb_device_collection_destroy`. */
 typedef struct {
   cubeb_devid devid;          /**< Device identifier handle. */
   char const * device_id;     /**< Device identifier which might be presented in a UI. */
@@ -355,10 +356,12 @@ typedef struct {
   unsigned int latency_hi; /**< Higest possible latency in frames. */
 } cubeb_device_info;
 
-/** Device collection. */
+/** Device collection.
+ *  Returned by `cubeb_enumerate_devices` and destroyed by
+ *  `cubeb_device_collection_destroy`. */
 typedef struct {
   uint32_t count;                 /**< Device count in collection. */
-  cubeb_device_info * device[1];   /**< Array of pointers to device info. */
+  cubeb_device_info * device[1];  /**< Array of pointers to device info. */
 } cubeb_device_collection;
 
 /** User supplied data callback.
@@ -616,12 +619,6 @@ CUBEB_EXPORT int cubeb_enumerate_devices(cubeb * context,
     @retval CUBEB_OK
     @retval CUBEB_ERROR_INVALID_PARAMETER if collection is an invalid pointer */
 CUBEB_EXPORT int cubeb_device_collection_destroy(cubeb_device_collection * collection);
-
-/** Destroy a cubeb_device_info structure.
-    @param info pointer to device info structure
-    @retval CUBEB_OK
-    @retval CUBEB_ERROR_INVALID_PARAMETER if info is an invalid pointer */
-CUBEB_EXPORT int cubeb_device_info_destroy(cubeb_device_info * info);
 
 /** Registers a callback which is called when the system detects
     a new device or a device is removed.

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -52,6 +52,7 @@ struct cubeb_ops {
   int (* get_preferred_channel_layout)(cubeb * context, cubeb_channel_layout * layout);
   int (* enumerate_devices)(cubeb * context, cubeb_device_type type,
                             cubeb_device_collection ** collection);
+  int (* device_collection_destroy)(cubeb * context, cubeb_device_collection * collection);
   void (* destroy)(cubeb * context);
   int (* stream_init)(cubeb * context,
                       cubeb_stream ** stream,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -571,12 +571,16 @@ int cubeb_enumerate_devices(cubeb * context,
   return rv;
 }
 
-int cubeb_device_collection_destroy(cubeb_device_collection * collection)
+int cubeb_device_collection_destroy(cubeb * context,
+                                    cubeb_device_collection * collection)
 {
-  if (collection == NULL)
+  if (context == NULL || collection == NULL)
     return CUBEB_ERROR_INVALID_PARAMETER;
 
-  return cubeb_utils_default_device_collection_destroy(collection);
+  if (!context->ops->device_collection_destroy)
+    return CUBEB_ERROR_NOT_SUPPORTED;
+
+  return context->ops->device_collection_destroy(context, collection);
 }
 
 int cubeb_register_device_collection_changed(cubeb * context,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -571,31 +571,12 @@ int cubeb_enumerate_devices(cubeb * context,
   return rv;
 }
 
-static void
-cubeb_device_info_destroy(cubeb_device_info * info)
-{
-  XASSERT(info);
-
-  free((void *) info->device_id);
-  free((void *) info->friendly_name);
-  free((void *) info->group_id);
-  free((void *) info->vendor_name);
-
-  free(info);
-}
-
 int cubeb_device_collection_destroy(cubeb_device_collection * collection)
 {
-  uint32_t i;
-
   if (collection == NULL)
     return CUBEB_ERROR_INVALID_PARAMETER;
 
-  for (i = 0; i < collection->count; i++)
-    cubeb_device_info_destroy(collection->device[i]);
-
-  free(collection);
-  return CUBEB_OK;
+  return cubeb_utils_default_device_collection_destroy(collection);
 }
 
 int cubeb_register_device_collection_changed(cubeb * context,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -571,6 +571,19 @@ int cubeb_enumerate_devices(cubeb * context,
   return rv;
 }
 
+static void
+cubeb_device_info_destroy(cubeb_device_info * info)
+{
+  XASSERT(info);
+
+  free((void *) info->device_id);
+  free((void *) info->friendly_name);
+  free((void *) info->group_id);
+  free((void *) info->vendor_name);
+
+  free(info);
+}
+
 int cubeb_device_collection_destroy(cubeb_device_collection * collection)
 {
   uint32_t i;
@@ -582,21 +595,6 @@ int cubeb_device_collection_destroy(cubeb_device_collection * collection)
     cubeb_device_info_destroy(collection->device[i]);
 
   free(collection);
-  return CUBEB_OK;
-}
-
-int cubeb_device_info_destroy(cubeb_device_info * info)
-{
-  if (info == NULL) {
-    return CUBEB_ERROR_INVALID_PARAMETER;
-  }
-
-  free((void *) info->device_id);
-  free((void *) info->friendly_name);
-  free((void *) info->group_id);
-  free((void *) info->vendor_name);
-
-  free(info);
   return CUBEB_OK;
 }
 

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -17,6 +17,7 @@
 #include <alsa/asoundlib.h>
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
+#include "cubeb_utils.h"
 
 #define CUBEB_STREAM_MAX 16
 #define CUBEB_WATCHDOG_MS 10000
@@ -1342,6 +1343,7 @@ static struct cubeb_ops const alsa_ops = {
   .get_preferred_sample_rate = alsa_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = alsa_enumerate_devices,
+  .device_collection_destroy = cubeb_utils_default_device_collection_destroy,
   .destroy = alsa_destroy,
   .stream_init = alsa_stream_init,
   .stream_destroy = alsa_stream_destroy,

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -423,6 +423,7 @@ static struct cubeb_ops const audiotrack_ops = {
   .get_preferred_sample_rate = audiotrack_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
+  .device_collection_destroy = NULL,
   .destroy = audiotrack_destroy,
   .stream_init = audiotrack_stream_init,
   .stream_destroy = audiotrack_stream_destroy,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3125,14 +3125,14 @@ audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
   }
 
   *collection = static_cast<cubeb_device_collection *>(malloc(sizeof(cubeb_device_collection) +
-                                                              sizeof(cubeb_device_info*) * (hwdevs.size() > 0 ? hwdevs.size() - 1 : 0)));
+							      sizeof(cubeb_device_info*) * (hwdevs.size() > 0 ? hwdevs.size() - 1 : 0)));
   (*collection)->count = 0;
 
   if (type & CUBEB_DEVICE_TYPE_OUTPUT) {
     for (i = 0; i < hwdevs.size(); i++) {
       cubeb_device_info * cur = audiounit_create_device_from_hwdev(hwdevs[i], CUBEB_DEVICE_TYPE_OUTPUT);
       if (cur != nullptr)
-        (*collection)->device[(*collection)->count++] = cur;
+	(*collection)->device[(*collection)->count++] = cur;
     }
   }
 
@@ -3140,7 +3140,7 @@ audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
     for (i = 0; i < hwdevs.size(); i++) {
       cubeb_device_info * cur = audiounit_create_device_from_hwdev(hwdevs[i], CUBEB_DEVICE_TYPE_INPUT);
       if (cur != nullptr)
-        (*collection)->device[(*collection)->count++] = cur;
+	(*collection)->device[(*collection)->count++] = cur;
     }
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3125,14 +3125,14 @@ audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
   }
 
   *collection = static_cast<cubeb_device_collection *>(malloc(sizeof(cubeb_device_collection) +
-							      sizeof(cubeb_device_info*) * (hwdevs.size() > 0 ? hwdevs.size() - 1 : 0)));
+                                                              sizeof(cubeb_device_info*) * (hwdevs.size() > 0 ? hwdevs.size() - 1 : 0)));
   (*collection)->count = 0;
 
   if (type & CUBEB_DEVICE_TYPE_OUTPUT) {
     for (i = 0; i < hwdevs.size(); i++) {
       cubeb_device_info * cur = audiounit_create_device_from_hwdev(hwdevs[i], CUBEB_DEVICE_TYPE_OUTPUT);
       if (cur != nullptr)
-	(*collection)->device[(*collection)->count++] = cur;
+        (*collection)->device[(*collection)->count++] = cur;
     }
   }
 
@@ -3140,7 +3140,7 @@ audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
     for (i = 0; i < hwdevs.size(); i++) {
       cubeb_device_info * cur = audiounit_create_device_from_hwdev(hwdevs[i], CUBEB_DEVICE_TYPE_INPUT);
       if (cur != nullptr)
-	(*collection)->device[(*collection)->count++] = cur;
+        (*collection)->device[(*collection)->count++] = cur;
     }
   }
 
@@ -3305,6 +3305,7 @@ cubeb_ops const audiounit_ops = {
   /*.get_preferred_sample_rate =*/ audiounit_get_preferred_sample_rate,
   /*.get_preferred_channel_layout =*/ audiounit_get_preferred_channel_layout,
   /*.enumerate_devices =*/ audiounit_enumerate_devices,
+  /*.device_collection_destroy =*/ cubeb_utils_default_device_collection_destroy,
   /*.destroy =*/ audiounit_destroy,
   /*.stream_init =*/ audiounit_stream_init,
   /*.stream_destroy =*/ audiounit_stream_destroy,

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -19,6 +19,7 @@
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
 #include "cubeb_resampler.h"
+#include "cubeb_utils.h"
 
 #include <jack/jack.h>
 #include <jack/statistics.h>
@@ -116,6 +117,7 @@ static struct cubeb_ops const cbjack_ops = {
   .get_preferred_sample_rate = cbjack_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = cbjack_enumerate_devices,
+  .device_collection_destroy = cubeb_utils_default_device_collection_destroy,
   .destroy = cbjack_destroy,
   .stream_init = cbjack_stream_init,
   .stream_destroy = cbjack_stream_destroy,

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -345,6 +345,7 @@ static struct cubeb_ops const kai_ops = {
   /*.get_preferred_sample_rate =*/ kai_get_preferred_sample_rate,
   /*.get_preferred_channel_layout =*/ NULL,
   /*.enumerate_devices =*/ NULL,
+  /*.device_collection_destroy =*/ NULL,
   /*.destroy =*/ kai_destroy,
   /*.stream_init =*/ kai_stream_init,
   /*.stream_destroy =*/ kai_stream_destroy,

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1740,6 +1740,7 @@ static struct cubeb_ops const opensl_ops = {
   .get_preferred_sample_rate = opensl_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
+  .device_collection_destroy = NULL,
   .destroy = opensl_destroy,
   .stream_init = opensl_stream_init,
   .stream_destroy = opensl_stream_destroy,

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1224,7 +1224,7 @@ pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
   devinfo->type = CUBEB_DEVICE_TYPE_OUTPUT;
   devinfo->state = pulse_get_state_from_sink_port(info->active_port);
   devinfo->preferred = (strcmp(info->name, list_data->default_sink_name) == 0) ?
-                                 CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
+				 CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
 
   devinfo->format = CUBEB_DEVICE_FMT_ALL;
   devinfo->default_format = pulse_format_to_cubeb_format(info->sample_spec.format);
@@ -1285,7 +1285,7 @@ pulse_source_info_cb(pa_context * context, const pa_source_info * info,
   devinfo->type = CUBEB_DEVICE_TYPE_INPUT;
   devinfo->state = pulse_get_state_from_source_port(info->active_port);
   devinfo->preferred = (strcmp(info->name, list_data->default_source_name) == 0) ?
-                                   CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
+				   CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
 
   devinfo->format = CUBEB_DEVICE_FMT_ALL;
   devinfo->default_format = pulse_format_to_cubeb_format(info->sample_spec.format);

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -13,6 +13,7 @@
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
 #include "cubeb_mixer.h"
+#include "cubeb_utils.h"
 #include <stdio.h>
 
 #ifdef DISABLE_LIBPULSE_DLOPEN
@@ -1223,7 +1224,7 @@ pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
   devinfo->type = CUBEB_DEVICE_TYPE_OUTPUT;
   devinfo->state = pulse_get_state_from_sink_port(info->active_port);
   devinfo->preferred = (strcmp(info->name, list_data->default_sink_name) == 0) ?
-				 CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
+                                 CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
 
   devinfo->format = CUBEB_DEVICE_FMT_ALL;
   devinfo->default_format = pulse_format_to_cubeb_format(info->sample_spec.format);
@@ -1284,7 +1285,7 @@ pulse_source_info_cb(pa_context * context, const pa_source_info * info,
   devinfo->type = CUBEB_DEVICE_TYPE_INPUT;
   devinfo->state = pulse_get_state_from_source_port(info->active_port);
   devinfo->preferred = (strcmp(info->name, list_data->default_source_name) == 0) ?
-				   CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
+                                   CUBEB_DEVICE_PREF_ALL : CUBEB_DEVICE_PREF_NONE;
 
   devinfo->format = CUBEB_DEVICE_FMT_ALL;
   devinfo->default_format = pulse_format_to_cubeb_format(info->sample_spec.format);
@@ -1495,6 +1496,7 @@ static struct cubeb_ops const pulse_ops = {
   .get_preferred_sample_rate = pulse_get_preferred_sample_rate,
   .get_preferred_channel_layout = pulse_get_preferred_channel_layout,
   .enumerate_devices = pulse_enumerate_devices,
+  .device_collection_destroy = cubeb_utils_default_device_collection_destroy,
   .destroy = pulse_destroy,
   .stream_init = pulse_stream_init,
   .stream_destroy = pulse_stream_destroy,

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -370,6 +370,7 @@ static struct cubeb_ops const sndio_ops = {
   .get_preferred_sample_rate = sndio_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = NULL,
+  .device_collection_destroy = NULL,
   .destroy = sndio_destroy,
   .stream_init = sndio_stream_init,
   .stream_destroy = sndio_stream_destroy,

--- a/src/cubeb_utils.c
+++ b/src/cubeb_utils.c
@@ -24,10 +24,13 @@ device_info_destroy(cubeb_device_info * info)
 }
 
 int
-cubeb_utils_default_device_collection_destroy(cubeb_device_collection * collection)
+cubeb_utils_default_device_collection_destroy(cubeb * context,
+                                              cubeb_device_collection * collection)
 {
   uint32_t i;
   XASSERT(collection);
+
+  (void) context;
 
   for (i = 0; i < collection->count; i++)
     device_info_destroy(collection->device[i]);

--- a/src/cubeb_utils.c
+++ b/src/cubeb_utils.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#include "cubeb_utils.h"
+#include "cubeb_assert.h"
+
+#include <stdlib.h>
+
+static void
+device_info_destroy(cubeb_device_info * info)
+{
+  XASSERT(info);
+
+  free((void *) info->device_id);
+  free((void *) info->friendly_name);
+  free((void *) info->group_id);
+  free((void *) info->vendor_name);
+
+  free(info);
+}
+
+int
+cubeb_utils_default_device_collection_destroy(cubeb_device_collection * collection)
+{
+  uint32_t i;
+  XASSERT(collection);
+
+  for (i = 0; i < collection->count; i++)
+    device_info_destroy(collection->device[i]);
+
+  free(collection);
+  return CUBEB_OK;
+}

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -8,6 +8,10 @@
 #if !defined(CUBEB_UTILS)
 #define CUBEB_UTILS
 
+#include "cubeb/cubeb.h"
+
+#ifdef __cplusplus
+
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
@@ -330,5 +334,18 @@ private:
 };
 
 using auto_lock = std::lock_guard<owned_critical_section>;
+#endif // __cplusplus
+
+// C language helpers
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cubeb_utils_default_device_collection_destroy(cubeb_device_collection * collection);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CUBEB_UTILS */

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -342,7 +342,8 @@ using auto_lock = std::lock_guard<owned_critical_section>;
 extern "C" {
 #endif
 
-int cubeb_utils_default_device_collection_destroy(cubeb_device_collection * collection);
+int cubeb_utils_default_device_collection_destroy(cubeb * context,
+                                                  cubeb_device_collection * collection);
 
 #ifdef __cplusplus
 }

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2323,6 +2323,7 @@ cubeb_ops const wasapi_ops = {
   /*.get_preferred_sample_rate =*/ wasapi_get_preferred_sample_rate,
   /*.get_preferred_channel_layout =*/ wasapi_get_preferred_channel_layout,
   /*.enumerate_devices =*/ wasapi_enumerate_devices,
+  /*.device_collection_destroy =*/ cubeb_utils_default_device_collection_destroy,
   /*.destroy =*/ wasapi_destroy,
   /*.stream_init =*/ wasapi_stream_init,
   /*.stream_destroy =*/ wasapi_stream_destroy,

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -19,6 +19,7 @@
 #include <math.h>
 #include "cubeb/cubeb.h"
 #include "cubeb-internal.h"
+#include "cubeb_utils.h"
 
 /* This is missing from the MinGW headers. Use a safe fallback. */
 #if !defined(MEMORY_ALLOCATION_ALIGNMENT)
@@ -1050,6 +1051,7 @@ static struct cubeb_ops const winmm_ops = {
   /*.get_preferred_sample_rate =*/ winmm_get_preferred_sample_rate,
   /*.get_preferred_channel_layout =*/ NULL,
   /*.enumerate_devices =*/ winmm_enumerate_devices,
+  /*.device_collection_destroy =*/ cubeb_utils_default_device_collection_destroy,
   /*.destroy =*/ winmm_destroy,
   /*.stream_init =*/ winmm_stream_init,
   /*.stream_destroy =*/ winmm_stream_destroy,

--- a/test/common.h
+++ b/test/common.h
@@ -82,7 +82,7 @@ int has_available_input_device(cubeb * ctx)
 
   if (devices->count == 0) {
     fprintf(stderr, "no input device available, skipping test.\n");
-    cubeb_device_collection_destroy(devices);
+    cubeb_device_collection_destroy(ctx, devices);
     return 0;
   }
 
@@ -96,7 +96,7 @@ int has_available_input_device(cubeb * ctx)
         "available, skipping\n");
   }
 
-  cubeb_device_collection_destroy(devices);
+  cubeb_device_collection_destroy(ctx, devices);
   return !!input_device_available;
 }
 

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -129,7 +129,7 @@ TEST(cubeb, enumerate_devices)
 
   fprintf(stdout, "Found %u input devices\n", collection->count);
   print_device_collection(collection, stdout);
-  cubeb_device_collection_destroy(collection);
+  cubeb_device_collection_destroy(ctx, collection);
 
   fprintf(stdout, "Enumerating output devices for backend %s\n",
           cubeb_get_backend_id(ctx));
@@ -139,5 +139,5 @@ TEST(cubeb, enumerate_devices)
 
   fprintf(stdout, "Found %u output devices\n", collection->count);
   print_device_collection(collection, stdout);
-  cubeb_device_collection_destroy(collection);
+  cubeb_device_collection_destroy(ctx, collection);
 }


### PR DESCRIPTION
In preparation for string interning of device id for selected backends, move the common cubeb_device_collection_destroy logic to backends. This allows for allocation other than malloc/free and having strings that statically allocated in cubeb_device_info.

To being with all backends use the same, default cleanup code from cubeb_utils.