### PR TITLE
More fixes for bug 1489052

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+build/

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -518,6 +518,7 @@ audiounit_input_callback(void * user_ptr,
 
   // Reset input buffer
   stm->input_linear_buffer->clear();
+  stm->available_input_frames = 0;
 
   return noErr;
 }
@@ -2056,6 +2057,7 @@ audiounit_init_input_linear_buffer(cubeb_stream * stream, uint32_t capacity)
     stream->input_linear_buffer.reset(new auto_array_wrapper_impl<float>(size));
   }
   assert(stream->input_linear_buffer->length() == 0);
+  stream->available_input_frames = 0;
 
   return CUBEB_OK;
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -450,7 +450,12 @@ audiounit_render_input(cubeb_stream * stm,
     if (r != kAudioUnitErr_CannotDoInCurrentContext) {
       return r;
     }
-    audiounit_reinit_stream_async(stm, DEV_INPUT | DEV_OUTPUT);
+    if (stm->output_unit) {
+      // kAudioUnitErr_CannotDoInCurrentContext is returned when using a BT
+      // headset and the profile is changed from A2DP to HFP/HSP. The previous
+      // output device is no longer valid and must be reset.
+      audiounit_reinit_stream_async(stm, DEV_INPUT | OUTPUT);
+    }
     // For now state that no error occurred and feed silence, stream will be
     // resumed once reinit has completed.
     ALOGV("(%p) input: reinit pending feeding silence instead", stm);

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1067,6 +1067,7 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
       LOG("AudioObjectRemovePropertyListener/output/kAudioDevicePropertyDataSource rv=%d, device id=%d", rv, stm->output_device.id);
       r = CUBEB_ERROR;
     }
+    stm->output_source_listener.reset();
   }
 
   if (stm->input_source_listener) {
@@ -1075,6 +1076,7 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
       LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDataSource rv=%d, device id=%d", rv, stm->input_device.id);
       r = CUBEB_ERROR;
     }
+    stm->input_source_listener.reset();
   }
 
   if (stm->input_alive_listener) {
@@ -1083,6 +1085,7 @@ audiounit_uninstall_device_changed_callback(cubeb_stream * stm)
       LOG("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDeviceIsAlive rv=%d, device id=%d", rv, stm->input_device.id);
       r = CUBEB_ERROR;
     }
+    stm->input_alive_listener.reset();
   }
 
   return r;
@@ -1098,6 +1101,7 @@ audiounit_uninstall_system_changed_callback(cubeb_stream * stm)
     if (r != noErr) {
       return CUBEB_ERROR;
     }
+    stm->default_output_listener.reset();
   }
 
   if (stm->default_input_listener) {
@@ -1105,6 +1109,7 @@ audiounit_uninstall_system_changed_callback(cubeb_stream * stm)
     if (r != noErr) {
       return CUBEB_ERROR;
     }
+    stm->default_input_listener.reset();
   }
   return CUBEB_OK;
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1860,7 +1860,6 @@ audiounit_create_aggregate_device(cubeb_stream * stm)
   int r = audiounit_create_blank_aggregate_device(&stm->plugin_id, &stm->aggregate_device_id);
   if (r != CUBEB_OK) {
     LOG("(%p) Failed to create blank aggregate device", stm);
-    audiounit_destroy_aggregate_device(stm->plugin_id, &stm->aggregate_device_id);
     return CUBEB_ERROR;
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -621,6 +621,7 @@ audiounit_output_callback(void * user_ptr,
     input_frames = stm->input_linear_buffer->length() / stm->input_desc.mChannelsPerFrame;
     // Number of input frames pushed inside resampler.
     input_frames_before_fill = input_frames;
+    assert(input_frames == stm->available_input_frames);
   }
 
   /* Call user callback through resampler. */
@@ -634,10 +635,11 @@ audiounit_output_callback(void * user_ptr,
                                         output_frames);
 
   if (input_buffer) {
+    // Pop from the buffer the frames used by the the resampler.
+    stm->input_linear_buffer->pop(input_frames * stm->input_desc.mChannelsPerFrame);
     // Decrease counter by the number of frames used by resampler
+    assert(stm->available_input_frames >= input_frames);
     stm->available_input_frames -= input_frames;
-    // Pop from the buffer the frames pushed to the resampler.
-    stm->input_linear_buffer->pop(input_frames_before_fill * stm->input_desc.mChannelsPerFrame);
   }
 
   if (outframes < 0 || outframes > output_frames) {


### PR DESCRIPTION
Lots of issues discovered during the course of this.

I hope I've resolved them all.
Removing microphone/replugging used to give me a 1 in 5 crash.
Sometimes gecko's AudioCallBackDriver would reset cubeb in a loop due to a race due to how errors were propagated and reinit task pending.

Can connect on the fly BT headset and disconnect (it then defaults to the default system input)