### PR TITLE
audiounit: correct output device reset (Bug 1421206)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -755,7 +755,7 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
   if (has_input(stm)) {
     switch_side |= DEV_INPUT;
   }
-  if (has_input(stm)) {
+  if (has_output(stm)) {
     switch_side |= DEV_OUTPUT;
   }
 


### PR DESCRIPTION
Oneliner, ridiculous error slipped off from previous commit. On reinit reset output device when output stream is on (not input).