### PR TITLE
Enable Windows build on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - os: osx
     - os: osx
       env: SCAN_BUILD=true
+    - os: windows
 before_install:
   - if [[ -n $SCAN_BUILD ]]; then
       if [[ $TRAVIS_OS_NAME = "osx" ]]; then


### PR DESCRIPTION
Builds work fine but tests fail with 0xc0000135 (STATUS_DLL_NOT_FOUND) or hang (test_ring_buffer).