### PR TITLE
audiounit: Fix up channel layout iteration logic.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1347,24 +1347,25 @@ audiounit_set_channel_layout(AudioUnit unit,
 
 
   OSStatus r;
-  int channels = cubeb_channel_layout_nb_channels(layout);
+  uint32_t nb_channels = cubeb_channel_layout_nb_channels(layout);
 
   // We do not use CoreAudio standard layout for lack of documentation on what
   // the actual channel orders are. So we set a custom layout.
-  size_t size = offsetof(AudioChannelLayout, mChannelDescriptions[channels]);
+  size_t size = offsetof(AudioChannelLayout, mChannelDescriptions[nb_channels]);
   auto au_layout = make_sized_audio_channel_layout(size);
   au_layout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions;
-  au_layout->mNumberChannelDescriptions = channels;
+  au_layout->mNumberChannelDescriptions = nb_channels;
+
+  uint32_t channels = 0;
   cubeb_channel_layout channelMap = layout;
-  int i = 0;
-  while (channelMap != 0) {
-    XASSERT(i < channels);
+  for (uint32_t i = 0; channelMap != 0; ++i) {
+    XASSERT(channels < nb_channels);
     uint32_t channel = (channelMap & 1) << i;
     if (channel != 0) {
-      au_layout->mChannelDescriptions[i].mChannelLabel =
+      au_layout->mChannelDescriptions[channels].mChannelLabel =
         cubeb_channel_to_channel_label(static_cast<cubeb_channel>(channel));
-      au_layout->mChannelDescriptions[i].mChannelFlags = kAudioChannelFlags_AllOff;
-      i += 1;
+      au_layout->mChannelDescriptions[channels].mChannelFlags = kAudioChannelFlags_AllOff;
+      channels++;
     }
     channelMap = channelMap >> 1;
   }


### PR DESCRIPTION
It turns out that there are subtleties to iterating the channel bitset that I messed up in a previous commit.
The use of while was trying to be *too* clever and `i` was being used in two places with different intent, so split `i` into `i: the current bit position` and `channels: the current channel index in mChannelDescriptions`.

`channels` is @jyavenard naming that I changed, so switching back to it. 