### PR TITLE
Wasapi reset stream on invalidated device error

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1016,11 +1016,21 @@ wasapi_stream_render_loop(LPVOID stream)
       }
       XASSERT(stm->output_client || stm->input_client);
       if (stm->output_client) {
-        stm->output_client->Start();
+        hr = stm->output_client->Start();
+        if (FAILED(hr)) {
+          LOG("Error starting output after reconfigure, error: %lx", hr);
+          is_playing = false;
+          continue;
+        }
         LOG("Output started after reconfigure.");
       }
       if (stm->input_client) {
-        stm->input_client->Start();
+        hr = stm->input_client->Start();
+        if (FAILED(hr)) {
+          LOG("Error starting input after reconfiguring, error: %lx", hr);
+          is_playing = false;
+          continue;
+        }
         LOG("Input started after reconfigure.");
       }
       break;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1987,6 +1987,7 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   *stream = stm.release();
 
+  LOG("Stream init succesfull (%p)", *stream);
   return CUBEB_OK;
 }
 
@@ -2016,6 +2017,7 @@ void close_wasapi_stream(cubeb_stream * stm)
 void wasapi_stream_destroy(cubeb_stream * stm)
 {
   XASSERT(stm);
+  LOG("Stream destroy (%p)", stm);
 
   // Only free stm->emergency_bailout if we could join the thread.
   // If we could not join the thread, stm->emergency_bailout is true

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -639,11 +639,10 @@ bool get_input_buffer(cubeb_stream * stm)
   for (hr = stm->capture_client->GetNextPacketSize(&next);
        next > 0;
        hr = stm->capture_client->GetNextPacketSize(&next)) {
-
     if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
-      // Application can recover from that error. More info
+      // Application can recover from this error. More info
       // https://msdn.microsoft.com/en-us/library/windows/desktop/dd316605(v=vs.85).aspx
-      LOG("Device invalidated error, reset deafult device");
+      LOG("Device invalidated error, reset default device");
       wasapi_stream_reset_default_device(stm);
       return true;
     }
@@ -723,11 +722,10 @@ bool get_output_buffer(cubeb_stream * stm, void *& buffer, size_t & frame_count)
   XASSERT(has_output(stm));
 
   hr = stm->output_client->GetCurrentPadding(&padding_out);
-
   if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
-      // Application can recover from that error. More info
+      // Application can recover from this error. More info
       // https://msdn.microsoft.com/en-us/library/windows/desktop/dd316605(v=vs.85).aspx
-      LOG("Device invalidated error, reset deafult device");
+      LOG("Device invalidated error, reset default device");
       wasapi_stream_reset_default_device(stm);
       return true;
   }


### PR DESCRIPTION
Device invalidated error can occurs in many case and the documentation suggests to reset the stream. More info in Bug 1426333. This is implemented on commit 1fb675.

The other two commits are complementary patches that add an error check and 2 log lines.