### PR TITLE
opensl: Pass in JNIEnv instead of JavaVM

### DIFF
--- a/src/cubeb-jni-instances.h
+++ b/src/cubeb-jni-instances.h
@@ -15,8 +15,8 @@
  * and application's Context object.
  * */
 
-JavaVM *
-cubeb_jni_get_java_vm()
+JNIEnv *
+cubeb_get_jni_env_for_thread()
 {
   return nullptr;
 }


### PR DESCRIPTION
JNIEnv struct is per thread and we need to detach any thread previously attached. Since cubeb is a library we have no control on the thread that initialized cubeb itself. Detaching a working thread is a crash or leaving an attached thread un-detached is also a crash. So we leave to the user the implementation of providing the right JNIEnv pointer for each thread and perform the attach and detach correctly. There is a standard way to implement that using pthread functionality. In Firefox this is implemented in method `mozilla::jni::GetEnvForThread()`.