### PR TITLE
WASAPI: Check that the input side of a stream was successfully setup before pushing silence

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1671,6 +1671,10 @@ int setup_wasapi_stream(cubeb_stream * stm)
                                       stm->input_available_event,
                                       stm->capture_client,
                                       &stm->input_mix_params);
+    if (rv != CUBEB_OK) {
+      LOG("Failure to open the input side.");
+      return rv;
+    }
 
     // We initializing an input stream, buffer ahead two buffers worth of silence.
     // This delays the input side slightly, but allow to not glitch when no input
@@ -1683,13 +1687,8 @@ int setup_wasapi_stream(cubeb_stream * stm)
     const int silent_buffer_count = 4;
 #endif
     stm->linear_input_buffer->push_silence(stm->input_buffer_frame_count *
-                                          stm->input_stream_params.channels *
-                                          silent_buffer_count);
-
-    if (rv != CUBEB_OK) {
-      LOG("Failure to open the input side.");
-      return rv;
-    }
+                                           stm->input_stream_params.channels *
+                                           silent_buffer_count);
   }
 
   if (has_output(stm)) {


### PR DESCRIPTION
Address #403 by checking if setup succeeded before pushing silence.