### PR TITLE
Tests for device-collection-changed callbacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,3 @@
 [submodule "cmake/sanitizers-cmake"]
 	path = cmake/sanitizers-cmake
 	url = https://github.com/arsenm/sanitizers-cmake
-[submodule "src/cubeb-coreaudio-rs"]
-	path = src/cubeb-coreaudio-rs
-	url = https://github.com/ChunMinChang/cubeb-coreaudio-rs.git
-	branch = build-config-in-cubeb

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "cmake/sanitizers-cmake"]
 	path = cmake/sanitizers-cmake
 	url = https://github.com/arsenm/sanitizers-cmake
+[submodule "src/cubeb-coreaudio-rs"]
+	path = src/cubeb-coreaudio-rs
+	url = https://github.com/ChunMinChang/cubeb-coreaudio-rs.git
+	branch = build-config-in-cubeb

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1542,11 +1542,15 @@ pulse_register_device_collection_changed(cubeb * context,
 {
   assert(devtype & (CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT));
 
+  // Current implementation requires unregistering the existing callback before
+  // registering a new one within the same scope.
   if (devtype & CUBEB_DEVICE_TYPE_INPUT) {
+    assert(!collection_changed_callback || !context->input_collection_changed_callback);
     context->input_collection_changed_callback = collection_changed_callback;
     context->input_collection_changed_user_ptr = user_ptr;
   }
   if (devtype & CUBEB_DEVICE_TYPE_OUTPUT) {
+    assert(!collection_changed_callback || !context->output_collection_changed_callback);
     context->output_collection_changed_callback = collection_changed_callback;
     context->output_collection_changed_user_ptr = user_ptr;
   }

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1540,6 +1540,8 @@ pulse_register_device_collection_changed(cubeb * context,
                                          cubeb_device_collection_changed_callback collection_changed_callback,
                                          void * user_ptr)
 {
+  assert(devtype & (CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT));
+
   if (devtype & CUBEB_DEVICE_TYPE_INPUT) {
     context->input_collection_changed_callback = collection_changed_callback;
     context->input_collection_changed_user_ptr = user_ptr;

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -258,7 +258,7 @@ void device_collection_changed_callback(cubeb * context, void * user)
 {
   fprintf(stderr, "device collection changed callback\n");
   ASSERT_TRUE(false) << "Error: device collection changed callback"
-                        " called when opening a stream";
+                        " called without changing devices";
 }
 
 TEST(cubeb, register_device_collection_change_for_unknown_type)

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -338,7 +338,7 @@ TEST(cubeb, device_collection_change)
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
 
-    // Unregister all the callbacks regardless of the scope.
+    // Unregister all the callbacks regardless of the scopes.
     r = cubeb_register_device_collection_changed(ctx,
                                                  static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
                                                                                 CUBEB_DEVICE_TYPE_OUTPUT),
@@ -435,7 +435,8 @@ TEST(cubeb, register_device_collection_changed_twice)
       cubeb_register_device_collection_changed(ctx,
                                                scope,
                                                device_collection_changed_callback,
-                                               nullptr), ""
+                                               nullptr),
+      ""
     );
   }
 }

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -431,7 +431,7 @@ TEST(cubeb, register_device_collection_changed_twice)
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
 
     // Get an assertion fails when registering a callback within same scope twice.
-    ASSERT_DEBUG_DEATH(
+    ASSERT_DEATH(
       cubeb_register_device_collection_changed(ctx,
                                                scope,
                                                device_collection_changed_callback,

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -274,9 +274,41 @@ TEST(cubeb, register_device_collection_change_for_unknown_type)
 
   r = cubeb_register_device_collection_changed(ctx,
                                                static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_UNKNOWN),
+                                               nullptr,
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_ERROR_INVALID_PARAMETER) << "Error returning wrong error type";
+
+  r = cubeb_register_device_collection_changed(ctx,
+                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_UNKNOWN),
                                                device_collection_changed_callback,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_ERROR_INVALID_PARAMETER) << "Error returning wrong error type";
+}
+
+TEST(cubeb, unregister_without_registering)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  int scopes[3] = {
+    CUBEB_DEVICE_TYPE_INPUT,
+    CUBEB_DEVICE_TYPE_OUTPUT,
+    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT
+  };
+
+  for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
+    r = cubeb_register_device_collection_changed(ctx,
+                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 nullptr,
+                                                 nullptr);
+    ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
+  }
 }
 
 TEST(cubeb, device_collection_change)

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -327,3 +327,38 @@ TEST(cubeb, device_collection_change)
     ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
   }
 }
