### PR TITLE
Fix memory leak

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -1683,6 +1683,9 @@ audiounit_create_blank_aggregate_device(AudioObjectID * plugin_id, AudioDeviceID
   return CUBEB_OK;
 }
 
+// The returned CFStringRef object needs to be released (via CFRelease)
+// if it's not NULL, since the reference count of the returned CFStringRef
+// object is increased.
 static CFStringRef
 get_device_name(AudioDeviceID id)
 {
@@ -1715,6 +1718,7 @@ audiounit_set_aggregate_sub_device_list(AudioDeviceID aggregate_device_id,
       return CUBEB_ERROR;
     }
     CFArrayAppendValue(aggregate_sub_devices_array, ref);
+    CFRelease(ref);
   }
   for (UInt32 i = 0; i < input_sub_devices.size(); i++) {
     CFStringRef ref = get_device_name(input_sub_devices[i]);
@@ -1723,6 +1727,7 @@ audiounit_set_aggregate_sub_device_list(AudioDeviceID aggregate_device_id,
       return CUBEB_ERROR;
     }
     CFArrayAppendValue(aggregate_sub_devices_array, ref);
+    CFRelease(ref);
   }
 
   AudioObjectPropertyAddress aggregate_sub_device_list = { kAudioAggregateDevicePropertyFullSubDeviceList,
@@ -1764,6 +1769,9 @@ audiounit_set_master_aggregate_device(const AudioDeviceID aggregate_device_id)
                                            NULL,
                                            size,
                                            &master_sub_device);
+  if (master_sub_device) {
+    CFRelease(master_sub_device);
+  }
   if (rv != noErr) {
     LOG("AudioObjectSetPropertyData/kAudioAggregateDevicePropertyMasterSubDevice, rv=%d", rv);
     return CUBEB_ERROR;
@@ -3429,6 +3437,9 @@ audiounit_get_devices_of_type(cubeb_device_type devtype)
       it = devices.erase(it);
     } else {
       it++;
+    }
+    if (name) {
+      CFRelease(name);
     }
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -139,7 +139,7 @@ struct cubeb {
   // Store list of devices to detect changes
   vector<AudioObjectID> input_device_array;
   vector<AudioObjectID> output_device_array;
-  // The queue is asynchronously deallocated once all references to it are released
+  // The queue should be released when it’s no longer needed.
   dispatch_queue_t serial_queue = dispatch_queue_create(DISPATCH_QUEUE_LABEL, DISPATCH_QUEUE_SERIAL);
   // Current used channel layout
   atomic<cubeb_channel_layout> layout{ CUBEB_LAYOUT_UNDEFINED };
@@ -1431,6 +1431,8 @@ audiounit_destroy(cubeb * ctx)
       audiounit_remove_device_listener(ctx, CUBEB_DEVICE_TYPE_OUTPUT);
     }
   }
+
+  dispatch_release(ctx->serial_queue);
 
   delete ctx;
 }


### PR DESCRIPTION
I found some memory leaks by running the *Instruments* on OSX.
- The `serial_queue` with type `dispatch_queue_t` created by `dispatch_queue_create` is not released.
- The `CFStringRef` object created by `get_device_name` is not released

### `serial_queue`

By the developer document about [`dispatch_queue_create`][dispatch_queue_create], `dispatch_release` could be saved with *ARC* (Automatic Reference Counting ?) support.

> If your app isn’t using ARC, you should call dispatch_release on a dispatch queue when it’s no longer needed.

However, it seems like we don't have *ARC* support now. From the resulte of *Instruments*, the `dispatch_queue_t` object created by `dispatch_queue_create` is leaked. Without *ARC* support, we should call `dispatch_release` explicitly.

![leak_dispatch_queue](https://user-images.githubusercontent.com/5111652/54146364-116a4c80-43ed-11e9-9d95-62b5c099db78.png)

### `get_device_name`
https://github.com/kinetiknz/cubeb/blob/6f2420de8f155b10330cf973900ac7bdbfee589d/src/cubeb_audiounit.cpp#L1684-L1694

![leak_cfstringref_1](https://user-images.githubusercontent.com/5111652/54147600-c4d44080-43ef-11e9-82b0-ba5925b121d9.png)
![leak_cfstringref_2](https://user-images.githubusercontent.com/5111652/54147604-c69e0400-43ef-11e9-8183-3d5f00cc7a18.png)

From the resulte of *Instruments*, it seems like the reference count of the `CFStringRef` object referring to the *device-uid* string is increased after calling `get_device_name`. The reference count shoud be decreased by `CFRelease` when it's no longer needed. That's what `audiounit_create_device_from_hwdev` does.

https://github.com/kinetiknz/cubeb/blob/6f2420de8f155b10330cf973900ac7bdbfee589d/src/cubeb_audiounit.cpp#L3239-L3249

[dispatch_queue_create]: https://developer.apple.com/documentation/dispatch/1453030-dispatch_queue_create