### PR TITLE
audiounit: clear tsan warnings

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -79,7 +79,7 @@ struct cubeb {
   // The queue is asynchronously deallocated once all references to it are released
   dispatch_queue_t serial_queue = dispatch_queue_create(DISPATCH_QUEUE_LABEL, DISPATCH_QUEUE_SERIAL);
   // Current used channel layout
-  cubeb_channel_layout layout;
+  std::atomic<cubeb_channel_layout> layout{ CUBEB_LAYOUT_UNDEFINED };
 };
 
 static std::unique_ptr<AudioChannelLayout, decltype(&free)>

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -17,13 +17,14 @@
 #include <limits.h>
 #include "cubeb/cubeb.h"
 #include "common.h"
+#include <atomic>
 
 #define SAMPLE_FREQUENCY 48000
 #define STREAM_FORMAT CUBEB_SAMPLE_S16LE
 
 /* store the phase of the generated waveform */
 struct cb_user_data {
-  long position;
+  std::atomic<long> position;
 };
 
 long data_cb_tone(cubeb_stream *stream, void *user, const void* /*inputbuffer*/, void *outputbuffer, long nframes)
@@ -111,5 +112,5 @@ TEST(cubeb, tone)
   delay(500);
   cubeb_stream_stop(stream);
 
-  ASSERT_TRUE(user_data->position);
+  ASSERT_TRUE(user_data->position.load());
 }


### PR DESCRIPTION
Clear TSAN warnings for audiounit backend. Full list of warnings can be found in #317.