### PR TITLE
wasapi: Add flag to disable default device switching.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -227,6 +227,9 @@ typedef enum {
                                          specified on the input params and an
                                          output device to loopback from should
                                          be passed in place of an input device. */
+  CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING = 0x02, /**< Disable switching
+                                                          default device on OS
+                                                          changes. */
   CUBEB_STREAM_PREF_VOICE = 0x04  /**< This stream is going to transport voice data.
                                        Depending on the backend and platform, this can
                                        change the audio input or output devices

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2158,11 +2158,16 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
     return rv;
   }
 
-  HRESULT hr = register_notification_client(stm.get());
-  if (FAILED(hr)) {
-    /* this is not fatal, we can still play audio, but we won't be able
-       to keep using the default audio endpoint if it changes. */
-    LOG("failed to register notification client, %lx", hr);
+  if (!((input_stream_params ?
+         (input_stream_params->prefs & CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING) : 0) ||
+        (output_stream_params ?
+         (output_stream_params->prefs & CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING) : 0))) {
+    HRESULT hr = register_notification_client(stm.get());
+    if (FAILED(hr)) {
+      /* this is not fatal, we can still play audio, but we won't be able
+         to keep using the default audio endpoint if it changes. */
+      LOG("failed to register notification client, %lx", hr);
+    }
   }
 
   *stream = stm.release();
@@ -2208,7 +2213,9 @@ void wasapi_stream_destroy(cubeb_stream * stm)
     stm->emergency_bailout = nullptr;
   }
 
-  unregister_notification_client(stm);
+  if (stm->notification_client) {
+    unregister_notification_client(stm);
+  }
 
   CloseHandle(stm->reconfigure_event);
   CloseHandle(stm->refill_event);


### PR DESCRIPTION
This has been merged in Gecko via BMO# 1427011 for quite some time.