### PR TITLE
audiounit: assert that I/O AU is not NULL in reinit

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -613,6 +613,7 @@ static int
 audiounit_reinit_stream(cubeb_stream * stm)
 {
   auto_lock context_lock(stm->context->mutex);
+  assert(stm->input_unit || stm->output_unit);
   if (!stm->shutdown) {
     audiounit_stream_stop_internal(stm);
   }
@@ -626,7 +627,7 @@ audiounit_reinit_stream(cubeb_stream * stm)
     auto_lock lock(stm->mutex);
     float volume = 0.0;
     int vol_rv = CUBEB_ERROR;
-    if (has_output(stm)) {
+    if (stm->output_unit) {
       vol_rv = audiounit_stream_get_volume(stm, &volume);
     }
 


### PR DESCRIPTION
I investigate the following assert crashes [here](https://crash-stats.mozilla.com/signature/?version=55.0b&version=55.0b1&version=55.0a1&version=56.0a1&proto_signature=~___ZL36audiounit_property_listener_callbackjjPK26AudioObjectPropertyAddressPv_block_invoke&signature=libsystem_kernel.dylib%400x15866&date=%3E%3D2017-05-11T13%3A45%3A00.000Z&date=%3C2017-06-15T13%3A45%3A00.000Z&_columns=date&_columns=product&_columns=version&_columns=build_id&_columns=platform&_columns=reason&_columns=address&_columns=install_time&_sort=-date&page=1#reports)

The assert will show if there is any chance to get stream_reinit block before the stream_close block in serial queue. 
