### PR TITLE
wasapi: Remove COM initialization and require caller to complete.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -408,6 +408,10 @@ typedef void (* cubeb_log_callback)(char const * fmt, ...);
 
 /** Initialize an application context.  This will perform any library or
     application scoped initialization.
+
+    Note: On Windows platforms, COM must be initialized in MTA mode on
+    any thread that will call the cubeb API.
+
     @param context A out param where an opaque pointer to the application
                    context will be returned.
     @param context_name A name for the context. Depending on the platform this

--- a/test/common.h
+++ b/test/common.h
@@ -11,6 +11,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#include <objbase.h>
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -108,5 +109,25 @@ int common_init(cubeb ** ctx, char const * ctx_name)
 
   return r;
 }
+
+#if defined( _WIN32)
+class TestEnvironment : public ::testing::Environment {
+public:
+  void SetUp() override {
+    hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  }
+
+  void TearDown() override {
+    if (SUCCEEDED(hr)) {
+      CoUninitialize();
+    }
+  }
+
+private:
+  HRESULT hr;
+};
+
+::testing::Environment* const foo_env = ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+#endif
 
 #endif /* TEST_COMMON */


### PR DESCRIPTION
This addresses the thread local COM initialization lifetime problem discussed in issue #416 by moving the responsibility for COM initialization from within cubeb to the caller.

This needs minor changes on the Gecko side to ensure COM is initialized from all calling threads.  That's tracked in [BMO 1445546](https://bugzilla.mozilla.org/show_bug.cgi?id=1445546).