### PR TITLE
pulse: avoid deadlock when context subscribe fails

### DIFF
--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1565,6 +1565,7 @@ pulse_register_device_collection_changed(cubeb * context,
   pa_operation * o;
   o = WRAP(pa_context_subscribe)(context->context, mask, subscribe_success, context);
   if (o == NULL) {
+    WRAP(pa_threaded_mainloop_unlock)(context->mainloop);
     LOG("Context subscribe failed");
     return CUBEB_ERROR;
   }


### PR DESCRIPTION
When `pa_context_subscribe` fails we need to unlock the main loop to avoid infinite blocking.