### PR TITLE
wasapi: Fix random crashes on shutdown

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1222,7 +1222,9 @@ bool stop_and_join_render_thread(cubeb_stream * stm)
     CloseHandle(stm->thread);
     stm->thread = NULL;
 
-    CloseHandle(stm->shutdown_event);
+	if (stm->shutdown_event != INVALID_HANDLE_VALUE) {
+      CloseHandle(stm->shutdown_event);
+	}
     stm->shutdown_event = 0;
   }
 


### PR DESCRIPTION
Hi there! This is a bug I discovered by accident while debugging a crash in [Dolphin](https://github.com/dolphin-emu/dolphin).

Sometimes when trying to close a cubeb stream, Dolphin will instead randomly crash because of an invalid handle. This PR fixes this.

If there's something off about this PR or this is a result of a mistake on our side, I'd be happy to assist!