### PR TITLE
wasapi: Assert COM is initialized in wasapi_init.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1449,6 +1449,7 @@ int wasapi_init(cubeb ** context, char const * context_name)
   com_ptr<IMMDevice> device;
   HRESULT hr = get_default_endpoint(device, eRender);
   if (FAILED(hr)) {
+    XASSERT(hr != CO_E_NOTINITIALIZED);
     LOG("It wasn't able to find a default rendering device: %lx", hr);
     hr = get_default_endpoint(device, eCapture);
     if (FAILED(hr)) {


### PR DESCRIPTION
Per cubeb.h#L414, COM must be initialized by the caller before calling
cubeb_init.

This assert is intended to avoid unintentional fallback to the winmm backend
when the caller forgot to initialize COM before calling cubeb_init.

Inspired by issue #492.