### PR TITLE
audiounit: fix assert for reinit on playback (Bug 1400465).

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -733,7 +733,12 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
         break;
       case kAudioDevicePropertyDataSource: {
           LOG("Event[%u] - mSelector == kAudioHardwarePropertyDataSource for id=%d", (unsigned int) i, id);
-          switch_side |= DEV_INPUT;
+          if (stm->input_unit) {
+            switch_side |= DEV_INPUT;
+          }
+          if (stm->output_unit) {
+            switch_side |= DEV_OUTPUT;
+          }
         }
         break;
       default:


### PR DESCRIPTION
Satisfy an assert when reinit on playback scenario. In the fix we check which side is on and request restart on the corresponding devices.