### PR TITLE
Add assertion to make sure output params are present for winmm_stream_init

### DIFF
--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -402,6 +402,7 @@ winmm_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_n
 
   XASSERT(context);
   XASSERT(stream);
+  XASSERT(output_stream_params);
 
   if (input_stream_params) {
     /* Capture support not yet implemented. */


### PR DESCRIPTION
Think we can end up with a nullptr deref at `if (output_stream_params->channels > 2) {`.

Wasn't sure if this should be an assert or an early return. Please advise if early return is preferred.