### PR TITLE
Rework device collection

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -8,6 +8,7 @@
 #define CUBEB_c2f983e9_c96f_e71c_72c3_bbf62992a382
 
 #include <stdint.h>
+#include <stdlib.h>
 #include "cubeb_export.h"
 
 #if defined(__cplusplus)
@@ -352,16 +353,16 @@ typedef struct {
   unsigned int max_rate;      /**< Maximum sample rate supported. */
   unsigned int min_rate;      /**< Minimum sample rate supported. */
 
-  unsigned int latency_lo; /**< Lowest possible latency in frames. */
-  unsigned int latency_hi; /**< Higest possible latency in frames. */
+  unsigned int latency_lo;    /**< Lowest possible latency in frames. */
+  unsigned int latency_hi;    /**< Higest possible latency in frames. */
 } cubeb_device_info;
 
 /** Device collection.
  *  Returned by `cubeb_enumerate_devices` and destroyed by
  *  `cubeb_device_collection_destroy`. */
 typedef struct {
-  uint32_t count;                 /**< Device count in collection. */
-  cubeb_device_info * device[1];  /**< Array of pointers to device info. */
+  cubeb_device_info * device; /**< Array of pointers to device info. */
+  size_t count;               /**< Device count in collection. */
 } cubeb_device_collection;
 
 /** User supplied data callback.
@@ -612,7 +613,7 @@ CUBEB_EXPORT int cubeb_stream_register_device_changed_callback(cubeb_stream * st
     @retval CUBEB_ERROR_NOT_SUPPORTED */
 CUBEB_EXPORT int cubeb_enumerate_devices(cubeb * context,
                                          cubeb_device_type devtype,
-                                         cubeb_device_collection ** collection);
+                                         cubeb_device_collection * collection);
 
 /** Destroy a cubeb_device_collection, and its `cubeb_device_info`.
     @param context

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -51,8 +51,9 @@ struct cubeb_ops {
   int (* get_preferred_sample_rate)(cubeb * context, uint32_t * rate);
   int (* get_preferred_channel_layout)(cubeb * context, cubeb_channel_layout * layout);
   int (* enumerate_devices)(cubeb * context, cubeb_device_type type,
-                            cubeb_device_collection ** collection);
-  int (* device_collection_destroy)(cubeb * context, cubeb_device_collection * collection);
+                            cubeb_device_collection * collection);
+  int (* device_collection_destroy)(cubeb * context,
+                                    cubeb_device_collection * collection);
   void (* destroy)(cubeb * context);
   int (* stream_init)(cubeb * context,
                       cubeb_stream ** stream,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -550,7 +550,7 @@ void log_device(cubeb_device_info * device_info)
 
 int cubeb_enumerate_devices(cubeb * context,
                             cubeb_device_type devtype,
-                            cubeb_device_collection ** collection)
+                            cubeb_device_collection * collection)
 {
   int rv;
   if ((devtype & (CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT)) == 0)
@@ -563,8 +563,8 @@ int cubeb_enumerate_devices(cubeb * context,
   rv = context->ops->enumerate_devices(context, devtype, collection);
 
   if (g_cubeb_log_callback) {
-    for (uint32_t i = 0; i < (*collection)->count; i++) {
-      log_device((*collection)->device[i]);
+    for (size_t i = 0; i < collection->count; i++) {
+      log_device(&collection->device[i]);
     }
   }
 

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -1288,8 +1288,10 @@ alsa_stream_set_volume(cubeb_stream * stm, float volume)
 
 static int
 alsa_enumerate_devices(cubeb * context, cubeb_device_type type,
-                       cubeb_device_collection ** collection)
+                       cubeb_device_collection * collection)
 {
+  cubeb_device_info* device = NULL;
+
   if (!context)
     return CUBEB_ERROR;
 
@@ -1306,32 +1308,42 @@ alsa_enumerate_devices(cubeb * context, cubeb_device_type type,
     return CUBEB_ERROR;
   }
 
-  *collection = (cubeb_device_collection *) calloc(1, sizeof(cubeb_device_collection) + 1*sizeof(cubeb_device_info *));
-  assert(*collection);
-
   char const * a_name = "default";
-  (*collection)->device[0] = (cubeb_device_info *) calloc(1, sizeof(cubeb_device_info));
-  assert((*collection)->device[0]);
+  device = (cubeb_device_info *) calloc(1, sizeof(cubeb_device_info));
+  assert(device);
+  if (!device)
+    return CUBEB_ERROR;
 
-  (*collection)->device[0]->device_id = strdup(a_name);
-  (*collection)->device[0]->devid = (*collection)->device[0]->device_id;
-  (*collection)->device[0]->friendly_name = strdup(a_name);
-  (*collection)->device[0]->group_id = strdup(a_name);
-  (*collection)->device[0]->vendor_name = strdup(a_name);
-  (*collection)->device[0]->type = type;
-  (*collection)->device[0]->state = CUBEB_DEVICE_STATE_ENABLED;
-  (*collection)->device[0]->preferred = CUBEB_DEVICE_PREF_ALL;
-  (*collection)->device[0]->format = CUBEB_DEVICE_FMT_S16NE;
-  (*collection)->device[0]->default_format = CUBEB_DEVICE_FMT_S16NE;
-  (*collection)->device[0]->max_channels = max_channels;
-  (*collection)->device[0]->min_rate = rate;
-  (*collection)->device[0]->max_rate = rate;
-  (*collection)->device[0]->default_rate = rate;
-  (*collection)->device[0]->latency_lo = 0;
-  (*collection)->device[0]->latency_hi = 0;
+  device->device_id = a_name;
+  device->devid = (cubeb_devid) device->device_id;
+  device->friendly_name = a_name;
+  device->group_id = a_name;
+  device->vendor_name = a_name;
+  device->type = type;
+  device->state = CUBEB_DEVICE_STATE_ENABLED;
+  device->preferred = CUBEB_DEVICE_PREF_ALL;
+  device->format = CUBEB_DEVICE_FMT_S16NE;
+  device->default_format = CUBEB_DEVICE_FMT_S16NE;
+  device->max_channels = max_channels;
+  device->min_rate = rate;
+  device->max_rate = rate;
+  device->default_rate = rate;
+  device->latency_lo = 0;
+  device->latency_hi = 0;
 
-  (*collection)->count = 1;
+  collection->device = device;
+  collection->count = 1;
 
+  return CUBEB_OK;
+}
+
+static int
+alsa_device_collection_destroy(cubeb * context,
+                               cubeb_device_collection * collection)
+{
+  assert(collection->count == 1);
+  (void) context;
+  free(collection->device);
   return CUBEB_OK;
 }
 
@@ -1343,7 +1355,7 @@ static struct cubeb_ops const alsa_ops = {
   .get_preferred_sample_rate = alsa_get_preferred_sample_rate,
   .get_preferred_channel_layout = NULL,
   .enumerate_devices = alsa_enumerate_devices,
-  .device_collection_destroy = cubeb_utils_default_device_collection_destroy,
+  .device_collection_destroy = alsa_device_collection_destroy,
   .destroy = alsa_destroy,
   .stream_init = alsa_stream_init,
   .stream_destroy = alsa_stream_destroy,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2917,8 +2917,9 @@ audiounit_strref_to_cstr_utf8(CFStringRef strref)
   }
 
   len = CFStringGetLength(strref);
-  size = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8);
-  ret = new char[size+1];
+  // Add 1 to size to allow for '\0' termination character.
+  size = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1;
+  ret = new char[size];
 
   if (!CFStringGetCString(strref, ret, size, kCFStringEncodingUTF8)) {
     delete [] ret;

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1148,7 +1148,7 @@ typedef struct {
   char * default_sink_name;
   char * default_source_name;
 
-  cubeb_device_info ** devinfo;
+  cubeb_device_info * devinfo;
   uint32_t max;
   uint32_t count;
   cubeb * context;
@@ -1177,7 +1177,7 @@ pulse_ensure_dev_list_data_list_size (pulse_dev_list_data * list_data)
   if (list_data->count == list_data->max) {
     list_data->max += 8;
     list_data->devinfo = realloc(list_data->devinfo,
-        sizeof(cubeb_device_info *) * list_data->max);
+        sizeof(cubeb_device_info) * list_data->max);
   }
 }
 
@@ -1209,7 +1209,9 @@ pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
   if (eol || info == NULL)
     return;
 
-  devinfo = calloc(1, sizeof(cubeb_device_info));
+  pulse_ensure_dev_list_data_list_size(list_data);
+  devinfo = &list_data->devinfo[list_data->count];
+  memset(devinfo, 0, sizeof(cubeb_device_info));
 
   devinfo->device_id = strdup(info->name);
   devinfo->devid = (cubeb_devid) devinfo->device_id;
@@ -1236,8 +1238,7 @@ pulse_sink_info_cb(pa_context * context, const pa_sink_info * info,
   devinfo->latency_lo = 0;
   devinfo->latency_hi = 0;
 
-  pulse_ensure_dev_list_data_list_size (list_data);
-  list_data->devinfo[list_data->count++] = devinfo;
+  list_data->count += 1;
 
   WRAP(pa_threaded_mainloop_signal)(list_data->context->mainloop, 0);
 }
@@ -1270,7 +1271,9 @@ pulse_source_info_cb(pa_context * context, const pa_source_info * info,
   if (eol)
     return;
 
-  devinfo = calloc(1, sizeof(cubeb_device_info));
+  pulse_ensure_dev_list_data_list_size(list_data);
+  devinfo = &list_data->devinfo[list_data->count];
+  memset(devinfo, 0, sizeof(cubeb_device_info));
 
   devinfo->device_id = strdup(info->name);
   devinfo->devid = (cubeb_devid) devinfo->device_id;
@@ -1297,9 +1300,7 @@ pulse_source_info_cb(pa_context * context, const pa_source_info * info,
   devinfo->latency_lo = 0;
   devinfo->latency_hi = 0;
 
-  pulse_ensure_dev_list_data_list_size (list_data);
-  list_data->devinfo[list_data->count++] = devinfo;
-
+  list_data->count += 1;
   WRAP(pa_threaded_mainloop_signal)(list_data->context->mainloop, 0);
 }
 
@@ -1320,11 +1321,10 @@ pulse_server_info_cb(pa_context * c, const pa_server_info * i, void * userdata)
 
 static int
 pulse_enumerate_devices(cubeb * context, cubeb_device_type type,
-                        cubeb_device_collection ** collection)
+                        cubeb_device_collection * collection)
 {
   pulse_dev_list_data user_data = { NULL, NULL, NULL, 0, 0, context };
   pa_operation * o;
-  uint32_t i;
 
   WRAP(pa_threaded_mainloop_lock)(context->mainloop);
 
@@ -1355,15 +1355,11 @@ pulse_enumerate_devices(cubeb * context, cubeb_device_type type,
 
   WRAP(pa_threaded_mainloop_unlock)(context->mainloop);
 
-  *collection = malloc(sizeof(cubeb_device_collection) +
-      sizeof(cubeb_device_info *) * (user_data.count > 0 ? user_data.count - 1 : 0));
-  (*collection)->count = user_data.count;
-  for (i = 0; i < user_data.count; i++)
-    (*collection)->device[i] = user_data.devinfo[i];
+  collection->device = user_data.devinfo;
+  collection->count = user_data.count;
 
   free(user_data.default_sink_name);
   free(user_data.default_source_name);
-  free(user_data.devinfo);
   return CUBEB_OK;
 }
 

--- a/src/cubeb_utils.c
+++ b/src/cubeb_utils.c
@@ -19,8 +19,6 @@ device_info_destroy(cubeb_device_info * info)
   free((void *) info->friendly_name);
   free((void *) info->group_id);
   free((void *) info->vendor_name);
-
-  free(info);
 }
 
 int
@@ -33,8 +31,8 @@ cubeb_utils_default_device_collection_destroy(cubeb * context,
   (void) context;
 
   for (i = 0; i < collection->count; i++)
-    device_info_destroy(collection->device[i]);
+    device_info_destroy(&collection->device[i]);
 
-  free(collection);
+  free(collection->device);
   return CUBEB_OK;
 }

--- a/test/common.h
+++ b/test/common.h
@@ -70,7 +70,7 @@ layout_info const layout_infos[CUBEB_LAYOUT_MAX] = {
 
 int has_available_input_device(cubeb * ctx)
 {
-  cubeb_device_collection * devices;
+  cubeb_device_collection devices;
   int input_device_available = 0;
   int r;
   /* Bail out early if the host does not have input devices. */
