### PR TITLE
WASAPI: handle KSAUDIO_SPEAKER_QUAD and KSAUDIO_SPEAKER_5POINT1 channel mapping

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1572,7 +1572,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   mix_params->channels = mix_format->nChannels;
   mix_params->layout = mask_to_channel_layout(mix_format.get());
   if (mix_params->layout == CUBEB_LAYOUT_UNDEFINED) {
-    LOG("Output using undefined layout!\n");
+    LOG("Stream using undefined layout! Any mixing may be unpredictable!\n");
   } else if (mix_format->nChannels != CUBEB_CHANNEL_LAYOUT_MAPS[mix_params->layout].channels) {
     // The CUBEB_CHANNEL_LAYOUT_MAPS[mix_params->layout].channels may be
     // different from the mix_params->channels. 6 channel ouput with stereo

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -499,9 +499,21 @@ mask_to_channel_layout(WAVEFORMATEX const * fmt)
     case MASK_3F1: return CUBEB_LAYOUT_3F1;
     case MASK_3F1_LFE: return CUBEB_LAYOUT_3F1_LFE;
     case MASK_2F2: return CUBEB_LAYOUT_2F2;
+    // Special case similar to MASK_2F2 but with rear left and right
+    // speakers instead of side left and right. This mapping is a band-aid as
+    // cubeb does not current have an enum to differentiate this and MASK_2F2,
+    // but is preferred to returning an undefined layout.
+    // See: https://github.com/kinetiknz/cubeb/issues/178 and https://bugzilla.mozilla.org/show_bug.cgi?id=1325023
+    case KSAUDIO_SPEAKER_QUAD: return CUBEB_LAYOUT_2F2;
     case MASK_2F2_LFE: return CUBEB_LAYOUT_2F2_LFE;
     case MASK_3F2: return CUBEB_LAYOUT_3F2;
     case MASK_3F2_LFE: return CUBEB_LAYOUT_3F2_LFE;
+    // Special case similar to MASK_3F2_LFE but with rear left and right
+    // speakers instead of side left and right. his mapping is a band-aid as
+    // cubeb does not current have an enum to differentiate this and MASK_3F2_LFE,
+    // but is preferred to returning an undefined layout.
+    // See: https://github.com/kinetiknz/cubeb/issues/178 and https://bugzilla.mozilla.org/show_bug.cgi?id=1325023
+    case KSAUDIO_SPEAKER_5POINT1: return CUBEB_LAYOUT_3F2_LFE;
     case MASK_3F3R_LFE: return CUBEB_LAYOUT_3F3R_LFE;
     case MASK_3F4_LFE: return CUBEB_LAYOUT_3F4_LFE;
     default: return CUBEB_LAYOUT_UNDEFINED;


### PR DESCRIPTION
Band aid WASAPI channel mappings so that KSAUDIO_SPEAKER_QUAD and KSAUDIO_SPEAKER_5POINT1 are handled rather than returning undefined. Addresses https://github.com/kinetiknz/cubeb/issues/383.