### PR TITLE
osx: close the stream before calling setup (BMO 1500109)

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -839,6 +839,7 @@ audiounit_reinit_stream(cubeb_stream * stm, device_flags_value flags)
       if (flags & DEV_INPUT && input_device != 0) {
         // Attempt to re-use the same device-id failed, so attempt again with
         // default input device.
+        audiounit_close_stream(stm);
         if (audiounit_set_device_info(stm, 0, io_side::INPUT) != CUBEB_OK ||
             audiounit_setup_stream(stm) != CUBEB_OK) {
           LOG("(%p) Second stream reinit failed.", stm);


### PR DESCRIPTION
Fix the crash describing by the following crash-stat:
https://crash-stats.mozilla.com/report/index/264771fe-ade3-41f6-baf8-92fff0181005