+
+TEST(cubeb, register_device_collection_changed_twice)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  int scopes[3] = {
+    CUBEB_DEVICE_TYPE_INPUT,
+    CUBEB_DEVICE_TYPE_OUTPUT,
+    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT
+  };
+
+  for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
+    // Register a callback within the defined scoped.
+    r = cubeb_register_device_collection_changed(ctx,
+                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 device_collection_changed_callback,
+                                                 nullptr);
+    ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
+
+    // Get an assertion fails when registering a callback within same scope twice.
+    ASSERT_DEBUG_DEATH(
+      cubeb_register_device_collection_changed(ctx,
+                                               static_cast<cubeb_device_type>(scopes[i]),
+                                               device_collection_changed_callback,
+                                               nullptr), ""
+    );
+  }
+}

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -362,6 +362,48 @@ TEST(cubeb, device_collection_change)
   }
 }
 
+TEST(cubeb, unregister_device_collection_changed_twice)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  cubeb_device_type scopes[3] = {
+    CUBEB_DEVICE_TYPE_INPUT,
+    CUBEB_DEVICE_TYPE_OUTPUT,
+    static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
+                                   CUBEB_DEVICE_TYPE_OUTPUT)
+  };
+
+  for (cubeb_device_type scope: scopes) {
+    // Register a callback within the defined scoped.
+    r = cubeb_register_device_collection_changed(ctx,
+                                                 scope,
+                                                 device_collection_changed_callback,
+                                                 nullptr);
+    ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
+
+    // Unregister the callback within the defined scope.
+    r = cubeb_register_device_collection_changed(ctx,
+                                                 scope,
+                                                 nullptr,
+                                                 nullptr);
+    ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
+
+    // Unregister the callback within the defined scope again.
+    r = cubeb_register_device_collection_changed(ctx,
+                                                 scope,
+                                                 nullptr,
+                                                 nullptr);
+    ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed again";
+  }
+}
+
 TEST(cubeb, register_device_collection_changed_twice)
 {
   cubeb *ctx;

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -273,13 +273,13 @@ TEST(cubeb, register_device_collection_change_for_unknown_type)
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
   r = cubeb_register_device_collection_changed(ctx,
-                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_UNKNOWN),
+                                               CUBEB_DEVICE_TYPE_UNKNOWN,
                                                nullptr,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_ERROR_INVALID_PARAMETER) << "Error returning wrong error type";
 
   r = cubeb_register_device_collection_changed(ctx,
-                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_UNKNOWN),
+                                               CUBEB_DEVICE_TYPE_UNKNOWN,
                                                device_collection_changed_callback,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_ERROR_INVALID_PARAMETER) << "Error returning wrong error type";
