### PR TITLE
audiounit: report removed devices correctly (BMO 1491152)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3396,16 +3396,25 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
   if (ret != noErr) {
     return vector<AudioObjectID>();
   }
-  /* Total number of input and output devices. */
-  uint32_t count = (uint32_t)(size / sizeof(AudioObjectID));
-
-  vector<AudioObjectID> devices(count);
+  vector<AudioObjectID> devices(size / sizeof(AudioObjectID));
   ret = AudioObjectGetPropertyData(kAudioObjectSystemObject,
                                    &DEVICES_PROPERTY_ADDRESS, 0, NULL, &size,
                                    devices.data());
   if (ret != noErr) {
     return vector<AudioObjectID>();
   }
+
+  // Remove the aggregate device from the list of devices (if any).
+  for (auto it = devices.begin(); it != devices.end();) {
+    CFStringRef name = get_device_name(*it);
+    if (CFStringFind(name, CFSTR("CubebAggregateDevice"), 0).location !=
+        kCFNotFound) {
+      it = devices.erase(it);
+    } else {
+      it++;
+    }
+  }
+
   /* Expected sorted but did not find anything in the docs. */
   sort(devices.begin(), devices.end(), [](AudioObjectID a, AudioObjectID b) {
       return a < b;
@@ -3420,7 +3429,7 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
                                          kAudioDevicePropertyScopeOutput;
 
   vector<AudioObjectID> devices_in_scope;
-  for (uint32_t i = 0; i < count; ++i) {
+  for (uint32_t i = 0; i < devices.size(); ++i) {
     /* For device in the given scope channel must be > 0. */
     if (audiounit_get_channel_count(devices[i], scope) > 0) {
       devices_in_scope.push_back(devices[i]);
@@ -3447,41 +3456,13 @@ audiounit_collection_changed_callback(AudioObjectID /* inObjectID */,
     }
 
     /* Differentiate input from output changes. */
-    if (context->collection_changed_devtype == CUBEB_DEVICE_TYPE_INPUT ||
-        context->collection_changed_devtype == CUBEB_DEVICE_TYPE_OUTPUT) {
+    if ((context->collection_changed_devtype & CUBEB_DEVICE_TYPE_INPUT) ||
+        (context->collection_changed_devtype & CUBEB_DEVICE_TYPE_OUTPUT)) {
       vector<AudioObjectID> devices = audiounit_get_devices_of_type(context->collection_changed_devtype);
       /* When count is the same examine the devid for the case of coalescing. */
       if (context->devtype_device_array == devices) {
         /* Device changed for the other scope, ignore. */
         return;
-      } else {
-        /* Also don't trigger the user callback if the new added device is private
-         * aggregate device: compute the set of new devices, and remove those
-         * with the name of our private aggregate devices. */
-        set<AudioObjectID> current_devices(devices.begin(), devices.end());
-        set<AudioObjectID> previous_devices(context->devtype_device_array.begin(),
-                                            context->devtype_device_array.end());
-        set<AudioObjectID> new_devices;
-        set_difference(current_devices.begin(), current_devices.end(),
-                       previous_devices.begin(), previous_devices.end(),
-                       inserter(new_devices, new_devices.begin()));
-
-        for (auto it = new_devices.begin(); it != new_devices.end();) {
-          CFStringRef name = get_device_name(*it);
-          if (CFStringFind(name, CFSTR("CubebAggregateDevice"), 0).location !=
-              kCFNotFound) {
-            it = new_devices.erase(it);
-          } else {
-            it++;
-          }
-        }
-
-        // If this set of new devices is empty, it means this was triggerd
-        // solely by creating an aggregate device, no need to trigger the user
-        // callback.
-        if (new_devices.empty()) {
-          return;
-        }
       }
       /* Device on desired scope changed. */
       context->devtype_device_array = devices;
@@ -3511,8 +3492,8 @@ audiounit_add_device_listener(cubeb * context,
     assert(context->devtype_device_array.empty());
     /* Listener works for input and output.
      * When requested one of them we need to differentiate. */
-    if (devtype == CUBEB_DEVICE_TYPE_INPUT ||
-        devtype == CUBEB_DEVICE_TYPE_OUTPUT) {
+    if (devtype & CUBEB_DEVICE_TYPE_INPUT ||
+        devtype & CUBEB_DEVICE_TYPE_OUTPUT) {
       /* Used to differentiate input from output device changes. */
       context->devtype_device_array = audiounit_get_devices_of_type(devtype);
     }


### PR DESCRIPTION
Collection changed callback did not handle correctly removed devices. This is because we verify that callback has not been triggered due to adding/removing of the Aggregate Device before reporting a device changed callback .

In this fix I have removed the enumeration of the AD completely so devices comparing includes "actual" devices. Any difference on the actual device will trigger a callback.