### PR TITLE
Don't use PLII matrices when downmixing.

### DIFF
--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -236,13 +236,8 @@ int MixerContext::auto_matrix()
       matrix[SIDE_LEFT][BACK_CENTER] += M_SQRT1_2;
       matrix[SIDE_RIGHT][BACK_CENTER] += M_SQRT1_2;
     } else if (out_ch_layout & CHANNEL_FRONT_LEFT) {
-      if (unaccounted & (CHANNEL_BACK_LEFT | CHANNEL_SIDE_LEFT)) {
-        matrix[FRONT_LEFT][BACK_CENTER] -= _surround_mix_level * M_SQRT1_2;
-        matrix[FRONT_RIGHT][BACK_CENTER] += _surround_mix_level * M_SQRT1_2;
-      } else {
-        matrix[FRONT_LEFT][BACK_CENTER] -= _surround_mix_level;
-        matrix[FRONT_RIGHT][BACK_CENTER] += _surround_mix_level;
-      }
+      matrix[FRONT_LEFT][BACK_CENTER] += _surround_mix_level * M_SQRT1_2;
+      matrix[FRONT_RIGHT][BACK_CENTER] += _surround_mix_level * M_SQRT1_2;
     } else if (out_ch_layout & CHANNEL_FRONT_CENTER) {
       matrix[FRONT_CENTER][BACK_CENTER] +=
         _surround_mix_level * M_SQRT1_2;
@@ -261,10 +256,8 @@ int MixerContext::auto_matrix()
         matrix[SIDE_RIGHT][BACK_RIGHT] += 1.0;
       }
     } else if (out_ch_layout & CHANNEL_FRONT_LEFT) {
-      matrix[FRONT_LEFT][BACK_LEFT] -= _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_LEFT][BACK_RIGHT] -= _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_RIGHT][BACK_LEFT] += _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_RIGHT][BACK_RIGHT] += _surround_mix_level * M_SQRT1_2;
+      matrix[FRONT_LEFT][BACK_LEFT] += _surround_mix_level;
+      matrix[FRONT_RIGHT][BACK_RIGHT] += _surround_mix_level;
     } else if (out_ch_layout & CHANNEL_FRONT_CENTER) {
       matrix[FRONT_CENTER][BACK_LEFT] += _surround_mix_level * M_SQRT1_2;
       matrix[FRONT_CENTER][BACK_RIGHT] += _surround_mix_level * M_SQRT1_2;
@@ -286,10 +279,8 @@ int MixerContext::auto_matrix()
       matrix[BACK_CENTER][SIDE_LEFT] += M_SQRT1_2;
       matrix[BACK_CENTER][SIDE_RIGHT] += M_SQRT1_2;
     } else if (out_ch_layout & CHANNEL_FRONT_LEFT) {
-      matrix[FRONT_LEFT][SIDE_LEFT] -= _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_LEFT][SIDE_RIGHT] -= _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_RIGHT][SIDE_LEFT] += _surround_mix_level * M_SQRT1_2;
-      matrix[FRONT_RIGHT][SIDE_RIGHT] += _surround_mix_level * M_SQRT1_2;
+      matrix[FRONT_LEFT][SIDE_LEFT] += _surround_mix_level;
+      matrix[FRONT_RIGHT][SIDE_RIGHT] += _surround_mix_level;
     } else if (out_ch_layout & CHANNEL_FRONT_CENTER) {
       matrix[FRONT_CENTER][SIDE_LEFT] += _surround_mix_level * M_SQRT1_2;
       matrix[FRONT_CENTER][SIDE_RIGHT] += _surround_mix_level * M_SQRT1_2;


### PR DESCRIPTION
PLII mix the opposed channel with the reversed phase. It doesn't sound good when used with a common stereo headset; like the left rear channel sounds too much like it's also coming from the right. Additionally, it clips significantly causing unwanted distortion. So we default to a simpler conversion instead: left goes to left only, same for the right channel.

(Part of the fix for BMO 1509875)

Fixes #476