### PR TITLE
wasapi: check for default playback or capture device on init

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1153,8 +1153,12 @@ int wasapi_init(cubeb ** context, char const * context_name)
   com_ptr<IMMDevice> device;
   HRESULT hr = get_default_endpoint(device, eRender);
   if (FAILED(hr)) {
-    LOG("Could not get device: %lx", hr);
-    return CUBEB_ERROR;
+    LOG("It wasn't able to find a default rendering device: %lx", hr);
+    hr = get_default_endpoint(device, eCapture);
+    if (FAILED(hr)) {
+      LOG("It wasn't able to find a default capture device: %lx", hr);
+      return CUBEB_ERROR;
+    }
   }
 
   cubeb * ctx = new cubeb();


### PR DESCRIPTION
Cubeb instance will fail to initialize when all playback devices are disabled even if there are capture devices available. This is because wasapi_init() method checks for default playback as an indirect way to verify that wasapi is enabled in the platform. In this patch if get default playback fail we check again for the default capture device.