### PR TITLE
wasapi: Reduce timeout threshold

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -871,7 +871,7 @@ wasapi_stream_render_loop(LPVOID stream)
      the timeout error handling only when the timeout_limit is reached, which is
      reset on each successful loop. */
   unsigned timeout_count = 0;
-  const unsigned timeout_limit = 5;
+  const unsigned timeout_limit = 3;
   while (is_playing) {
     // We want to check the emergency bailout variable before a
     // and after the WaitForMultipleObject, because the handles WaitForMultipleObjects


### PR DESCRIPTION
See [bug 1465617 comment 20](https://bugzilla.mozilla.org/show_bug.cgi?id=1465617#c20) for the background for this change.

In short the Firefox shutdown hang monitor also times out after 5 seconds by default, so cubeb has to timeout faster or confusing almost-coherent stacks show up in crash-stats.