### PR TITLE
Elaborate the build instructions for Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,14 +11,36 @@ You must have CMake v3.1 or later installed.
 
 # Windows build notes
 
-Windows builds can use Microsoft Visual Studio 2015 (the default) or MinGW-w64
-with Win32 threads (by passing `cmake -G` to generate the appropriate build
-configuration).  To build with MinGW-w64, install the following items:
+Windows builds can use Microsoft Visual Studio 2015, Microsoft Visual Studio
+2017, or MinGW-w64 with Win32 threads (by passing `cmake -G` to generate the
+appropriate build configuration).
+
+## Microsoft Visual Studio 2015 or 2017 Command Line
+
+CMake can be used from the command line by following the build steps at the top
+of this file. CMake will select a default generator based on the environment,
+or one can be specified with the `-G` argument.
+
+## Microsoft Visual Studio 2017 IDE
+
+Visual Studio 2017 adds in built support for CMake. CMake can be used from
+within the IDE via the following steps:
+
+- Navigate to `File -> Open -> Cmake...`
+- Open `CMakeLists.txt` file in the root of the project.
+
+Note, to generate the build in the cubeb dir CMake settings need to be updated
+via: `CMake -> Change CMake Settings -> CMakeLists.txt`. The default
+configuration used by Visual Studio will place the build in a different location
+than the steps detailed at the top of this file.
+
+## MinGW-w64
+
+To build with MinGW-w64, install the following items:
 
 - Download and install MinGW-w64 with Win32 threads.
 - Download and install CMake.
 - Run MinGW-w64 Terminal from the Start Menu.
-- Follow the build steps above, but at step 3 run:
+- Follow the build steps at the top of this file, but at step 3 run:
   `cmake -G "MinGW Makefiles" ..`
-- Continue the build steps above.
-
+- Continue the build steps at the top of this file.


### PR DESCRIPTION
Add mention of visual studio 2017, add instructions on how to use CMake from within VS2017. Point out gotcha of default build dirs in VS2017.