### PR TITLE
Add a thread reset API for the ring buffer class.

### DIFF
--- a/src/cubeb_log.cpp
+++ b/src/cubeb_log.cpp
@@ -95,6 +95,12 @@ public:
       }
     }).detach();
   }
+  // Tell the underlying queue the producer thread has changed, so it does not
+  // assert in debug. This should be called with the thread stopped.
+  void reset_producer_thread()
+  {
+    msg_queue.reset_thread_ids();
+  }
 private:
 #ifndef _WIN32
   const struct timespec sleep_for = {
@@ -127,4 +133,12 @@ void cubeb_async_log(char const * fmt, ...)
   vsnprintf(msg, CUBEB_LOG_MESSAGE_MAX_SIZE, fmt, args);
   cubeb_async_logger::get().push(msg);
   va_end(args);
+}
+
+void cubeb_async_log_reset_threads()
+{
+  if (!g_cubeb_log_callback) {
+    return;
+  }
+  cubeb_async_logger::get().reset_producer_thread();
 }

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -23,6 +23,7 @@ extern "C" {
 extern cubeb_log_level g_cubeb_log_level;
 extern cubeb_log_callback g_cubeb_log_callback PRINTF_FORMAT(1, 2);
 void cubeb_async_log(const char * fmt, ...);
+void cubeb_async_log_reset_threads();
 
 #ifdef __cplusplus
 }

--- a/src/cubeb_ringbuffer.h
+++ b/src/cubeb_ringbuffer.h
@@ -226,6 +226,17 @@ public:
   {
     return storage_capacity() - 1;
   }
+  /**
+   * Reset the consumer and producer thread identifier, in case the thread are
+   * being changed. This has to be externally synchronized. This is no-op when
+   * asserts are disabled.
+   */
+  void reset_thread_ids()
+  {
+#ifndef DEBUG
+    consumer_id = producer_id = std::thread::id();
+#endif
+  }
 private:
   /** Return true if the ring buffer is empty.
    *

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1972,6 +1972,7 @@ int wasapi_stream_start(cubeb_stream * stm)
     return CUBEB_ERROR;
   }
 
+  cubeb_async_log_reset_threads();
   stm->thread = (HANDLE) _beginthreadex(NULL, 512 * 1024, wasapi_stream_render_loop, stm, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
   if (stm->thread == NULL) {
     LOG("could not create WASAPI render thread.");


### PR DESCRIPTION
This allow reseting the consumer/producer thread id in the ring buffer
class, so that we can take into account the change in thread inherent to
the audio devices changes.

This fixes #320.