### PR TITLE
return unique_ptr normally, without std::move

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2138,7 +2138,7 @@ utf8_to_wstr(char const * str)
 
   std::unique_ptr<wchar_t []> ret(new wchar_t[size]);
   ::MultiByteToWideChar(CP_UTF8, 0, str, -1, ret.get(), size);
-  return std::move(ret);
+  return ret;
 }
 
 static com_ptr<IMMDevice>


### PR DESCRIPTION
clang warns about using `return std::move($LOCAL)`.