### PR TITLE
Fix deadlock and device collection changed callback issue on OSX 

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -67,7 +67,7 @@ void audiounit_stream_stop_internal(cubeb_stream * stm);
 void audiounit_stream_start_internal(cubeb_stream * stm);
 static void audiounit_close_stream(cubeb_stream *stm);
 static int audiounit_setup_stream(cubeb_stream *stm);
-static std::vector<AudioObjectID>
+static vector<AudioObjectID>
 audiounit_get_devices_of_type(cubeb_device_type devtype);
 
 extern cubeb_ops const audiounit_ops;
@@ -75,26 +75,26 @@ extern cubeb_ops const audiounit_ops;
 struct cubeb {
   cubeb_ops const * ops = &audiounit_ops;
   owned_critical_section mutex;
-  std::atomic<int> active_streams{ 0 };
+  atomic<int> active_streams{ 0 };
   uint32_t global_latency_frames = 0;
   cubeb_device_collection_changed_callback collection_changed_callback = nullptr;
   void * collection_changed_user_ptr = nullptr;
   /* Differentiate input from output devices. */
   cubeb_device_type collection_changed_devtype = CUBEB_DEVICE_TYPE_UNKNOWN;
-  std::vector<AudioObjectID> devtype_device_array;
+  vector<AudioObjectID> devtype_device_array;
   // The queue is asynchronously deallocated once all references to it are released
   dispatch_queue_t serial_queue = dispatch_queue_create(DISPATCH_QUEUE_LABEL, DISPATCH_QUEUE_SERIAL);
   // Current used channel layout
-  std::atomic<cubeb_channel_layout> layout{ CUBEB_LAYOUT_UNDEFINED };
+  atomic<cubeb_channel_layout> layout{ CUBEB_LAYOUT_UNDEFINED };
 };
 
