### PR TITLE
Fix test_mixer fails on local build

### DIFF
--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -325,14 +325,14 @@ mix_remap(long inframes,
     return false;
   }
 
-  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
+  for (long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
     for (unsigned int j = 0; j < out_channels; ++j) {
       cubeb_channel channel = CHANNEL_INDEX_TO_ORDER[out_layout][j];
       uint32_t channel_mask = 1 << channel;
       int channel_index = CHANNEL_ORDER_TO_INDEX[in_layout][channel];
-      assert(out_index + j < out_len);
+      assert((unsigned long)out_index + j < out_len);
       if (in_layout_mask & channel_mask) {
-        assert(i + channel_index < in_len);
+        assert((unsigned long)i + channel_index < in_len);
         assert(channel_index != -1);
         out[out_index + j] = in[i + channel_index];
       } else {
@@ -359,9 +359,9 @@ downmix_fallback(long inframes,
     return;
   }
 
-  for (unsigned long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
+  for (long i = 0, out_index = 0; i < inframes * in_channels; i += in_channels, out_index += out_channels) {
     for (unsigned int j = 0; j < out_channels; ++j) {
-      assert(i + j < in_len && out_index + j < out_len);
+      assert((unsigned long)i + j < in_len && (unsigned long)out_index + j < out_len);
       out[out_index + j] = in[i + j];
     }
   }
@@ -416,7 +416,7 @@ mono_to_stereo(long insamples, T const * in, unsigned long in_len,
                T * out, unsigned long out_len, unsigned int out_channels)
 {
   for (long i = 0, j = 0; i < insamples; ++i, j += out_channels) {
-    assert(i < in_len && j + 1 < out_len);
+    assert((unsigned long)i < in_len && (unsigned long)j + 1 < out_len);
     out[j] = out[j + 1] = in[i];
   }
 }
@@ -460,7 +460,7 @@ cubeb_upmix(long inframes,
   /* Put silence in remaining channels. */
   for (long i = 0, o = 0; i < inframes; ++i, o += out_channels) {
     for (unsigned int j = 2; j < out_channels; ++j) {
-      assert(o + j < out_len);
+      assert((unsigned long)o + j < out_len);
       out[o + j] = 0.0;
     }
   }

--- a/test/common.h
+++ b/test/common.h
@@ -18,6 +18,7 @@
 
 #include <cstdarg>
 #include "cubeb/cubeb.h"
+#include "cubeb_mixer.h"
 
 template<typename T, size_t N>
 constexpr size_t
@@ -66,6 +67,20 @@ layout_info const layout_infos[CUBEB_LAYOUT_MAX] = {
   { "3f2 lfe",        6,  CUBEB_LAYOUT_3F2_LFE },
   { "3f3r lfe",       7,  CUBEB_LAYOUT_3F3R_LFE },
   { "3f4 lfe",        8,  CUBEB_LAYOUT_3F4_LFE }
+};
+
+char const * channel_names[CHANNEL_UNMAPPED + 1] = {
+  "mono",                   // CHANNEL_MONO
+  "left",                   // CHANNEL_LEFT
+  "right",                  // CHANNEL_RIGHT
+  "center",                 // CHANNEL_CENTER
+  "left surround",          // CHANNEL_LS
+  "right surround",         // CHANNEL_RS
+  "rear left surround",     // CHANNEL_RLS
+  "rear center",            // CHANNEL_RCENTER
+  "rear right surround",    // CHANNEL_RRS
+  "low frequency effects",  // CHANNEL_LFE
+  "unmapped"                // CHANNEL_UNMAPPED
 };
 
 int has_available_input_device(cubeb * ctx)

--- a/test/common.h
+++ b/test/common.h
@@ -69,20 +69,6 @@ layout_info const layout_infos[CUBEB_LAYOUT_MAX] = {
   { "3f4 lfe",        8,  CUBEB_LAYOUT_3F4_LFE }
 };
 
-char const * channel_names[CHANNEL_UNMAPPED + 1] = {
-  "mono",                   // CHANNEL_MONO
-  "left",                   // CHANNEL_LEFT
-  "right",                  // CHANNEL_RIGHT
-  "center",                 // CHANNEL_CENTER
-  "left surround",          // CHANNEL_LS
-  "right surround",         // CHANNEL_RS
-  "rear left surround",     // CHANNEL_RLS
-  "rear center",            // CHANNEL_RCENTER
-  "rear right surround",    // CHANNEL_RRS
-  "low frequency effects",  // CHANNEL_LFE
-  "unmapped"                // CHANNEL_UNMAPPED
-};
-
 int has_available_input_device(cubeb * ctx)
 {
   cubeb_device_collection devices;

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -174,7 +174,7 @@ downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_l
   }
 
   for (unsigned int i = 0 ; i < out.size() ; ++i) {
-    assert(in_params.channels && out_params.channels);
+    assert(in_params.channels && out_params.channels); // to pass the scan-build warning: Division by zero.
 #if defined(__APPLE__)
     // The size of audio mix buffer(vector out above) on OS X is same as input,
     // so we need to check whether the out[i] will be dropped or not.

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -88,6 +88,20 @@ audio_input audio_inputs[CUBEB_LAYOUT_MAX] = {
   { CUBEB_LAYOUT_3F4_LFE,       { L, R, C, LFE, RLS, RRS, LS, RS } }
 };
 
+char const * channel_names[CHANNEL_UNMAPPED + 1] = {
+  "mono",                   // CHANNEL_MONO
+  "left",                   // CHANNEL_LEFT
+  "right",                  // CHANNEL_RIGHT
+  "center",                 // CHANNEL_CENTER
+  "left surround",          // CHANNEL_LS
+  "right surround",         // CHANNEL_RS
+  "rear left surround",     // CHANNEL_RLS
+  "rear center",            // CHANNEL_RCENTER
+  "rear right surround",    // CHANNEL_RRS
+  "low frequency effects",  // CHANNEL_LFE
+  "unmapped"                // CHANNEL_UNMAPPED
+};
+
 // The test cases must be aligned with cubeb_downmix.
 void
 downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_layout out_layout)

--- a/test/test_mixer.cpp
+++ b/test/test_mixer.cpp
@@ -167,6 +167,7 @@ downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_l
     unsigned int index = i % in_params.channels;
     if (index >= out_params.channels) {
       // The out[i] will be dropped, so we don't care the data inside.
+      fprintf(stderr, "\tOS X: %d will be dropped. Ignore it.\n", i);
       continue;
     }
 #else
@@ -177,26 +178,26 @@ downmix_test(float const * data, cubeb_channel_layout in_layout, cubeb_channel_l
     if ((in_layout == CUBEB_LAYOUT_3F2 || in_layout == CUBEB_LAYOUT_3F2_LFE) &&
         out_layout >= CUBEB_LAYOUT_MONO && out_layout <= CUBEB_LAYOUT_2F2_LFE) {
       auto & downmix_results = DOWNMIX_3F2_RESULTS[in_layout - CUBEB_LAYOUT_3F2][out_layout - CUBEB_LAYOUT_MONO];
-      fprintf(stderr, "[3f2] Expect: %lf, Get: %lf\n", downmix_results[index], out[i]);
+      fprintf(stderr, "\t[3f2] %d(%s) - Expect: %lf, Get: %lf\n", i, channel_names[ CHANNEL_INDEX_TO_ORDER[out_layout][index] ], downmix_results[index], out[i]);
       ASSERT_EQ(downmix_results[index], out[i]);
       continue;
     }
 
 #if defined(__APPLE__)
-    // We only support downmix for audio 5.1 on OS X currently.
+    fprintf(stderr, "\tOS X: We only support downmix for audio 5.1 currently.\n");
     return;
 #endif
 
     // mix_remap
     if (out_layout_mask & in_layout_mask) {
       uint32_t mask = 1 << CHANNEL_INDEX_TO_ORDER[out_layout][index];
-      fprintf(stderr, "[map channels] Expect: %lf, Get: %lf\n", (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[i]);
+      fprintf(stderr, "\t[remap] %d(%s) - Expect: %lf, Get: %lf\n", i, channel_names[ CHANNEL_INDEX_TO_ORDER[out_layout][index] ], (mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[i]);
       ASSERT_EQ((mask & in_layout_mask) ? audio_inputs[out_layout].data[index] : 0, out[i]);
       continue;
     }
 
     // downmix_fallback
-    fprintf(stderr, "[fallback] Expect: %lf, Get: %lf\n", audio_inputs[in_layout].data[index], out[i]);
+    fprintf(stderr, "\t[fallback] %d - Expect: %lf, Get: %lf\n", i, audio_inputs[in_layout].data[index], out[i]);
     ASSERT_EQ(audio_inputs[in_layout].data[index], out[i]);
   }
 }


### PR DESCRIPTION
- Fix #314 
- Fix warnings of comparison of integers of different signs
- Add debugging messages