### PR TITLE
pulse: check pa_context_connect return value

### DIFF
--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -581,6 +581,8 @@ static void pulse_destroy(cubeb * ctx);
 static int
 pulse_context_init(cubeb * ctx)
 {
+  int r;
+
   if (ctx->context) {
     assert(ctx->error == 1);
     pulse_context_destroy(ctx);
@@ -594,9 +596,9 @@ pulse_context_init(cubeb * ctx)
   WRAP(pa_context_set_state_callback)(ctx->context, context_state_callback, ctx);
 
   WRAP(pa_threaded_mainloop_lock)(ctx->mainloop);
-  WRAP(pa_context_connect)(ctx->context, NULL, 0, NULL);
+  r = WRAP(pa_context_connect)(ctx->context, NULL, 0, NULL);
 
-  if (wait_until_context_ready(ctx) != 0) {
+  if (r < 0 || wait_until_context_ready(ctx) != 0) {
     WRAP(pa_threaded_mainloop_unlock)(ctx->mainloop);
     pulse_context_destroy(ctx);
     ctx->context = NULL;


### PR DESCRIPTION
In `src/cubeb_pulse.c` many calls to PA API never check return codes. I discovered this while I was debugging why Firefox crashes with my "superior reimplementation" of libpulse API (https://github.com/oxij/libcardiacarrest). This is the I needed for my use case. However, if you look at PA API documentation, you'll notice that not only cubeb_pulse.c ignores some PA errors, it is not entirely clear whenever all of the uses of PA API in cubeb_pulse.c are even correct. For instance, is it ok to `drain` the `pa_context` before it successfully connected to the PA daemon? I'm not sure. cubeb_pulse.c `drain`s it anyway.

(Adapted from https://bugzilla.mozilla.org/show_bug.cgi?id=1444519.)