### PR TITLE
Add backend specification support to common.h

### DIFF
--- a/test/common.h
+++ b/test/common.h
@@ -108,4 +108,26 @@ void print_log(const char * msg, ...)
   va_end(args);
 }
 
+/** Initialize cubeb with backend override.
+ *  Create call cubeb_init passing value for CUBEB_BACKEND env var as
+ *  override. */
+int common_init(cubeb ** ctx, char const * ctx_name)
+{
+  int r;
+  char const * backend;
+  char const * ctx_backend;
+
+  backend = getenv("CUBEB_BACKEND");
+  r = cubeb_init(ctx, ctx_name, backend);
+  if (r == CUBEB_OK && backend) {
+    ctx_backend = cubeb_get_backend_id(*ctx);
+    if (strcmp(backend, ctx_backend) != 0) {
+      fprintf(stderr, "Requested backend `%s', got `%s'\n",
+              backend, ctx_backend);
+    }
+  }
+
+  return r;
+}
+
 #endif /* TEST_COMMON */

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -100,7 +100,7 @@ int run_test(int num_channels, layout_info layout, int sampling_rate, int is_flo
 
   cubeb *ctx = NULL;
 
-  r = cubeb_init(&ctx, "Cubeb audio test: channels", NULL);
+  r = common_init(&ctx, "Cubeb audio test: channels");
   if (r != CUBEB_OK) {
     fprintf(stderr, "Error initializing cubeb library\n");
     return r;
@@ -150,7 +150,7 @@ int run_panning_volume_test(int is_float)
 
   cubeb *ctx = NULL;
 
-  r = cubeb_init(&ctx, "Cubeb audio test", NULL);
+  r = common_init(&ctx, "Cubeb audio test");
   if (r != CUBEB_OK) {
     fprintf(stderr, "Error initializing cubeb library\n");
     return r;

--- a/test/test_deadlock.cpp
+++ b/test/test_deadlock.cpp
@@ -81,7 +81,7 @@ cubeb * get_cubeb_context_unlocked()
   }
 
   int r = CUBEB_OK;
-  r = cubeb_init(&context, "Cubeb deadlock test", NULL);
+  r = common_init(&context, "Cubeb deadlock test");
   if (r != CUBEB_OK) {
     context = nullptr;
   }

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <memory>
 #include "cubeb/cubeb.h"
+#include "common.h"
 
 static void
 print_device_info(cubeb_device_info * info, FILE * f)
@@ -110,7 +111,7 @@ TEST(cubeb, enumerate_devices)
   cubeb * ctx = NULL;
   cubeb_device_collection * collection = NULL;
 
-  r = cubeb_init(&ctx, "Cubeb audio test", NULL);
+  r = common_init(&ctx, "Cubeb audio test");
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -83,7 +83,7 @@ TEST(cubeb, duplex)
   user_state_duplex stream_state = { false };
   uint32_t latency_frames = 0;
 
-  r = cubeb_init(&ctx, "Cubeb duplex example", NULL);
+  r = common_init(&ctx, "Cubeb duplex example");
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>

--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <memory>
 #include "cubeb/cubeb.h"
+#include "common.h"
 
 TEST(cubeb, latency)
 {
@@ -12,7 +13,7 @@ TEST(cubeb, latency)
   uint32_t latency_frames;
   cubeb_channel_layout layout;
 
-  r = cubeb_init(&ctx, "Cubeb audio test", NULL);
+  r = common_init(&ctx, "Cubeb audio test");
   ASSERT_EQ(r, CUBEB_OK);
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>

--- a/test/test_overload_callback.cpp
+++ b/test/test_overload_callback.cpp
@@ -58,7 +58,7 @@ TEST(cubeb, overload_callback)
   int r;
   uint32_t latency_frames = 0;
 
-  r = cubeb_init(&ctx, "Cubeb callback overload", NULL);
+  r = common_init(&ctx, "Cubeb callback overload");
   ASSERT_EQ(r, CUBEB_OK);
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>

--- a/test/test_record.cpp
+++ b/test/test_record.cpp
@@ -77,7 +77,7 @@ TEST(cubeb, record)
   int r;
   user_state_record stream_state = { false };
 
-  r = cubeb_init(&ctx, "Cubeb record example", NULL);
+  r = common_init(&ctx, "Cubeb record example");
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -77,7 +77,7 @@ TEST(cubeb, init_destroy_context)
   cubeb * ctx;
   char const* backend_id;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -98,7 +98,7 @@ TEST(cubeb, init_destroy_multiple_contexts)
   ASSERT_EQ(ARRAY_LENGTH(ctx), ARRAY_LENGTH(order));
 
   for (i = 0; i < ARRAY_LENGTH(ctx); ++i) {
-    r = cubeb_init(&ctx[i], NULL, NULL);
+    r = common_init(&ctx[i], NULL);
     ASSERT_EQ(r, CUBEB_OK);
     ASSERT_NE(ctx[i], nullptr);
   }
@@ -116,7 +116,7 @@ TEST(cubeb, context_variables)
   uint32_t value;
   cubeb_stream_params params;
 
-  r = cubeb_init(&ctx, "test_context_variables", NULL);
+  r = common_init(&ctx, "test_context_variables");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -149,7 +149,7 @@ TEST(cubeb, init_destroy_stream)
   cubeb_stream * stream;
   cubeb_stream_params params;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -178,7 +178,7 @@ TEST(cubeb, init_destroy_multiple_streams)
   cubeb_stream * stream[8];
   cubeb_stream_params params;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -211,7 +211,7 @@ TEST(cubeb, configure_stream)
   cubeb_stream * stream;
   cubeb_stream_params params;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -247,7 +247,7 @@ test_init_start_stop_destroy_multiple_streams(int early, int delay_ms)
   cubeb_stream * stream[8];
   cubeb_stream_params params;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -347,7 +347,7 @@ TEST(cubeb, init_destroy_multiple_contexts_and_streams)
 #endif
 
   for (i = 0; i < ARRAY_LENGTH(ctx); ++i) {
-    r = cubeb_init(&ctx[i], "test_sanity", NULL);
+    r = common_init(&ctx[i], "test_sanity");
     ASSERT_EQ(r, CUBEB_OK);
     ASSERT_NE(ctx[i], nullptr);
 
@@ -375,7 +375,7 @@ TEST(cubeb, basic_stream_operations)
   cubeb_stream_params params;
   uint64_t position;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -426,7 +426,7 @@ TEST(cubeb, stream_position)
 
   total_frames_written = 0;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 
@@ -562,7 +562,7 @@ TEST(cubeb, drain)
   delay_callback = 0;
   total_frames_written = 0;
 
-  r = cubeb_init(&ctx, "test_sanity", NULL);
+  r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(ctx, nullptr);
 

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -84,7 +84,7 @@ TEST(cubeb, tone)
   cubeb_stream_params params;
   int r;
 
-  r = cubeb_init(&ctx, "Cubeb tone example", NULL);
+  r = common_init(&ctx, "Cubeb tone example");
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>


### PR DESCRIPTION
Set CUBEB_BACKEND env var to the name of valid backend supported by
the current platform to prefer that backend over the default choice.

If CUBEB_BACKEND is not valid, backend selection falls back to the
standard behaviour.

A warning is printed to stderr if the chosen backend id doesn't match
the requested one.

(Issue #306)