### PR TITLE
Simplify audiounit_add/remove_listener() by introducing property_listener

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3308,11 +3308,10 @@ audiounit_device_collection_destroy(cubeb * /* context */,
 static vector<AudioObjectID>
 audiounit_get_devices_of_type(cubeb_device_type devtype)
 {
-  AudioObjectPropertyAddress adr = { kAudioHardwarePropertyDevices,
-                                     kAudioObjectPropertyScopeGlobal,
-                                     kAudioObjectPropertyElementMaster };
   UInt32 size = 0;
-  OSStatus ret = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &adr, 0, NULL, &size);
+  OSStatus ret = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
+                                                &DEVICES_PROPERTY_ADDRESS, 0,
+                                                NULL, &size);
   if (ret != noErr) {
     return vector<AudioObjectID>();
   }
@@ -3320,7 +3319,9 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
   uint32_t count = (uint32_t)(size / sizeof(AudioObjectID));
 
   vector<AudioObjectID> devices(count);
-  ret = AudioObjectGetPropertyData(kAudioObjectSystemObject, &adr, 0, NULL, &size, devices.data());
+  ret = AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                   &DEVICES_PROPERTY_ADDRESS, 0, NULL, &size,
+                                   devices.data());
   if (ret != noErr) {
     return vector<AudioObjectID>();
   }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1062,7 +1062,7 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
   // Failing to uninstall listeners is not a fatal error.
   int r = CUBEB_OK;
 