@@ -80,14 +80,14 @@ int has_available_input_device(cubeb * ctx)
     return 0;
   }
 
-  if (devices->count == 0) {
+  if (devices.count == 0) {
     fprintf(stderr, "no input device available, skipping test.\n");
-    cubeb_device_collection_destroy(ctx, devices);
+    cubeb_device_collection_destroy(ctx, &devices);
     return 0;
   }
 
-  for (uint32_t i = 0; i < devices->count; i++) {
-    input_device_available |= (devices->device[i]->state ==
+  for (uint32_t i = 0; i < devices.count; i++) {
+    input_device_available |= (devices.device[i].state ==
                                CUBEB_DEVICE_STATE_ENABLED);
   }
 
@@ -96,7 +96,7 @@ int has_available_input_device(cubeb * ctx)
         "available, skipping\n");
   }
 
-  cubeb_device_collection_destroy(ctx, devices);
+  cubeb_device_collection_destroy(ctx, &devices);
   return !!input_device_available;
 }
 

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -102,14 +102,14 @@ print_device_collection(cubeb_device_collection * collection, FILE * f)
   uint32_t i;
 
   for (i = 0; i < collection->count; i++)
-    print_device_info(collection->device[i], f);
+    print_device_info(&collection->device[i], f);
 }
 
 TEST(cubeb, enumerate_devices)
 {
   int r;
   cubeb * ctx = NULL;
-  cubeb_device_collection * collection = NULL;
+  cubeb_device_collection collection;
 
   r = common_init(&ctx, "Cubeb audio test");
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
@@ -128,9 +128,9 @@ TEST(cubeb, enumerate_devices)
   }
   ASSERT_EQ(r, CUBEB_OK) << "Error enumerating devices " << r;
 
