### PR TITLE
wasapi: tie monitor lifetime with notification client lifetime. BMO 1545279

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -450,9 +450,9 @@ public:
   wasapi_collection_notification_client(cubeb * context)
     : ref_count(1)
     , cubeb_context(context)
+    , monitor_notifications(context)
   {
     XASSERT(cubeb_context);
-    monitor_notifications.reset(new monitor_device_notifications(cubeb_context));
   }
 
   virtual ~wasapi_collection_notification_client()
@@ -493,7 +493,7 @@ public:
       if (FAILED(hr)) {
         return hr;
       }
-      monitor_notifications->notify(flow);
+      monitor_notifications.notify(flow);
     }
     return S_OK;
   }
@@ -531,7 +531,7 @@ private:
   LONG ref_count;
 
   cubeb * cubeb_context = nullptr;
-  std::unique_ptr<monitor_device_notifications> monitor_notifications;
+  monitor_device_notifications monitor_notifications;
 };
 
 class wasapi_endpoint_notification_client : public IMMNotificationClient


### PR DESCRIPTION
Addressing crash in [1].

For the collection callback there are two object involved, the "notification client" which provides the callback and the "monitor" object that handles the thread and executes the user callback. The crash appears on the second object. The cubeb pointer there is null. The immediate problem I am observing is that monitor is created after the notification client. This patch will tie the two object together in order to have the same lifetime.

[1] https://crash-stats.mozilla.com/report/index/883c36f7-d02e-4b41-9377-0135b0190415