### PR TITLE
Test stream register device changed callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,4 +300,5 @@ if(BUILD_TESTS)
 
   cubeb_add_test(utils)
   cubeb_add_test(ring_buffer)
+  cubeb_add_test(device_changed_callback)
 endif()

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3101,7 +3101,7 @@ int audiounit_stream_register_device_changed_callback(cubeb_stream * stream,
   auto_lock dev_cb_lock(stream->device_changed_callback_lock);
   /* Note: second register without unregister first causes 'nope' error.
    * Current implementation requires unregister before register a new cb. */
-  assert(!stream->device_changed_callback);
+  assert(!device_changed_callback || !stream->device_changed_callback);
   stream->device_changed_callback = device_changed_callback;
   return CUBEB_OK;
 }

--- a/test/test_device_changed_callback.cpp
+++ b/test/test_device_changed_callback.cpp
@@ -65,8 +65,12 @@ void test_registering_second_callbacks(cubeb_stream * stream)
   }
   ASSERT_EQ(r, CUBEB_OK) << "Error registering device changed callback";
 
-  r = cubeb_stream_register_device_changed_callback(stream, device_changed_callback);
-  ASSERT_EQ(r, CUBEB_ERROR) << "Not getting an error when registering same callback twice";
+  // Get an assertion fails when registering a callback
+  // without unregistering the original one.
+  ASSERT_DEATH(
+    cubeb_stream_register_device_changed_callback(stream, device_changed_callback),
+    ""
+  );
 }
 
 TEST(cubeb, device_changed_callbacks)

--- a/test/test_device_changed_callback.cpp
+++ b/test/test_device_changed_callback.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2018 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+/* libcubeb api/function test. Check behaviors of registering device changed
+ * callbacks for the streams. */
+#include "gtest/gtest.h"
+#if !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 600
+#endif
+#include <stdio.h>
+#include <memory>
+#include "cubeb/cubeb.h"
+
+//#define ENABLE_NORMAL_LOG
+//#define ENABLE_VERBOSE_LOG
+#include "common.h"
+
+#define SAMPLE_FREQUENCY 48000
+#define STREAM_FORMAT CUBEB_SAMPLE_FLOAT32LE
+#define INPUT_CHANNELS 1
+#define INPUT_LAYOUT CUBEB_LAYOUT_MONO
+#define OUTPUT_CHANNELS 2
+#define OUTPUT_LAYOUT CUBEB_LAYOUT_STEREO
+
+void device_changed_callback(void * user)
+{
+  fprintf(stderr, "device changed callback\n");
+  ASSERT_TRUE(false) << "Error: device changed callback"
+                        " called without changing devices";
+}
+
+void test_registering_null_callback_twice(cubeb_stream * stream)
+{
+  int r = cubeb_stream_register_device_changed_callback(stream, nullptr);
+  if (r == CUBEB_ERROR_NOT_SUPPORTED) {
+    return;
+  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering null device changed callback";
+
+  r = cubeb_stream_register_device_changed_callback(stream, nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering null device changed callback again";
+}
+
+void test_registering_and_unregistering_callback(cubeb_stream * stream)
+{
+  int r = cubeb_stream_register_device_changed_callback(stream, device_changed_callback);
+  if (r == CUBEB_ERROR_NOT_SUPPORTED) {
+    return;
+  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device changed callback";
+
+  r = cubeb_stream_register_device_changed_callback(stream, nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device changed callback";
+}
+
+void test_registering_second_callbacks(cubeb_stream * stream)
+{
+  int r = cubeb_stream_register_device_changed_callback(stream, device_changed_callback);
+  if (r == CUBEB_ERROR_NOT_SUPPORTED) {
+    return;
+  }
+  ASSERT_EQ(r, CUBEB_OK) << "Error registering device changed callback";
+
+  r = cubeb_stream_register_device_changed_callback(stream, device_changed_callback);
+  ASSERT_EQ(r, CUBEB_ERROR) << "Not getting an error when registering same callback twice";
+}
+
+TEST(cubeb, device_changed_callbacks)
+{
+  cubeb * ctx;
+  cubeb_stream * stream;
+  cubeb_stream_params input_params;
+  cubeb_stream_params output_params;
+  int r = CUBEB_OK;
+  uint32_t latency_frames = 0;
+
+  r = common_init(&ctx, "Cubeb duplex example with device change");
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb library";
+
+  std::unique_ptr<cubeb, decltype(&cubeb_destroy)>
+    cleanup_cubeb_at_exit(ctx, cubeb_destroy);
+
+  /* typical user-case: mono input, stereo output, low latency. */
+  input_params.format = STREAM_FORMAT;
+  input_params.rate = SAMPLE_FREQUENCY;
+  input_params.channels = INPUT_CHANNELS;
+  input_params.layout = INPUT_LAYOUT;
+  input_params.prefs = CUBEB_STREAM_PREF_NONE;
+  output_params.format = STREAM_FORMAT;
+  output_params.rate = SAMPLE_FREQUENCY;
+  output_params.channels = OUTPUT_CHANNELS;
+  output_params.layout = OUTPUT_LAYOUT;
+  output_params.prefs = CUBEB_STREAM_PREF_NONE;
+
+  r = cubeb_get_min_latency(ctx, &output_params, &latency_frames);
+  ASSERT_EQ(r, CUBEB_OK) << "Could not get minimal latency";
+
+  r = cubeb_stream_init(ctx, &stream, "Cubeb duplex",
+                        NULL, &input_params, NULL, &output_params,
+                        latency_frames, nullptr, nullptr, nullptr);
+  ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
+
+  test_registering_null_callback_twice(stream);
+
+  test_registering_and_unregistering_callback(stream);
+
+  test_registering_second_callbacks(stream);
+
+  cubeb_stream_destroy(stream);
+}


### PR DESCRIPTION
Creating a test to make sure `device_changed_callback` works as what we expected and it can also be used to check Rust's `device_changed_callback` implementation.