-  fprintf(stdout, "Found %u input devices\n", collection->count);
-  print_device_collection(collection, stdout);
-  cubeb_device_collection_destroy(ctx, collection);
+  fprintf(stdout, "Found %zu input devices\n", collection.count);
+  print_device_collection(&collection, stdout);
+  cubeb_device_collection_destroy(ctx, &collection);
 
   fprintf(stdout, "Enumerating output devices for backend %s\n",
           cubeb_get_backend_id(ctx));
@@ -138,7 +138,7 @@ TEST(cubeb, enumerate_devices)
   r = cubeb_enumerate_devices(ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection);
   ASSERT_EQ(r, CUBEB_OK) << "Error enumerating devices " << r;
 
-  fprintf(stdout, "Found %u output devices\n", collection->count);
-  print_device_collection(collection, stdout);
-  cubeb_device_collection_destroy(ctx, collection);
+  fprintf(stdout, "Found %zu output devices\n", collection.count);
+  print_device_collection(&collection, stdout);
+  cubeb_device_collection_destroy(ctx, &collection);
 }


### PR DESCRIPTION
Rust compatiblity change to cubeb_device_collection.

Convert the C dynamic array with magic header into a structure that hold pointer + count of entries.  This is the same memory layout that rust uses for fat pointers for &[T], Box<[T]>, etc, which will make it much easier to return memory allocated in cubeb-pulse-rust backend.

(Fixes issue #286)

@kinetiknz and I discussed the design options off-line and decided that returning pointer + count was acceptible (breaking the requirement for one allocation for count + storage)