### PR TITLE
Trivial test for getting stream latency

### DIFF
--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -416,7 +416,7 @@ TEST(cubeb, basic_stream_operations)
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(stream, nullptr);
 
-  /* position and volume before stream has started */
+  /* position before stream has started */
   r = cubeb_stream_get_position(stream, &position);
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_EQ(position, 0u);
@@ -424,14 +424,14 @@ TEST(cubeb, basic_stream_operations)
   r = cubeb_stream_start(stream);
   ASSERT_EQ(r, CUBEB_OK);
 
-  /* position and volume after while stream running */
+  /* position after while stream running */
   r = cubeb_stream_get_position(stream, &position);
   ASSERT_EQ(r, CUBEB_OK);
 
   r = cubeb_stream_stop(stream);
   ASSERT_EQ(r, CUBEB_OK);
 
-  /* position and volume after stream has stopped */
+  /* position after stream has stopped */
   r = cubeb_stream_get_position(stream, &position);
   ASSERT_EQ(r, CUBEB_OK);
 

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -400,6 +400,7 @@ TEST(cubeb, basic_stream_operations)
   cubeb_stream * stream;
   cubeb_stream_params params;
   uint64_t position;
+  uint32_t latency;
 
   r = common_init(&ctx, "test_sanity");
   ASSERT_EQ(r, CUBEB_OK);
@@ -416,23 +417,32 @@ TEST(cubeb, basic_stream_operations)
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_NE(stream, nullptr);
 
-  /* position before stream has started */
+  /* position and latency before stream has started */
   r = cubeb_stream_get_position(stream, &position);
   ASSERT_EQ(r, CUBEB_OK);
   ASSERT_EQ(position, 0u);
 
+  r = cubeb_stream_get_latency(stream, &latency);
+  ASSERT_EQ(r, CUBEB_OK);
+
   r = cubeb_stream_start(stream);
   ASSERT_EQ(r, CUBEB_OK);
 
-  /* position after while stream running */
+  /* position and latency after while stream running */
   r = cubeb_stream_get_position(stream, &position);
+  ASSERT_EQ(r, CUBEB_OK);
+
+  r = cubeb_stream_get_latency(stream, &latency);
   ASSERT_EQ(r, CUBEB_OK);
 
   r = cubeb_stream_stop(stream);
   ASSERT_EQ(r, CUBEB_OK);
 
-  /* position after stream has stopped */
+  /* position and latency after stream has stopped */
   r = cubeb_stream_get_position(stream, &position);
+  ASSERT_EQ(r, CUBEB_OK);
+
+  r = cubeb_stream_get_latency(stream, &latency);
   ASSERT_EQ(r, CUBEB_OK);
 
   cubeb_stream_destroy(stream);


### PR DESCRIPTION
Adding trivial function calls to check `cubeb_stream_get_latency` API is callable for Rust implementation on OSX.