### PR TITLE
Fix for #448

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -291,7 +291,7 @@ cubeb_channel_to_channel_label(cubeb_channel channel)
     case CHANNEL_TOP_BACK_RIGHT:
       return kAudioChannelLabel_TopBackRight;
     default:
-      return CHANNEL_UNKNOWN;
+      return kAudioChannelLabel_Unknown;
   }
 }
 
@@ -1232,8 +1232,12 @@ audiounit_convert_channel_layout(AudioChannelLayout * layout)
 
   cubeb_channel_layout cl = 0;
   for (UInt32 i = 0; i < layout->mNumberChannelDescriptions; ++i) {
-    cl |= channel_label_to_cubeb_channel(
+    cubeb_channel cc = channel_label_to_cubeb_channel(
       layout->mChannelDescriptions[i].mChannelLabel);
+    if (cc == CHANNEL_UNKNOWN) {
+      return CUBEB_LAYOUT_UNDEFINED;
+    }
+    cl |= cc;
   }
 
   return cl;

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -533,6 +533,18 @@ struct cubeb_mixer
         output_buffer += _context._out_ch_count - _context._in_ch_count;
       }
     } else {
+      if (_context._in_ch_count == 1 && _context._out_ch_count >= 2) {
+        // Special case for upmixing mono input to stereo and more. We will
+        // duplicate the mono channel to the first two channels. On most system,
+        // the first two channels are for left and right. It is commonly
+        // expected that mono will on both left+right channels
+        for (uint32_t i = 0; i < frames; i++) {
+          output_buffer[0] = output_buffer[1] = *input_buffer;
+          output_buffer += _context._out_ch_count ;
+          input_buffer++;
+        }
+        return;
+      }
       for (uint32_t i = 0; i < frames; i++) {
         PodCopy(output_buffer, input_buffer, _context._out_ch_count);
         output_buffer += _context._out_ch_count;


### PR DESCRIPTION
The method kAudioUnitProperty_AudioChannelLayout used to retrieve the channel layout wasn't introduced until 10.12. So we use kAudioDevicePropertyPreferredChannelLayout instead should it fails.

Fixes #448