### PR TITLE
Add a hint for building cubeb with cubeb-pulse-rs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,8 @@ if(USE_PULSE_RUST)
     LOG_BUILD ON)
   add_dependencies(cubeb cubeb_pulse_rs)
   target_compile_definitions(cubeb PRIVATE USE_PULSE_RUST)
+  # Add `pulse`at the end of target_link_libraries if pulse-dlopen feature is
+  # not turned on. Otherwise, the libpulse APIs cannot be linked.
   target_link_libraries(cubeb PRIVATE
     debug "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/debug/libcubeb_pulse.a"
     optimized "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/release/libcubeb_pulse.a")


### PR DESCRIPTION
I ran into a problem on building _cubeb_ with _cubeb-pulse-rs_ today. I cloned a _cubeb-pulse-rs_ repo under _cubeb/src_, turned on `BUILD_RUST_LIBS` (by `option(BUILD_RUST_LIBS "Build rust backends" ON)`) and then ran a command to build. As a result, all _libpulse_ APIs are _undefined references_ on _linking_ stage while compiling. To link to those APIs, either _libpulse_ needs to be passed to linker via `target_link_libraries(... pulse)` (something like `-lpulse` for _gcc_), or `pulse-dlopen` feature needs to be turned on (by setting `pulse-dlopen` to default in _Cargo.toml_ under _cubeb/src/cubeb-pulse-rs_). I think it's better to add some hints for the configuration in case others run into the same issue.