### PR TITLE
Potential null pointer in audiounit_set_device_info

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -744,6 +744,7 @@ static int
 audiounit_set_device_info(cubeb_stream * stm, AudioDeviceID id, io_side side)
 {
   assert(stm);
+  assert(side == io_side::INPUT || side == io_side::OUTPUT);
 
   device_info * info = nullptr;
   cubeb_device_type type = CUBEB_DEVICE_TYPE_UNKNOWN;
@@ -751,7 +752,7 @@ audiounit_set_device_info(cubeb_stream * stm, AudioDeviceID id, io_side side)
   if (side == io_side::INPUT) {
     info = &stm->input_device;
     type = CUBEB_DEVICE_TYPE_INPUT;
-  } else if (side == io_side::OUTPUT) {
+  } else {
     info = &stm->output_device;
     type = CUBEB_DEVICE_TYPE_OUTPUT;
   }
@@ -760,7 +761,7 @@ audiounit_set_device_info(cubeb_stream * stm, AudioDeviceID id, io_side side)
 
   if (side == io_side::INPUT) {
     info->flags |= DEV_INPUT;
-  } else if (side == io_side::OUTPUT) {
+  } else {
     info->flags |= DEV_OUTPUT;
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -755,7 +755,9 @@ audiounit_set_device_info(cubeb_stream * stm, AudioDeviceID id, cubeb_device_typ
   info->flags |= (type == CUBEB_DEVICE_TYPE_INPUT) ? DEV_INPUT : DEV_OUTPUT;
 
   AudioDeviceID default_device_id = audiounit_get_default_device_id(type);
-  assert(default_device_id != kAudioObjectUnknown);
+  if (default_device_id == kAudioObjectUnknown) {
+    return CUBEB_ERROR;
+  }
 
   if (id == kAudioObjectUnknown) {
     info->id = default_device_id;


### PR DESCRIPTION
The `device_info * info` will be `nullptr` when `audiounit_set_device_info(stm, id, static_cast<io_side>(10))` is called (see [here](https://github.com/kinetiknz/cubeb/blob/9a7a55153e7f9b9e0036ab023909c7bc4a41688b/src/cubeb_audiounit.cpp#L748-L759)). 
 
```cpp
device_info * info = nullptr;
cubeb_device_type type = CUBEB_DEVICE_TYPE_UNKNOWN;

if (side == io_side::INPUT) {
  info = &stm->input_device;
  type = CUBEB_DEVICE_TYPE_INPUT;
} else if (side == io_side::OUTPUT) {
  info = &stm->output_device;
  type = CUBEB_DEVICE_TYPE_OUTPUT;
}
memset(info, 0, sizeof(device_info));
```

On the other hand, it is unable to translate them into Rust directly. The Rust version will be something like:

```rust
let info: &mut device_info;
let mut devtype = DeviceType::UNKNOWN;

if side == io_side::INPUT {
    info = &mut stm.input_device;
    type = DeviceType::INPUT;
} else if side == io_side::OUTPUT {
    info = &mut stm.output_device;
    type = DeviceType::OUTPUT;
}
*info = unsafe { mem::zeroed() };
```

It cannot compile since there will be an error like  `'info' may be a null reference`.

Since `audiounit_set_device_info` is either called for the input side or called for the output side, we can add an assertion to make sure it only used within either input or output scope, then replace *if-else-if* by *if-else* or *ternary operator*(`?` and `:`). 
