### PR TITLE
Reduce duplicate code in audiounit_stream_get_current_device

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2891,15 +2891,19 @@ int audiounit_stream_set_panning(cubeb_stream * stm, float panning)
 
 unique_ptr<char[]> convert_uint32_into_string(UInt32 data)
 {
-  /* Simply create an empty string if no data. */
-  size_t size = data == 0 ? 0 : sizeof(data);
-  auto str = unique_ptr<char[]> { new char[size + 1] };
-  // Reverse 0xWXYZ into 0xZYXW.
-  for (size_t i = 0; i < size; ++i) {
-    char * p = (char *) &data;
-    str[i] = p[size - 1 - i];
-  }
+  // Simply create an empty string if no data.
+  size_t size = data == 0 ? 0 : 4; // 4 bytes for uint32.
+  auto str = unique_ptr<char[]> { new char[size + 1] }; // + 1 for '\0'.
   str[size] = '\0';
+  if (size < 4) {
+    return str;
+  }
+
+  // Reverse 0xWXYZ into 0xZYXW.
+  str[0] = (char)(data >> 24);
+  str[1] = (char)(data >> 16);
+  str[2] = (char)(data >> 8);
+  str[3] = (char)(data);
   return str;
 }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2907,8 +2907,8 @@ unique_ptr<char[]> convert_uint32_into_string(UInt32 data)
   return str;
 }
 
-int audiounit_get_default_device_data(cubeb_device_type type,
-                                      UInt32 * data)
+int audiounit_get_default_device_datasource(cubeb_device_type type,
+                                            UInt32 * data)
 {
   AudioDeviceID id = audiounit_get_default_device_id(type);
   if (id == kAudioObjectUnknown) {
@@ -2949,7 +2949,7 @@ int audiounit_get_default_device_name(cubeb_stream * stm,
   assert(device);
 
   UInt32 data;
-  int r = audiounit_get_default_device_data(type, &data);
+  int r = audiounit_get_default_device_datasource(type, &data);
   if (r != CUBEB_OK) {
     return r;
   }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2908,8 +2908,7 @@ unique_ptr<char[]> convert_uint32_into_string(UInt32 data)
 }
 
 int audiounit_get_default_device_data(cubeb_device_type type,
-                                      UInt32 * data,
-                                      cubeb_stream * stm /* for log */)
+                                      UInt32 * data)
 {
   AudioDeviceID id = audiounit_get_default_device_id(type);
   if (id == kAudioObjectUnknown) {
@@ -2936,8 +2935,6 @@ int audiounit_get_default_device_data(cubeb_device_type type,
                                             &datasource_address_output,
                                           0, NULL, &size, data);
   if (r != noErr) {
-    LOG("(%p) Error when getting %s device!", stm,
-        type == CUBEB_DEVICE_TYPE_INPUT ? "input" : "output");
     *data = 0;
   }
 
@@ -2952,13 +2949,17 @@ int audiounit_get_default_device_name(cubeb_stream * stm,
   assert(device);
 
   UInt32 data;
-  int r = audiounit_get_default_device_data(type, &data, stm);
+  int r = audiounit_get_default_device_data(type, &data);
   if (r != CUBEB_OK) {
     return r;
   }
   char ** name = type == CUBEB_DEVICE_TYPE_INPUT ?
     &device->input_name : &device->output_name;
   *name = convert_uint32_into_string(data).release();
+  if (!strlen(*name)) { // empty string.
+    LOG("(%p) name of %s device is empty!", stm,
+        type == CUBEB_DEVICE_TYPE_INPUT ? "input" : "output");
+  }
   return CUBEB_OK;
 }
 


### PR DESCRIPTION
1. Add a simple test for ```cubeb_stream_get_current_device(...)```
2. Reduce duplicate code for input and output in ```audiounit_stream_get_current_device(...)```