### PR TITLE
Make sure data_callback and state_callback are not null

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -303,7 +303,7 @@ cubeb_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_n
 {
   int r;
 
-  if (!context || !stream) {
+  if (!context || !stream || !data_callback || !state_callback) {
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2762,8 +2762,6 @@ audiounit_stream_init(cubeb * context,
   int r;
   *stream = NULL;
   assert(latency_frames > 0);
-  assert(state_callback);
-  assert(data_callback);
 
   /* These could be different in the future if we have both
    * full-duplex stream and different devices for input vs output. */

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2762,6 +2762,8 @@ audiounit_stream_init(cubeb * context,
   int r;
   *stream = NULL;
   assert(latency_frames > 0);
+  assert(state_callback);
+  assert(data_callback);
 
   /* These could be different in the future if we have both
    * full-duplex stream and different devices for input vs output. */

--- a/test/test_device_changed_callback.cpp
+++ b/test/test_device_changed_callback.cpp
@@ -26,6 +26,15 @@
 #define OUTPUT_CHANNELS 2
 #define OUTPUT_LAYOUT CUBEB_LAYOUT_STEREO
 
+long data_callback(cubeb_stream * stream, void * user, const void * inputbuffer, void * outputbuffer, long nframes)
+{
+  return 0;
+}
+
+void state_callback(cubeb_stream * stream, void * user, cubeb_state state)
+{
+}
+
 void device_changed_callback(void * user)
 {
   fprintf(stderr, "device changed callback\n");
@@ -105,7 +114,7 @@ TEST(cubeb, device_changed_callbacks)
 
   r = cubeb_stream_init(ctx, &stream, "Cubeb duplex",
                         NULL, &input_params, NULL, &output_params,
-                        latency_frames, nullptr, nullptr, nullptr);
+                        latency_frames, data_callback, state_callback, nullptr);
   ASSERT_EQ(r, CUBEB_OK) << "Error initializing cubeb stream";
 
   test_registering_null_callback_twice(stream);


### PR DESCRIPTION
If `state_callback` and `data_callback` are null, we will fail to call `stm->data_callback` and `stm->data_callback`. We call them without checking if they are not nulls. It seems to me that they are no options, so we should make sure they are properly set.