### PR TITLE
Provide access to cubeb_stream's user ptr.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -599,6 +599,11 @@ CUBEB_EXPORT int cubeb_stream_device_destroy(cubeb_stream * stream,
 CUBEB_EXPORT int cubeb_stream_register_device_changed_callback(cubeb_stream * stream,
                                                                cubeb_device_changed_callback device_changed_callback);
 
+/** Return the user data pointer registered with the stream with cubeb_stream_init.
+    @param stream the stream for which to retrieve user data pointer.
+    @retval user data pointer */
+CUBEB_EXPORT void * cubeb_stream_user_ptr(cubeb_stream * stream);
+
 /** Returns enumerated devices.
     @param context
     @param devtype device type to include

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -20,6 +20,7 @@ struct cubeb {
 
 struct cubeb_stream {
   struct cubeb * context;
+  void * user_ptr;
 };
 
 #if defined(USE_PULSE)
@@ -473,6 +474,15 @@ int cubeb_stream_register_device_changed_callback(cubeb_stream * stream,
   }
 
   return stream->context->ops->stream_register_device_changed_callback(stream, device_changed_callback);
+}
+
+void * cubeb_stream_user_ptr(cubeb_stream * stream)
+{
+  if (!stream) {
+    return NULL;
+  }
+
+  return stream->user_ptr;
 }
 
 static

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -19,6 +19,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /*
+   * Note: All implementations of cubeb_stream must keep the following
+   * layout.
+   */
   struct cubeb * context;
   void * user_ptr;
 };

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -76,8 +76,10 @@ enum stream_state {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
   pthread_mutex_t mutex;
   snd_pcm_t * pcm;
   cubeb_data_callback data_callback;

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -77,11 +77,11 @@ enum stream_state {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
   pthread_mutex_t mutex;
   snd_pcm_t * pcm;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
-  void * user_ptr;
   snd_pcm_uframes_t stream_position;
   snd_pcm_uframes_t last_position;
   snd_pcm_uframes_t buffer_size;

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -75,8 +75,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -76,11 +76,11 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
   void * instance;
-  void * user_ptr;
   /* Number of frames that have been passed to the AudioTrack callback */
   long unsigned written;
   int draining;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -129,9 +129,10 @@ struct device_info {
 struct cubeb_stream {
   explicit cubeb_stream(cubeb * context);
 
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
-  /* User pointer of data_callback */
   void * user_ptr = nullptr;
+  /**/
 
   cubeb_data_callback data_callback = nullptr;
   cubeb_state_callback state_callback = nullptr;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -130,6 +130,9 @@ struct cubeb_stream {
   explicit cubeb_stream(cubeb * context);
 
   cubeb * context;
+  /* User pointer of data_callback */
+  void * user_ptr = nullptr;
+
   cubeb_data_callback data_callback = nullptr;
   cubeb_state_callback state_callback = nullptr;
   cubeb_device_changed_callback device_changed_callback = nullptr;
@@ -139,8 +142,6 @@ struct cubeb_stream {
   cubeb_stream_params output_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0, CUBEB_LAYOUT_UNDEFINED, CUBEB_STREAM_PREF_NONE };
   device_info input_device;
   device_info output_device;
-  /* User pointer of data_callback */
-  void * user_ptr = nullptr;
   /* Format descriptions */
   AudioStreamBasicDescription input_desc;
   AudioStreamBasicDescription output_desc;

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -139,8 +139,10 @@ static struct cubeb_ops const cbjack_ops = {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
 
   /**< Mutex for each stream */
   pthread_mutex_t mutex;

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -140,6 +140,7 @@ static struct cubeb_ops const cbjack_ops = {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
 
   /**< Mutex for each stream */
   pthread_mutex_t mutex;
@@ -149,7 +150,6 @@ struct cubeb_stream {
 
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
-  void * user_ptr;
   cubeb_stream_params in_params;
   cubeb_stream_params out_params;
 

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -31,8 +31,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -32,10 +32,10 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
-  void * user_ptr;
 
   HKAI hkai;
   KAISPEC spec;

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -87,9 +87,10 @@ struct cubeb {
 #define AUDIO_STREAM_TYPE_MUSIC 3
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
-  /* User pointer for data & state callbacks*/
   void * user_ptr;
+  /**/
   pthread_mutex_t mutex;
   SLObjectItf playerObj;
   SLPlayItf play;

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -88,6 +88,8 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  /* User pointer for data & state callbacks*/
+  void * user_ptr;
   pthread_mutex_t mutex;
   SLObjectItf playerObj;
   SLPlayItf play;
@@ -148,8 +150,6 @@ struct cubeb_stream {
   cubeb_data_callback data_callback;
   /* Store state callback. */
   cubeb_state_callback state_callback;
-  /* User pointer for data & state callbacks*/
-  void * user_ptr;
 
   cubeb_resampler * resampler;
   unsigned int inputrate;

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -118,11 +118,11 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
   pa_stream * output_stream;
   pa_stream * input_stream;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
-  void * user_ptr;
   pa_time_event * drain_timer;
   pa_sample_spec output_sample_spec;
   pa_sample_spec input_sample_spec;

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -117,8 +117,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
   pa_stream * output_stream;
   pa_stream * input_stream;
   cubeb_data_callback data_callback;

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -30,6 +30,7 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  void * arg;                     /* user arg to {data,state}_cb */
   pthread_t th;                   /* to run real-time audio i/o */
   pthread_mutex_t mtx;            /* protects hdl and pos */
   struct sio_hdl *hdl;            /* link us to sndio */
@@ -48,7 +49,6 @@ struct cubeb_stream {
   uint64_t swpos;                 /* number of frames produced/consumed */
   cubeb_data_callback data_cb;    /* cb to preapare data */
   cubeb_state_callback state_cb;  /* cb to notify about state changes */
-  void *arg;                      /* user arg to {data,state}_cb */
 };
 
 static void

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -29,8 +29,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * arg;                     /* user arg to {data,state}_cb */
+  /**/
   pthread_t th;                   /* to run real-time audio i/o */
   pthread_mutex_t mtx;            /* protects hdl and pos */
   struct sio_hdl *hdl;            /* link us to sndio */

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -190,6 +190,7 @@ typedef bool (*wasapi_refill_callback)(cubeb_stream * stm);
 
 struct cubeb_stream {
   cubeb * context = nullptr;
+  void * user_ptr = nullptr;
   /* Mixer pameters. We need to convert the input stream to this
      samplerate/channel layout, as WASAPI does not resample nor upmix
      itself. */
@@ -211,7 +212,6 @@ struct cubeb_stream {
      case a dummy output device is opened to drive the loopback, but should not
      be exposed. */
   bool has_dummy_output = false;
-  void * user_ptr = nullptr;
   /* Lifetime considerations:
      - client, render_client, audio_clock and audio_stream_volume are interface
        pointer to the IAudioClient.

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -189,8 +189,11 @@ class wasapi_endpoint_notification_client;
 typedef bool (*wasapi_refill_callback)(cubeb_stream * stm);
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context = nullptr;
   void * user_ptr = nullptr;
+  /**/
+
   /* Mixer pameters. We need to convert the input stream to this
      samplerate/channel layout, as WASAPI does not resample nor upmix
      itself. */

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -94,10 +94,10 @@ struct cubeb {
 
 struct cubeb_stream {
   cubeb * context;
+  void * user_ptr;
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;
-  void * user_ptr;
   WAVEHDR buffers[NBUFS];
   size_t buffer_size;
   int next_buffer;

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -93,8 +93,10 @@ struct cubeb {
 };
 
 struct cubeb_stream {
+  /* Note: Must match cubeb_stream layout in cubeb.c. */
   cubeb * context;
   void * user_ptr;
+  /**/
   cubeb_stream_params params;
   cubeb_data_callback data_callback;
   cubeb_state_callback state_callback;


### PR DESCRIPTION
cubeb_stream in every backend has a copy of the user data ptr passed
in during `stream_init` but there is no way to access the
value. (Besides from `data_callback`/`state_callback`).

Add `cubeb_stream_user_ptr()` to retrieve the stored value.