### PR TITLE
Only add device listener when it's not null

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3489,6 +3489,7 @@ audiounit_add_device_listener(cubeb * context,
 {
   context->mutex.assert_current_thread_owns();
   assert(devtype & (CUBEB_DEVICE_TYPE_INPUT | CUBEB_DEVICE_TYPE_OUTPUT));
+  assert(collection_changed_callback);
   /* Note: second register without unregister first causes 'nope' error.
    * Current implementation requires unregister before register a new cb. */
   assert((devtype & CUBEB_DEVICE_TYPE_INPUT) && !context->input_collection_changed_callback ||


### PR DESCRIPTION
`audiounit_add_device_listener` will add `audiounit_collection_changed_callback` as the inner device-changed callback regardless of user-defined callback is null or not. That is, `audiounit_collection_changed_callback` will be registered as the device-changed callback even user set the callback to `nullptr` (e.g., `OSStatus r = audiounit_add_device_listener(context, type, nullptr, nullptr)`).

This won't happen in the current code flow since we will check the user-defined callback is null or not in `audiounit_register_device_collection_changed` (see [here][register]).

However, in Rust implementation, I have a [problem][rs-test-problem] if I'd like to add a test to check if `audiounit_add_device_listener` works as expected. The test in C will be something like:

```cpp
void test_add_device_listener(cubeb * context)
{
  cubeb_device_type types[2] = {
    CUBEB_DEVICE_TYPE_INPUT,
    CUBEB_DEVICE_TYPE_OUTPUT
  };

  auto_lock lock(context->mutex);

  for (cubeb_device_type type: types) {
    OSStatus r = audiounit_add_device_listener(context, type, nullptr, nullptr);
    // Either it's ok to register a null callback, or it's not ok.
    assert(r != noErr);     // Fail!
    // assert(r == noErr);  // Fail!
  }
}
```

If it's ok to register a null callback, then the test fails. If it's not ok to register a null callback, then the test also fails. 

In above test, we will add `audiounit_collection_changed_callback` as the inner device-changed callback and set `input_collection_changed_callback` to null. Then we will add the `audiounit_collection_changed_callback` as the inner device-changed callback **again** since `input_collection_changed_callback` and `output_collection_changed_callback` are [all null][check]. Therefore, `AudioObjectAddPropertyListener` will retun a *nope* error. It causes *inconsistent* behaviors when registering null callbacks.

The easiest way to avoid the problem is to add an assertion to make sure `audiounit_collection_changed_callback` is only registered as the inner callback when user-defined callback is not null. There is no reason to register the listener if user don't care about it.

I try to translate the code from C to Rust with minimal differences. I cannot turn on the [test][rs-test-problem] for `audiounit_add_device_listener` without changing the C code. This change won't affect the current code flow, but it helps enlarging the test coverage in Rust implementation.

[register]: https://github.com/kinetiknz/cubeb/blob/9a7a55153e7f9b9e0036ab023909c7bc4a41688b/src/cubeb_audiounit.cpp#L3561-L3568 "audiounit_register_device_collection_changed"
[check]: https://github.com/kinetiknz/cubeb/blob/9a7a55153e7f9b9e0036ab023909c7bc4a41688b/src/cubeb_audiounit.cpp#L3497-L3498 "Check if we could add listeners"
[rs-test-problem]: https://github.com/ChunMinChang/cubeb-coreaudio-rs/blob/517c47a974c2e335569904e12527c6f83507861c/src/backend/test.rs#L1245-L1278 "Problem to test add_device_listener"
