### PR TITLE
wasapi: use number of frames instead of samples

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -753,6 +753,7 @@ bool
 refill_callback_input(cubeb_stream * stm)
 {
   bool rv;
+  size_t input_frames;
 
   XASSERT(has_input(stm) && !has_output(stm));
 
@@ -761,16 +762,16 @@ refill_callback_input(cubeb_stream * stm)
     return rv;
   }
 
-  // This can happen at the very beginning of the stream.
-  if (!stm->linear_input_buffer->length()) {
+  input_frames = stm->linear_input_buffer->length() / stm->input_stream_params.channels;
+  if (!input_frames) {
     return true;
   }
 
-  ALOGV("Input callback: input frames: %Iu", stm->linear_input_buffer->length());
+  ALOGV("Input callback: input frames: %Iu", input_frames);
 
   long read = refill(stm,
                      stm->linear_input_buffer->data(),
-                     stm->linear_input_buffer->length(),
+                     input_frames,
                      nullptr,
                      0);
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -731,11 +731,11 @@ refill_callback_duplex(cubeb_stream * stm)
 
 
   ALOGV("Duplex callback: input frames: %Iu, output frames: %Iu",
-        stm->linear_input_buffer->length(), output_frames);
+        input_frames, output_frames);
 
   refill(stm,
          stm->linear_input_buffer->data(),
-         stm->linear_input_buffer->length(),
+         input_frames,
          output_buffer,
          output_frames);
 


### PR DESCRIPTION
In duplex callback we used to pass through the number of samples instead of frames. This is ok on MONO but it does not work on STEREO capture.

P.S. I need this fix for the stereo gum bug. It will be great to get a quick review. I plan to import it to gecko as soon as possible. 