-static std::unique_ptr<AudioChannelLayout, decltype(&free)>
+static unique_ptr<AudioChannelLayout, decltype(&free)>
 make_sized_audio_channel_layout(size_t sz)
 {
     assert(sz >= sizeof(AudioChannelLayout));
     AudioChannelLayout * acl = reinterpret_cast<AudioChannelLayout *>(calloc(1, sz));
     assert(acl); // Assert the allocation works.
-    return std::unique_ptr<AudioChannelLayout, decltype(&free)>(acl, free);
+    return unique_ptr<AudioChannelLayout, decltype(&free)>(acl, free);
 }
 
 enum io_side {
@@ -158,33 +158,33 @@ struct cubeb_stream {
   owned_critical_section mutex;
   /* Hold the input samples in every
    * input callback iteration */
-  std::unique_ptr<auto_array_wrapper> input_linear_buffer;
+  unique_ptr<auto_array_wrapper> input_linear_buffer;
   owned_critical_section input_linear_buffer_lock;
   // After the resampling some input data remains stored inside
   // the resampler. This number is used in order to calculate
   // the number of extra silence frames in input.
-  std::atomic<uint32_t> available_input_frames{ 0 };
+  atomic<uint32_t> available_input_frames{ 0 };
   /* Frames on input buffer */
-  std::atomic<uint32_t> input_buffer_frames{ 0 };
+  atomic<uint32_t> input_buffer_frames{ 0 };
   /* Frame counters */
-  std::atomic<uint64_t> frames_played{ 0 };
+  atomic<uint64_t> frames_played{ 0 };
   uint64_t frames_queued = 0;
-  std::atomic<int64_t> frames_read{ 0 };
-  std::atomic<bool> shutdown{ true };
-  std::atomic<bool> draining{ false };
+  atomic<int64_t> frames_read{ 0 };
+  atomic<bool> shutdown{ true };
+  atomic<bool> draining{ false };
   /* Latency requested by the user. */
   uint32_t latency_frames = 0;
-  std::atomic<uint64_t> current_latency_frames{ 0 };
+  atomic<uint64_t> current_latency_frames{ 0 };
   uint64_t hw_latency_frames = UINT64_MAX;
-  std::atomic<float> panning{ 0 };
-  std::unique_ptr<cubeb_resampler, decltype(&cubeb_resampler_destroy)> resampler;
+  atomic<float> panning{ 0 };
+  unique_ptr<cubeb_resampler, decltype(&cubeb_resampler_destroy)> resampler;
   /* This is true if a device change callback is currently running.  */
-  std::atomic<bool> switching_device{ false };
-  std::atomic<bool> buffer_size_change_state{ false };
+  atomic<bool> switching_device{ false };
+  atomic<bool> buffer_size_change_state{ false };
   AudioDeviceID aggregate_device_id = 0;    // the aggregate device id
   AudioObjectID plugin_id = 0;              // used to create aggregate device
   /* Mixer interface */
-  std::unique_ptr<cubeb_mixer, decltype(&cubeb_mixer_destroy)> mixer;
+  unique_ptr<cubeb_mixer, decltype(&cubeb_mixer_destroy)> mixer;
 };
 
 bool has_input(cubeb_stream * stm)
@@ -528,7 +528,7 @@ audiounit_output_callback(void * user_ptr,
 
   AudioFormatFlags outaff = stm->output_desc.mFormatFlags;
   float panning = (stm->output_desc.mChannelsPerFrame == 2) ?
-      stm->panning.load(std::memory_order_relaxed) : 0.0f;
+      stm->panning.load(memory_order_relaxed) : 0.0f;
 
   /* Post process output samples. */
   if (stm->draining) {
@@ -1067,7 +1067,7 @@ audiounit_get_min_latency(cubeb * /* ctx */,
     return CUBEB_ERROR;
   }
 
-  *latency_frames = std::max<uint32_t>(latency_range.mMinimum,
+  *latency_frames = max<uint32_t>(latency_range.mMinimum,
                                        SAFE_MIN_LATENCY_FRAMES);
 #endif
 
@@ -1411,10 +1411,10 @@ audiounit_layout_init(cubeb_stream * stm, io_side side)
   stm->context->layout = audiounit_get_current_channel_layout(stm->output_unit);
 }
 
-static std::vector<AudioObjectID>
+static vector<AudioObjectID>
 audiounit_get_sub_devices(AudioDeviceID device_id)
 {
-  std::vector<AudioDeviceID> sub_devices;
+  vector<AudioDeviceID> sub_devices;
   AudioObjectPropertyAddress property_address = { kAudioAggregateDevicePropertyActiveSubDeviceList,
                                                   kAudioObjectPropertyScopeGlobal,
                                                   kAudioObjectPropertyElementMaster };
@@ -1553,8 +1553,8 @@ audiounit_set_aggregate_sub_device_list(AudioDeviceID aggregate_device_id,
 {
   LOG("Add devices input %u and output %u into aggregate device %u",
       input_device_id, output_device_id, aggregate_device_id);
-  const std::vector<AudioDeviceID> output_sub_devices = audiounit_get_sub_devices(output_device_id);
-  const std::vector<AudioDeviceID> input_sub_devices = audiounit_get_sub_devices(input_device_id);
+  const vector<AudioDeviceID> output_sub_devices = audiounit_get_sub_devices(output_device_id);
+  const vector<AudioDeviceID> input_sub_devices = audiounit_get_sub_devices(input_device_id);
 
   CFMutableArrayRef aggregate_sub_devices_array = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
   /* The order of the items in the array is significant and is used to determine the order of the streams
@@ -1605,7 +1605,7 @@ audiounit_set_master_aggregate_device(const AudioDeviceID aggregate_device_id)
 
   // Master become the 1st output sub device
   AudioDeviceID output_device_id = audiounit_get_default_device_id(CUBEB_DEVICE_TYPE_OUTPUT);
-  const std::vector<AudioDeviceID> output_sub_devices = audiounit_get_sub_devices(output_device_id);
+  const vector<AudioDeviceID> output_sub_devices = audiounit_get_sub_devices(output_device_id);
   CFStringRef master_sub_device = get_device_name(output_sub_devices[0]);
 
   UInt32 size = sizeof(CFStringRef);
@@ -1966,7 +1966,7 @@ audiounit_clamp_latency(cubeb_stream * stm, uint32_t latency_frames)
   // For the 1st stream set anything within safe min-max
   assert(stm->context->active_streams > 0);
   if (stm->context->active_streams == 1) {
-    return std::max(std::min<uint32_t>(latency_frames, SAFE_MAX_LATENCY_FRAMES),
+    return max(min<uint32_t>(latency_frames, SAFE_MAX_LATENCY_FRAMES),
                     SAFE_MIN_LATENCY_FRAMES);
   }
   assert(stm->output_unit);
@@ -1988,7 +1988,7 @@ audiounit_clamp_latency(cubeb_stream * stm, uint32_t latency_frames)
       return 0;
     }
 
-    output_buffer_size = std::max(std::min<uint32_t>(output_buffer_size, SAFE_MAX_LATENCY_FRAMES),
+    output_buffer_size = max(min<uint32_t>(output_buffer_size, SAFE_MAX_LATENCY_FRAMES),
                                   SAFE_MIN_LATENCY_FRAMES);
   }
 
@@ -2005,14 +2005,14 @@ audiounit_clamp_latency(cubeb_stream * stm, uint32_t latency_frames)
       return 0;
     }
 
-    input_buffer_size = std::max(std::min<uint32_t>(input_buffer_size, SAFE_MAX_LATENCY_FRAMES),
+    input_buffer_size = max(min<uint32_t>(input_buffer_size, SAFE_MAX_LATENCY_FRAMES),
                                  SAFE_MIN_LATENCY_FRAMES);
   }
 
   // Every following active streams can only set smaller latency
   UInt32 upper_latency_limit = 0;
   if (input_buffer_size != 0 && output_buffer_size != 0) {
-    upper_latency_limit = std::min<uint32_t>(input_buffer_size, output_buffer_size);
+    upper_latency_limit = min<uint32_t>(input_buffer_size, output_buffer_size);
   } else if (input_buffer_size != 0) {
     upper_latency_limit = input_buffer_size;
   } else if (output_buffer_size != 0) {
@@ -2021,7 +2021,7 @@ audiounit_clamp_latency(cubeb_stream * stm, uint32_t latency_frames)
     upper_latency_limit = SAFE_MAX_LATENCY_FRAMES;
   }
 
-  return std::max(std::min<uint32_t>(latency_frames, upper_latency_limit),
+  return max(min<uint32_t>(latency_frames, upper_latency_limit),
                   SAFE_MIN_LATENCY_FRAMES);
 }
 
@@ -2561,8 +2561,8 @@ audiounit_stream_init(cubeb * context,
                       cubeb_state_callback state_callback,
                       void * user_ptr)
 {
-  std::unique_ptr<cubeb_stream, decltype(&audiounit_stream_destroy)> stm(new cubeb_stream(context),
-                                                                         audiounit_stream_destroy);
+  unique_ptr<cubeb_stream, decltype(&audiounit_stream_destroy)> stm(new cubeb_stream(context),
+                                                                    audiounit_stream_destroy);
   context->active_streams += 1;
   int r;
 
@@ -2867,7 +2867,7 @@ int audiounit_stream_set_panning(cubeb_stream * stm, float panning)
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 
-  stm->panning.store(panning, std::memory_order_relaxed);
+  stm->panning.store(panning, memory_order_relaxed);
   return CUBEB_OK;
 }
 
@@ -3048,7 +3048,7 @@ audiounit_get_available_samplerate(AudioObjectID devid, AudioObjectPropertyScope
   if (AudioObjectHasProperty(devid, &adr) &&
       AudioObjectGetPropertyDataSize(devid, &adr, 0, NULL, &size) == noErr) {
     uint32_t count = size / sizeof(AudioValueRange);
-    std::vector<AudioValueRange> ranges(count);
+    vector<AudioValueRange> ranges(count);
     range.mMinimum = 9999999999.0;
     range.mMaximum = 0.0;
     if (AudioObjectGetPropertyData(devid, &adr, 0, NULL, &size, ranges.data()) == noErr) {
@@ -3191,8 +3191,8 @@ static int
 audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
                             cubeb_device_collection * collection)
 {
-  std::vector<AudioObjectID> input_devs;
-  std::vector<AudioObjectID> output_devs;
+  vector<AudioObjectID> input_devs;
+  vector<AudioObjectID> output_devs;
 
   // Count number of input and output devices.  This is not
   // necessarily the same as the count of raw devices supported by the
@@ -3257,7 +3257,7 @@ audiounit_device_collection_destroy(cubeb * /* context */,
   return CUBEB_OK;
 }
 
-static std::vector<AudioObjectID>
+static vector<AudioObjectID>
 audiounit_get_devices_of_type(cubeb_device_type devtype)
 {
   AudioObjectPropertyAddress adr = { kAudioHardwarePropertyDevices,
@@ -3266,18 +3266,18 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
   UInt32 size = 0;
   OSStatus ret = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &adr, 0, NULL, &size);
   if (ret != noErr) {
-    return std::vector<AudioObjectID>();
+    return vector<AudioObjectID>();
   }
   /* Total number of input and output devices. */
   uint32_t count = (uint32_t)(size / sizeof(AudioObjectID));
 
-  std::vector<AudioObjectID> devices(count);
+  vector<AudioObjectID> devices(count);
   ret = AudioObjectGetPropertyData(kAudioObjectSystemObject, &adr, 0, NULL, &size, devices.data());
   if (ret != noErr) {
-    return std::vector<AudioObjectID>();
+    return vector<AudioObjectID>();
   }
   /* Expected sorted but did not find anything in the docs. */
-  std::sort(devices.begin(), devices.end(), [](AudioObjectID a, AudioObjectID b) {
+  sort(devices.begin(), devices.end(), [](AudioObjectID a, AudioObjectID b) {
       return a < b;
     });
 
@@ -3289,7 +3289,7 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
                                          kAudioDevicePropertyScopeInput :
                                          kAudioDevicePropertyScopeOutput;
 
-  std::vector<AudioObjectID> devices_in_scope;
+  vector<AudioObjectID> devices_in_scope;
   for (uint32_t i = 0; i < count; ++i) {
     /* For device in the given scope channel must be > 0. */
     if (audiounit_get_channel_count(devices[i], scope) > 0) {
@@ -3319,7 +3319,7 @@ audiounit_collection_changed_callback(AudioObjectID /* inObjectID */,
     /* Differentiate input from output changes. */
     if (context->collection_changed_devtype == CUBEB_DEVICE_TYPE_INPUT ||
         context->collection_changed_devtype == CUBEB_DEVICE_TYPE_OUTPUT) {
-      std::vector<AudioObjectID> devices = audiounit_get_devices_of_type(context->collection_changed_devtype);
+      vector<AudioObjectID> devices = audiounit_get_devices_of_type(context->collection_changed_devtype);
       /* When count is the same examine the devid for the case of coalescing. */
       if (context->devtype_device_array == devices) {
         /* Device changed for the other scope, ignore. */

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3340,7 +3340,7 @@ audiounit_collection_changed_callback(AudioObjectID /* inObjectID */,
           CFStringRef name = get_device_name(*it);
           if (CFStringFind(name, CFSTR("CubebAggregateDevice"), 0).location !=
               kCFNotFound) {
-            it = new_devices.erase(it++);
+            it = new_devices.erase(it);
           } else {
             it++;
           }

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -127,6 +127,8 @@ TEST(cubeb, duplex)
 void device_collection_changed_callback(cubeb * context, void * user)
 {
   fprintf(stderr, "collection changed callback\n");
+  ASSERT_TRUE(false) << "Error: device collection changed callback"
+                        " called when opening a stream";
 }
 
 TEST(cubeb, duplex_collection_change)

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -123,3 +123,49 @@ TEST(cubeb, duplex)
 
   ASSERT_TRUE(stream_state.seen_audio.load());
 }
+
+void device_collection_changed_callback(cubeb * context, void * user)
+{
+  fprintf(stderr, "collection changed callback\n");
+}
+
+TEST(cubeb, duplex_collection_change)
+{
+  cubeb *ctx;
+  cubeb_stream *stream;
+  cubeb_stream_params input_params;
+  cubeb_stream_params output_params;
+  int r;
+  uint32_t latency_frames = 0;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  r = cubeb_register_device_collection_changed(ctx,
+                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT & CUBEB_DEVICE_TYPE_INPUT),
+                                               device_collection_changed_callback,
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  /* typical user-case: mono input, stereo output, low latency. */
+  input_params.format = STREAM_FORMAT;
+  input_params.rate = 48000;
+  input_params.channels = 1;
+  input_params.layout = CUBEB_LAYOUT_MONO;
+  output_params.format = STREAM_FORMAT;
+  output_params.rate = 48000;
+  output_params.channels = 2;
+  output_params.layout = CUBEB_LAYOUT_STEREO;
+
+  r = cubeb_get_min_latency(ctx, &output_params, &latency_frames);
+  ASSERT_EQ(r, CUBEB_OK) << "Could not get minimal latency";
+
+  r = cubeb_stream_init(ctx, &stream, "Cubeb duplex",
+                        NULL, &input_params, NULL, &output_params,
+                        latency_frames, data_cb_duplex, state_cb_duplex, nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
+  cubeb_stream_destroy(stream);
+}

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -144,7 +144,7 @@ TEST(cubeb, duplex_collection_change)
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   r = cubeb_register_device_collection_changed(ctx,
-                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT & CUBEB_DEVICE_TYPE_INPUT),
+                                               CUBEB_DEVICE_TYPE_INPUT & CUBEB_DEVICE_TYPE_INPUT,
                                                device_collection_changed_callback,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -144,7 +144,7 @@ TEST(cubeb, duplex_collection_change)
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   r = cubeb_register_device_collection_changed(ctx,
-                                               CUBEB_DEVICE_TYPE_INPUT & CUBEB_DEVICE_TYPE_INPUT,
+                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT),
                                                device_collection_changed_callback,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";


### PR DESCRIPTION
- Fix deadlock when creating a duplex stream when a device collection change callback was installed
- Stop calling this callback when creating a duplex stream (the fact that we create a device internally should not be exposed), and add a test for it.
- sed 's/std:://' since I added `using namespace std;`.