### PR TITLE
audiounit: set id when it's not the default

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -590,6 +590,7 @@ audiounit_set_device_info(cubeb_stream * stm, AudioDeviceID id, io_side side)
     type = CUBEB_DEVICE_TYPE_OUTPUT;
   }
   memset(info, 0, sizeof(device_info));
+  info->id = id;
 
   if (side == INPUT) {
     info->flags |= DEV_INPUT;


### PR DESCRIPTION
Fix for crash in Bug 1385448. The crash blocks all webrtc calls in today's Nightly. I would appreciate a quick review.