### PR TITLE
Add audiounit-rust backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ if (BUILD_RUST_LIBS)
   if(EXISTS "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs")
     set(USE_PULSE_RUST 1)
   endif()
+  if(EXISTS "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs")
+    set(USE_AUDIOUNIT_RUST 1)
+  endif()
 endif()
 
 # On OS/2, visibility attribute is not supported.
@@ -246,6 +249,24 @@ if(USE_PULSE_RUST)
   target_link_libraries(cubeb PRIVATE
     debug "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/debug/libcubeb_pulse.a"
     optimized "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/release/libcubeb_pulse.a")
+endif()
+
+if(USE_AUDIOUNIT_RUST)
+  include(ExternalProject)
+  set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/rust)
+  ExternalProject_Add(
+    cubeb_coreaudio_rs
+    DOWNLOAD_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND cargo build COMMAND cargo build --release
+    BINARY_DIR "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs"
+    INSTALL_COMMAND ""
+    LOG_BUILD ON)
+  add_dependencies(cubeb cubeb_coreaudio_rs)
+  target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT_RUST)
+  target_link_libraries(cubeb PRIVATE
+    debug "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/debug/libcubeb_coreaudio.a"
+    optimized "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/release/libcubeb_coreaudio.a")
 endif()
 
 find_package(Doxygen)

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -42,6 +42,9 @@ int alsa_init(cubeb ** context, char const * context_name);
 #if defined(USE_AUDIOUNIT)
 int audiounit_init(cubeb ** context, char const * context_name);
 #endif
+#if defined(USE_AUDIOUNIT_RUST)
+int audiounit_rust_init(cubeb ** contet, char const * context_name);
+#endif
 #if defined(USE_WINMM)
 int winmm_init(cubeb ** context, char const * context_name);
 #endif
@@ -136,6 +139,10 @@ cubeb_init(cubeb ** context, char const * context_name, char const * backend_nam
 #if defined(USE_AUDIOUNIT)
       init_oneshot = audiounit_init;
 #endif
+    } else if (!strcmp(backend_name, "audiounit-rust")) {
+#if defined(USE_AUDIOUNIT_RUST)
+      init_oneshot = audiounit_rust_init;
+#endif
     } else if (!strcmp(backend_name, "wasapi")) {
 #if defined(USE_WASAPI)
       init_oneshot = wasapi_init;
@@ -185,6 +192,9 @@ cubeb_init(cubeb ** context, char const * context_name, char const * backend_nam
 #endif
 #if defined(USE_AUDIOUNIT)
     audiounit_init,
+#endif
+#if defined(USE_AUDIOUNIT_RUST)
+    audiounit_rust_init,
 #endif
 #if defined(USE_WASAPI)
     wasapi_init,


### PR DESCRIPTION
Add a configuration setting for the _Rust_ version of the _AudioUnit_ backend.

Some changes maded in cubeb.c has reviewed in [D23432][D23432], but the changes in  _CMakeLists.txt_ has not reviewed yet.

[D23432]: https://phabricator.services.mozilla.com/D23432