-  if (stm->output_unit && stm->output_source_listener) {
+  if (stm->output_source_listener) {
     rv = audiounit_remove_listener(stm->output_source_listener.get());
     if (rv != noErr) {
       LOG("AudioObjectRemovePropertyListener/output/kAudioDevicePropertyDataSource rv=%d, device id=%d", rv, stm->output_device.id);
@@ -1070,23 +1070,22 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
     }
   }
 
-  if (stm->input_unit) {
-    if (stm->input_source_listener) {
-      rv = audiounit_remove_listener(stm->input_source_listener.get());
-      if (rv != noErr) {
-        LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDataSource rv=%d, device id=%d", rv, stm->input_device.id);
-        r = CUBEB_ERROR;
-      }
-    }
-
-    if (stm->input_alive_listener) {
-      rv = audiounit_remove_listener(stm->input_alive_listener.get());
-      if (rv != noErr) {
-        LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDeviceIsAlive rv=%d, device id=%d", rv, stm->input_device.id);
-        r = CUBEB_ERROR;
-      }
+  if (stm->input_source_listener) {
+    rv = audiounit_remove_listener(stm->input_source_listener.get());
+    if (rv != noErr) {
+      LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDataSource rv=%d, device id=%d", rv, stm->input_device.id);
+      r = CUBEB_ERROR;
     }
   }
+
+  if (stm->input_alive_listener) {
+    rv = audiounit_remove_listener(stm->input_alive_listener.get());
+    if (rv != noErr) {
+      LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDeviceIsAlive rv=%d, device id=%d", rv, stm->input_device.id);
+      r = CUBEB_ERROR;
+    }
+  }
+
   return r;
 }
 
@@ -1095,14 +1094,14 @@ audiounit_uninstall_system_changed_callback(cubeb_stream * stm)
 {
   OSStatus r;
 
-  if (has_output(stm) && stm->default_output_listener) {
+  if (stm->default_output_listener) {
     r = audiounit_remove_listener(stm->default_output_listener.get());
     if (r != noErr) {
       return CUBEB_ERROR;
     }
   }
 
-  if (has_input(stm) && stm->default_input_listener) {
+  if (stm->default_input_listener) {
     r = audiounit_remove_listener(stm->default_input_listener.get());
     if (r != noErr) {
       return CUBEB_ERROR;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -64,6 +64,12 @@ const char * PRIVATE_AGGREGATE_DEVICE_NAME = "CubebAggregateDevice";
 const uint32_t SAFE_MIN_LATENCY_FRAMES = 256;
 const uint32_t SAFE_MAX_LATENCY_FRAMES = 512;
 
+const AudioObjectPropertyAddress DEVICES_PROPERTY_ADDRESS = {
+  kAudioHardwarePropertyDevices,
+  kAudioObjectPropertyScopeGlobal,
+  kAudioObjectPropertyElementMaster
+};
+
 void audiounit_stream_stop_internal(cubeb_stream * stm);
 void audiounit_stream_start_internal(cubeb_stream * stm);
 static void audiounit_close_stream(cubeb_stream *stm);
@@ -3414,13 +3420,8 @@ audiounit_add_device_listener(cubeb * context,
    * Current implementation requires unregister before register a new cb. */
   assert(context->collection_changed_callback == NULL);
 
-  AudioObjectPropertyAddress devAddr;
-  devAddr.mSelector = kAudioHardwarePropertyDevices;
-  devAddr.mScope = kAudioObjectPropertyScopeGlobal;
-  devAddr.mElement = kAudioObjectPropertyElementMaster;
-
   OSStatus ret = AudioObjectAddPropertyListener(kAudioObjectSystemObject,
-                                                &devAddr,
+                                                &DEVICES_PROPERTY_ADDRESS,
                                                 audiounit_collection_changed_callback,
                                                 context);
   if (ret == noErr) {
@@ -3443,14 +3444,9 @@ audiounit_add_device_listener(cubeb * context,
 static OSStatus
 audiounit_remove_device_listener(cubeb * context)
 {
-  AudioObjectPropertyAddress devAddr;
-  devAddr.mSelector = kAudioHardwarePropertyDevices;
-  devAddr.mScope = kAudioObjectPropertyScopeGlobal;
-  devAddr.mElement = kAudioObjectPropertyElementMaster;
-
   /* Note: unregister a non registered cb is not a problem, not checking. */
   OSStatus ret = AudioObjectRemovePropertyListener(kAudioObjectSystemObject,
-                                                   &devAddr,
+                                                   &DEVICES_PROPERTY_ADDRESS,
                                                    audiounit_collection_changed_callback,
                                                    context);
   if (ret == noErr) {

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1120,20 +1120,19 @@ audiounit_get_acceptable_latency_range(AudioValueRange * latency_range)
 static AudioObjectID
 audiounit_get_default_device_id(cubeb_device_type type)
 {
-  AudioObjectPropertyAddress adr = { 0, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster };
-  AudioDeviceID devid;
-  UInt32 size;
-
+  const AudioObjectPropertyAddress * adr;
   if (type == CUBEB_DEVICE_TYPE_OUTPUT) {
-    adr.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+    adr = &DEFAULT_OUTPUT_DEVICE_PROPERTY_ADDRESS;
   } else if (type == CUBEB_DEVICE_TYPE_INPUT) {
-    adr.mSelector = kAudioHardwarePropertyDefaultInputDevice;
+    adr = &DEFAULT_INPUT_DEVICE_PROPERTY_ADDRESS;
   } else {
     return kAudioObjectUnknown;
   }
 
-  size = sizeof(AudioDeviceID);
-  if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &adr, 0, NULL, &size, &devid) != noErr) {
+  AudioDeviceID devid;
+  UInt32 size = sizeof(AudioDeviceID);
+  if (AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                 adr, 0, NULL, &size, &devid) != noErr) {
     return kAudioObjectUnknown;
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2949,24 +2949,12 @@ int audiounit_get_default_device_datasource(cubeb_device_type type,
     return CUBEB_ERROR;
   }
 
-  AudioObjectPropertyAddress datasource_address_output = {
-    kAudioDevicePropertyDataSource,
-    kAudioDevicePropertyScopeOutput,
-    kAudioObjectPropertyElementMaster
-  };
-
-  AudioObjectPropertyAddress datasource_address_input = {
-    kAudioDevicePropertyDataSource,
-    kAudioDevicePropertyScopeInput,
-    kAudioObjectPropertyElementMaster
-  };
-
   UInt32 size = sizeof(*data);
   /* This fails with some USB headsets (e.g., Plantronic .Audio 628). */
   OSStatus r = AudioObjectGetPropertyData(id,
                                           type == CUBEB_DEVICE_TYPE_INPUT ?
-                                            &datasource_address_input :
-                                            &datasource_address_output,
+                                            &INPUT_DATA_SOURCE_PROPERTY_ADDRESS :
+                                            &OUTPUT_DATA_SOURCE_PROPERTY_ADDRESS,
                                           0, NULL, &size, data);
   if (r != noErr) {
     *data = 0;

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -951,7 +951,7 @@ audiounit_property_listener_callback(AudioObjectID id, UInt32 address_count,
 }
 
 OSStatus
-audiounit_add_listener(property_listener * listener)
+audiounit_add_listener(const property_listener * listener)
 {
   assert(listener);
   return AudioObjectAddPropertyListener(listener->device_id,
@@ -961,7 +961,7 @@ audiounit_add_listener(property_listener * listener)
 }
 
 OSStatus
-audiounit_remove_listener(property_listener * listener)
+audiounit_remove_listener(const property_listener * listener)
 {
   assert(listener);
   return AudioObjectRemovePropertyListener(listener->device_id,


### PR DESCRIPTION
```audiounit_add_listener(...)``` and ```audiounit_remove_listener(...)``` should use exactly same variable to register and unregister event listener. Originally, these two functions are set by different local variables with same values: ```audiounit_add_listener(X, Y, Z, ...)``` and ```audiounit_remove_listener(X', Y', Z', ...)```, where X = X', Y = Y',...etc. There are too many function parameters so it's not easy to check if we have same parameters for ```audiounit_add_listener(...)``` and ```audiounit_remove_listener(...)```.

```property_listener``` is introduced to simplify the parameter issues by using ```audiounit_add/remove_listener(property_listener L)```. A property_listener object L is created to register a event listener, and then be used to unregister the listener later. It'll be safer if ```audiounit_add_listener(...)``` and ```audiounit_remove_listener(...)``` use the exactly same object as their parameters. In addition, The readability is better since there is a **listener** be added/removed when we call ```audiounit_add/remove_listener(listener L)```.