### PR TITLE
Link ole32 in WASAPI backend for COM symbols.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(USE_WASAPI)
   target_sources(cubeb PRIVATE
     src/cubeb_wasapi.cpp)
   target_compile_definitions(cubeb PRIVATE USE_WASAPI)
-  target_link_libraries(cubeb PRIVATE avrt)
+  target_link_libraries(cubeb PRIVATE avrt ole32)
 endif()
 
 check_include_files("windows.h;mmsystem.h" USE_WINMM)


### PR DESCRIPTION
Fixes build on aarch64.  We must've been picking ole32 up implicitly on x86 platforms.

FWIW: building on aarch64 requires CMake 3.10 or later and just requires passing "-A ARM64" when generating the MSVC projects.