### PR TITLE
osx: check null reference before using the string (BMO 1502165).

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3413,7 +3413,7 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
   // Remove the aggregate device from the list of devices (if any).
   for (auto it = devices.begin(); it != devices.end();) {
     CFStringRef name = get_device_name(*it);
-    if (CFStringFind(name, CFSTR("CubebAggregateDevice"), 0).location !=
+    if (name && CFStringFind(name, CFSTR("CubebAggregateDevice"), 0).location !=
         kCFNotFound) {
       it = devices.erase(it);
     } else {


### PR DESCRIPTION
Check for null reference. Fixing crash:
https://crash-stats.mozilla.com/report/index/d4e665aa-1cd7-4547-95b6-877670181023