### PR TITLE
Test cubeb_get_preferred_channel_layout in test_sanity instead of test_latency

### DIFF
--- a/test/test_latency.cpp
+++ b/test/test_latency.cpp
@@ -11,7 +11,6 @@ TEST(cubeb, latency)
   uint32_t max_channels;
   uint32_t preferred_rate;
   uint32_t latency_frames;
-  cubeb_channel_layout layout;
 
   r = common_init(&ctx, "Cubeb audio test");
   ASSERT_EQ(r, CUBEB_OK);
@@ -31,15 +30,11 @@ TEST(cubeb, latency)
     ASSERT_GT(preferred_rate, 0u);
   }
 
-  r = cubeb_get_preferred_channel_layout(ctx, &layout);
-  ASSERT_TRUE(r == CUBEB_OK || r == CUBEB_ERROR_NOT_SUPPORTED ||
-              (r == CUBEB_ERROR && layout == CUBEB_LAYOUT_UNDEFINED));
-
   cubeb_stream_params params = {
     CUBEB_SAMPLE_FLOAT32NE,
     preferred_rate,
     max_channels,
-    (r == CUBEB_OK) ? layout : CUBEB_LAYOUT_UNDEFINED
+    CUBEB_LAYOUT_UNDEFINED
 #if defined(__ANDROID__)
     , CUBEB_STREAM_TYPE_MUSIC
 #endif

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -114,6 +114,7 @@ TEST(cubeb, context_variables)
   int r;
   cubeb * ctx;
   uint32_t value;
+  cubeb_channel_layout layout;
   cubeb_stream_params params;
 
   r = common_init(&ctx, "test_context_variables");
@@ -138,6 +139,11 @@ TEST(cubeb, context_variables)
   if (r == CUBEB_OK) {
     ASSERT_TRUE(value > 0);
   }
+
+  r = cubeb_get_preferred_channel_layout(ctx, &layout);
+  ASSERT_TRUE(r == CUBEB_ERROR_NOT_SUPPORTED ||
+              (r == CUBEB_OK && layout != CUBEB_LAYOUT_UNDEFINED) ||
+              (r == CUBEB_ERROR && layout == CUBEB_LAYOUT_UNDEFINED));
 
   cubeb_destroy(ctx);
 }


### PR DESCRIPTION
We used to test ```cubeb_get_preferred_channel_layout``` in ```test_latency.cpp```, however, the latency doesn't be affected by the layout. It's more reasonable to test it in ```test_sanity.cpp```