### PR TITLE
Fix issue 378: Pass through as more data as possible when upmixing

### DIFF
--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -460,7 +460,7 @@ cubeb_upmix(long inframes,
 
   /* Put silence in remaining channels. */
   for (long i = 0, o = 0; i < inframes; ++i, o += out_channels) {
-    for (unsigned int j = 2; j < out_channels; ++j) {
+    for (unsigned int j = in_channels; j < out_channels; ++j) {
       assert((unsigned long)o + j < out_len);
       out[o + j] = 0.0;
     }


### PR DESCRIPTION
In the current implementation, only stereo channel will have data. Those channels beyond stereo will be silenced. We should pass through as more data as possible.