### PR TITLE
audiounit: Change AD nominal rate only when is needed

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1752,8 +1752,12 @@ audiounit_create_aggregate_device(cubeb_stream * stm)
     return  CUBEB_ERROR;
   }
 
-  if (input_nominal_rate != output_nominal_rate) {
-    Float64 rate = std::min(input_nominal_rate, output_nominal_rate);
+  /* Do not attempt to change the nominal rate if it's the same with the nominal rate of
+   * output device because it's the master device and rate will set to that anyway. */
+  uint32_t min_rate = std::min(input_nominal_rate, output_nominal_rate);
+  if (input_nominal_rate != output_nominal_rate && min_rate != output_nominal_rate) {
+    LOG("Update aggregate device rate to %u", min_rate);
+    Float64 rate = min_rate;
     AudioObjectPropertyAddress addr = {kAudioDevicePropertyNominalSampleRate,
                                        kAudioObjectPropertyScopeGlobal,
                                        kAudioObjectPropertyElementMaster};
@@ -1765,8 +1769,7 @@ audiounit_create_aggregate_device(cubeb_stream * stm)
                                              sizeof(Float64),
                                              &rate);
     if (rv != noErr) {
-      LOG("AudioObjectSetPropertyData/kAudioDevicePropertyNominalSampleRate, rv=%d", rv);
-      return CUBEB_ERROR;
+      LOG("Non fatal error, AudioObjectSetPropertyData/kAudioDevicePropertyNominalSampleRate, rv=%d", rv);
     }
   }
 


### PR DESCRIPTION
Updating device nominal rate for aggregate device (AD) updates the sampling rate of the devices that AD is consisting of. If the device does not support the given rate the update fails. This patch does 2 things: (a) does not attempt to change the nominal rate of an AD if it is the same with output device rate (output is the master device so the rate will set to that anyway) (b) handle the update failure as non fatal failure.

Update of nominal sample rate for AD used in order to fix a dysfunction on Airpods device but the way that it works makes me wonder if we should ever attempt to change it. I push that fix in order to avoid some known failures and I will continue investigating a better way to approach the problem from the beginning.

cc @djg 