### PR TITLE
audiounit: stop leaking after calling audiounit_create_device_from_hw_dev. Fixes #482

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1834,6 +1834,7 @@ static void audiounit_get_available_samplerate(AudioObjectID devid, AudioObjectP
                                    uint32_t * min, uint32_t * max, uint32_t * def);
 static int
 audiounit_create_device_from_hwdev(cubeb_device_info * dev_info, AudioObjectID devid, cubeb_device_type type);
+static void audiounit_device_destroy(cubeb_device_info * device);
 
 static void
 audiounit_workaround_for_airpod(cubeb_stream * stm)
@@ -1879,6 +1880,8 @@ audiounit_workaround_for_airpod(cubeb_stream * stm)
       LOG("Non fatal error, AudioObjectSetPropertyData/kAudioDevicePropertyNominalSampleRate, rv=%d", rv);
     }
   }
+  audiounit_device_destroy(&input_device_info);
+  audiounit_device_destroy(&output_device_info);
 }
 
 /*
@@ -3378,14 +3381,20 @@ audiounit_enumerate_devices(cubeb * /* context */, cubeb_device_type type,
   return CUBEB_OK;
 }
 
+static void
+audiounit_device_destroy(cubeb_device_info * device)
+{
+  delete [] device->device_id;
+  delete [] device->friendly_name;
+  delete [] device->vendor_name;
+}
+
 static int
 audiounit_device_collection_destroy(cubeb * /* context */,
                                     cubeb_device_collection * collection)
 {
   for (size_t i = 0; i < collection->count; i++) {
-    delete [] collection->device[i].device_id;
-    delete [] collection->device[i].friendly_name;
-    delete [] collection->device[i].vendor_name;
+    audiounit_device_destroy(&collection->device[i]);
   }
   delete [] collection->device;
 


### PR DESCRIPTION
When `audiounit_create_device_from_hw_dev` is called in an internal method we need to manually delete the allocated memory. When the same method is called from the external API method `audiounit_enumerate_devices` we don't need that because delete will happen on `audiounit_collection_destroy`.