### PR TITLE
pulse: guess default layout when it is not configured (BMO 1518106).

### DIFF
--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -85,6 +85,7 @@
   X(pa_context_subscribe)                       \
   X(pa_mainloop_api_once)                       \
   X(pa_get_library_version)                     \
+  X(pa_channel_map_init_auto)                   \
 
 #define MAKE_TYPEDEF(x) static typeof(x) * cubeb_##x;
 LIBPULSE_API_VISIT(MAKE_TYPEDEF);
@@ -786,6 +787,25 @@ to_pulse_format(cubeb_sample_format format)
   }
 }
 
+static cubeb_channel_layout
+pulse_default_layout_for_channels(uint32_t ch)
+{
+  assert (ch > 0 && ch <= 8);
+  switch (ch) {
+    case 1: return CUBEB_LAYOUT_MONO;
+    case 2: return CUBEB_LAYOUT_STEREO;
+    case 3: return CUBEB_LAYOUT_3F;
+    case 4: return CUBEB_LAYOUT_QUAD;
+    case 5: return CUBEB_LAYOUT_3F2;
+    case 6: return CUBEB_LAYOUT_3F_LFE |
+                   CHANNEL_SIDE_LEFT | CHANNEL_SIDE_RIGHT;
+    case 7: return CUBEB_LAYOUT_3F3R_LFE;
+    case 8: return CUBEB_LAYOUT_3F4_LFE;
+  }
+  // Never get here!
+  return CUBEB_LAYOUT_UNDEFINED;
+}
+
 static int
 create_pa_stream(cubeb_stream * stm,
                  pa_stream ** pa_stm,
@@ -809,7 +829,16 @@ create_pa_stream(cubeb_stream * stm,
   ss.channels = stream_params->channels;
 
   if (stream_params->layout == CUBEB_LAYOUT_UNDEFINED) {
-    *pa_stm = WRAP(pa_stream_new)(stm->context->context, stream_name, &ss, NULL);
+    pa_channel_map cm;
+    if (stream_params->channels <= 8 &&
+       !pa_channel_map_init_auto(&cm, stream_params->channels, PA_CHANNEL_MAP_DEFAULT)) {
+      LOG("Layout undefined and PulseAudio's default layout has not been configured, guess one.");
+      layout_to_channel_map(pulse_default_layout_for_channels(stream_params->channels), &cm);
+      *pa_stm = WRAP(pa_stream_new)(stm->context->context, stream_name, &ss, &cm);
+    } else {
+      LOG("Layout undefined, PulseAudio will use its default.");
+      *pa_stm = WRAP(pa_stream_new)(stm->context->context, stream_name, &ss, NULL);
+    }
   } else {
     pa_channel_map cm;
     layout_to_channel_map(stream_params->layout, &cm);


### PR DESCRIPTION
In PulseAudio when channel layout is not specified a default is being used. If default layout is not set `stream_init` will fail. On PA channel I was recommended to use a channel layout instead of relying on default because it is not guaranteed to be set. This patch will check if a default layout exists, if not a layout is set. The default layouts have been taken from Gecko's default layout in playback (link bellow):

https://searchfox.org/mozilla-central/rev/6e0e603f4852b8e571e5b8ae133e772b18b6016e/dom/media/AudioConfig.cpp#75