@@ -296,15 +296,16 @@ TEST(cubeb, unregister_without_registering)
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
-  int scopes[3] = {
+  cubeb_device_type scopes[3] = {
     CUBEB_DEVICE_TYPE_INPUT,
     CUBEB_DEVICE_TYPE_OUTPUT,
-    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT
+    static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
+                                   CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
   for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
     r = cubeb_register_device_collection_changed(ctx,
-                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 scopes[i],
                                                  nullptr,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
@@ -322,16 +323,17 @@ TEST(cubeb, device_collection_change)
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
-  int scopes[3] = {
+  cubeb_device_type scopes[3] = {
     CUBEB_DEVICE_TYPE_INPUT,
     CUBEB_DEVICE_TYPE_OUTPUT,
-    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT
+    static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
+                                   CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
   for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
     // Register a callback within the defined scoped.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 scopes[i],
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
@@ -346,14 +348,14 @@ TEST(cubeb, device_collection_change)
 
     // Register a callback within the defined scoped again.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 scopes[i],
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed again";
 
     // Unregister the callback within the defined scope.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 scopes[i],
                                                  nullptr,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
@@ -371,16 +373,17 @@ TEST(cubeb, register_device_collection_changed_twice)
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
-  int scopes[3] = {
+  cubeb_device_type scopes[3] = {
     CUBEB_DEVICE_TYPE_INPUT,
     CUBEB_DEVICE_TYPE_OUTPUT,
-    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT
+    static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
+                                   CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
   for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
     // Register a callback within the defined scoped.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 static_cast<cubeb_device_type>(scopes[i]),
+                                                 scopes[i],
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
@@ -388,7 +391,7 @@ TEST(cubeb, register_device_collection_changed_twice)
     // Get an assertion fails when registering a callback within same scope twice.
     ASSERT_DEBUG_DEATH(
       cubeb_register_device_collection_changed(ctx,
-                                               static_cast<cubeb_device_type>(scopes[i]),
+                                               scopes[i],
                                                device_collection_changed_callback,
                                                nullptr), ""
     );

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -404,7 +404,7 @@ TEST(cubeb, unregister_device_collection_changed_twice)
   }
 }
 
-TEST(cubeb, register_device_collection_changed_twice)
+TEST(cubeb, register_device_collection_changed_twice_input)
 {
   cubeb *ctx;
   int r = CUBEB_OK;
@@ -415,28 +415,78 @@ TEST(cubeb, register_device_collection_changed_twice)
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);
 
-  cubeb_device_type scopes[3] = {
-    CUBEB_DEVICE_TYPE_INPUT,
-    CUBEB_DEVICE_TYPE_OUTPUT,
-    static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT |
-                                   CUBEB_DEVICE_TYPE_OUTPUT)
-  };
-
-  for (cubeb_device_type scope: scopes) {
-    // Register a callback within the defined scoped.
-    r = cubeb_register_device_collection_changed(ctx,
-                                                 scope,
-                                                 device_collection_changed_callback,
-                                                 nullptr);
-    ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
-
-    // Get an assertion fails when registering a callback within same scope twice.
-    ASSERT_DEATH(
-      cubeb_register_device_collection_changed(ctx,
-                                               scope,
+  // Register a callback within the defined scoped.
+  r = cubeb_register_device_collection_changed(ctx,
+                                               CUBEB_DEVICE_TYPE_INPUT,
                                                device_collection_changed_callback,
-                                               nullptr),
-      ""
-    );
-  }
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
+
+  // Get an assertion fails when registering a callback within same scope twice.
+  ASSERT_DEATH(
+    cubeb_register_device_collection_changed(ctx,
+                                             CUBEB_DEVICE_TYPE_INPUT,
+                                             device_collection_changed_callback,
+                                             nullptr),
+    ""
+  );
+}
+
+TEST(cubeb, register_device_collection_changed_twice_output)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  // Register a callback within the defined scoped.
+  r = cubeb_register_device_collection_changed(ctx,
+                                               CUBEB_DEVICE_TYPE_OUTPUT,
+                                               device_collection_changed_callback,
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
+
+  // Get an assertion fails when registering a callback within same scope twice.
+  ASSERT_DEATH(
+    cubeb_register_device_collection_changed(ctx,
+                                             CUBEB_DEVICE_TYPE_OUTPUT,
+                                             device_collection_changed_callback,
+                                             nullptr),
+    ""
+  );
+}
+
+TEST(cubeb, register_device_collection_changed_twice_inout)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  cubeb_device_type type = static_cast<cubeb_device_type>(
+    CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT);
+
+  // Register a callback within the defined scoped.
+  r = cubeb_register_device_collection_changed(ctx,
+                                               type,
+                                               device_collection_changed_callback,
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
+
+  // Get an assertion fails when registering a callback within same scope twice.
+  ASSERT_DEATH(
+    cubeb_register_device_collection_changed(ctx,
+                                             type,
+                                             device_collection_changed_callback,
+                                             nullptr),
+    ""
+  );
 }

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -303,9 +303,9 @@ TEST(cubeb, unregister_without_registering)
                                    CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
-  for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
+  for (cubeb_device_type scope: scopes) {
     r = cubeb_register_device_collection_changed(ctx,
-                                                 scopes[i],
+                                                 scope,
                                                  nullptr,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
@@ -330,10 +330,10 @@ TEST(cubeb, device_collection_change)
                                    CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
-  for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
+  for (cubeb_device_type scope: scopes) {
     // Register a callback within the defined scoped.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 scopes[i],
+                                                 scope,
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
@@ -348,14 +348,14 @@ TEST(cubeb, device_collection_change)
 
     // Register a callback within the defined scoped again.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 scopes[i],
+                                                 scope,
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed again";
 
     // Unregister the callback within the defined scope.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 scopes[i],
+                                                 scope,
                                                  nullptr,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device collection changed";
@@ -380,10 +380,10 @@ TEST(cubeb, register_device_collection_changed_twice)
                                    CUBEB_DEVICE_TYPE_OUTPUT)
   };
 
-  for (size_t i = 0 ; i < ARRAY_LENGTH(scopes) ; ++i) {
+  for (cubeb_device_type scope: scopes) {
     // Register a callback within the defined scoped.
     r = cubeb_register_device_collection_changed(ctx,
-                                                 scopes[i],
+                                                 scope,
                                                  device_collection_changed_callback,
                                                  nullptr);
     ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
@@ -391,7 +391,7 @@ TEST(cubeb, register_device_collection_changed_twice)
     // Get an assertion fails when registering a callback within same scope twice.
     ASSERT_DEBUG_DEATH(
       cubeb_register_device_collection_changed(ctx,
-                                               scopes[i],
+                                               scope,
                                                device_collection_changed_callback,
                                                nullptr), ""
     );

--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -253,3 +253,28 @@ TEST(cubeb, stream_get_current_device)
   r = cubeb_stream_device_destroy(stream, device);
   ASSERT_EQ(r, CUBEB_OK) << "Error destroying current devices";
 }
+
+void device_collection_changed_callback(cubeb * context, void * user)
+{
+  fprintf(stderr, "device collection changed callback\n");
+  ASSERT_TRUE(false) << "Error: device collection changed callback"
+                        " called when opening a stream";
+}
+
+TEST(cubeb, register_device_collection_change_for_unknown_type)
+{
+  cubeb *ctx;
+  int r = CUBEB_OK;
+
+  r = common_init(&ctx, "Cubeb duplex example with collection change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  r = cubeb_register_device_collection_changed(ctx,
+                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_UNKNOWN),
+                                               device_collection_changed_callback,
+                                               nullptr);
+  ASSERT_EQ(r, CUBEB_ERROR_INVALID_PARAMETER) << "Error returning wrong error type";
+}

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -153,7 +153,7 @@ TEST(cubeb, duplex_collection_change)
                                                static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT),
                                                device_collection_changed_callback,
                                                nullptr);
-  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";
 
   std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
     cleanup_cubeb_at_exit(ctx, cubeb_destroy);

--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -150,7 +150,7 @@ TEST(cubeb, duplex_collection_change)
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
 
   r = cubeb_register_device_collection_changed(ctx,
-                                               static_cast<cubeb_device_type>(CUBEB_DEVICE_TYPE_INPUT),
+                                               CUBEB_DEVICE_TYPE_INPUT,
                                                device_collection_changed_callback,
                                                nullptr);
   ASSERT_EQ(r, CUBEB_OK) << "Error registering device collection changed";


### PR DESCRIPTION
It would be better if we have tests for device-collection-changed callbacks. 
1. For Rust version, it needs to check if the device ralated APIs can work with C APIs.
2. We are refactoring the device-collection-changed callbacks for [BMO 1498242](https://bugzilla.mozilla.org/show_bug.cgi?id=1498242). It should be helpful to check if the code works like what we expect.
