### PR TITLE
When having on or two channel, force mono or stereo.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1141,6 +1141,12 @@ audiounit_convert_channel_layout(AudioChannelLayout * layout)
     cm.map[i] = channel_label_to_cubeb_channel(layout->mChannelDescriptions[i].mChannelLabel);
   }
 
+  if (layout->mNumberChannelDescriptions == 1) {
+    return CUBEB_LAYOUT_MONO;
+  } else if (layout->mNumberChannelDescriptions == 2) {
+    return CUBEB_LAYOUT_STEREO;
+  }
+
   return cubeb_channel_map_to_layout(&cm);
 }
 


### PR DESCRIPTION
Some devices (namely, Bose QC35, mark 1 and 2), expose a single channel mapped
to the right for some reason, and this confuses our channel mapping code.

This fixes bugzilla bug [#1429725](https://bugzilla.mozilla.org/show_bug.cgi?id=1437366#c9).