### PR TITLE
Implement some rudimentary underrun protection for duplex streams

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -43,9 +43,9 @@ passthrough_resampler<T>::passthrough_resampler(cubeb_stream * s,
                                                 uint32_t sample_rate)
   : processor(input_channels)
   , stream(s)
-  , sample_rate(sample_rate)
   , data_callback(cb)
   , user_ptr(ptr)
+  , sample_rate(sample_rate)
 {
 }
 

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -42,8 +42,8 @@ passthrough_resampler<T>::passthrough_resampler(cubeb_stream * s,
                                                 uint32_t input_channels,
                                                 uint32_t sample_rate)
   : processor(input_channels)
-  , sample_rate(sample_rate)
   , stream(s)
+  , sample_rate(sample_rate)
   , data_callback(cb)
   , user_ptr(ptr)
 {
@@ -208,7 +208,6 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   /* The number of frames returned from the callback. */
   long got = 0;
 
-
   /* We need to determine how much frames to present to the consumer.
    * - If we have a two way stream, but we're only resampling input, we resample
    * the input to the number of output frames.
@@ -246,9 +245,6 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
 
   output_processor->written(got);
 
-  /* If either the input buffer or the output buffer grew too big, drop some
-     audio. This will glitch, but will prevent delay buildups. We drop before
-     adding the new audio in, because we always want to read/write recent audio. */
   input_processor->drop_audio_if_needed();
 
   /* Process the output. If not enough frames have been returned from the

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -100,8 +100,9 @@ public:
   void drop_audio_if_needed()
   {
     uint32_t to_keep = min_buffered_audio_frame(sample_rate);
-    if (samples_to_frames(internal_input_buffer.length()) > to_keep) {
-      internal_input_buffer.pop(nullptr, samples_to_frames(internal_input_buffer.length()) - to_keep);
+    uint32_t available = samples_to_frames(internal_input_buffer.length());
+    if (available > to_keep) {
+      internal_input_buffer.pop(nullptr, frames_to_samples(available - to_keep));
     }
   }
 
@@ -485,7 +486,7 @@ public:
     size_t available = samples_to_frames(delay_input_buffer.length());
     uint32_t to_keep = min_buffered_audio_frame(sample_rate);
     if (available > to_keep) {
-      delay_input_buffer.pop(nullptr, available - frames_to_samples(sample_rate));
+      delay_input_buffer.pop(nullptr, frames_to_samples(available - to_keep));
     }
   }
 private:

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -125,7 +125,7 @@ void test_delay_lines(uint32_t delay_frames, uint32_t channels, uint32_t chunk_m
   const size_t length_s = 2;
   const size_t rate = 44100;
   const size_t length_frames = rate * length_s;
-  delay_line<float> delay(delay_frames, channels);
+  delay_line<float> delay(delay_frames, channels, rate);
   auto_array<float> input;
   auto_array<float> output;
   uint32_t chunk_length = channels * chunk_ms * rate / 1000;


### PR DESCRIPTION
For now, it leaves at most 100ms in the buffer. It seem to behave well. I've used this to test:

```diff
diff --git a/test/test_duplex.cpp b/test/test_duplex.cpp
index 427b503..f17634d 100644
--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -17,11 +17,14 @@
 #include <memory>
 #include "cubeb/cubeb.h"
 #include "common.h"
+#include <iostream>
 #include <atomic>

 #define SAMPLE_FREQUENCY 48000
 #define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE

+static std::atomic<int> rounds = 0;
+
 struct user_state_duplex
 {
   std::atomic<int> seen_audio{ 0 };
@@ -50,7 +53,11 @@ long data_cb_duplex(cubeb_stream * stream, void * user, const void * inputbuffer
     output_index += 2;
   }

-  u->seen_audio |= seen_audio;
+  for (uint32_t i = 0; i < nframes * rounds; i++) {
+    if (ib[i % nframes] <= -1.0 && ib[i % nframes] >= 1.0) {
+      u->seen_audio |= seen_audio;
+    }
+  }

   return nframes;
 }
@@ -118,8 +125,13 @@ TEST(cubeb, duplex)
     cleanup_stream_at_exit(stream, cubeb_stream_destroy);

   cubeb_stream_start(stream);
-  delay(500);
-  cubeb_stream_stop(stream);
+  std::string str;
+  while (getline(std::cin, str)) {
+    std::stringstream iss(str);
+    int temp;
+    iss >> temp;
+    rounds = temp;
+  }

   ASSERT_TRUE(stream_state.seen_audio.load());
 }

```

On my windows machine, I can make it glitch by typing, say, `5000<enter>`, and then bring it back to normal by doing `1000<enter>`.

If I backout the actual patch in this PR, delay accumulates between input and output.