### PR TITLE
-Wimplicit-int-conversion warning fixes

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -74,7 +74,7 @@ validate_stream_params(cubeb_stream_params * input_stream_params,
   XASSERT(input_stream_params || output_stream_params);
   if (output_stream_params) {
     if (output_stream_params->rate < 1000 || output_stream_params->rate > 192000 ||
-        output_stream_params->channels < 1) {
+        output_stream_params->channels < 1 || output_stream_params->channels > UINT8_MAX) {
       return CUBEB_ERROR_INVALID_FORMAT;
     }
   }

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -573,7 +573,9 @@ layout_to_channel_map(cubeb_channel_layout layout, pa_channel_map * cm)
     }
     channelMap = channelMap >> 1;
   }
-  cm->channels = cubeb_channel_layout_nb_channels(layout);
+  unsigned int channels_from_layout = cubeb_channel_layout_nb_channels(layout);
+  assert(channels_from_layout <= UINT8_MAX);
+  cm->channels = (uint8_t) channels_from_layout;
 }
 
 static void pulse_context_destroy(cubeb * ctx);
@@ -826,7 +828,9 @@ create_pa_stream(cubeb_stream * stm,
   if (ss.format == PA_SAMPLE_INVALID)
     return CUBEB_ERROR_INVALID_FORMAT;
   ss.rate = stream_params->rate;
-  ss.channels = stream_params->channels;
+  if (stream_params->channels > UINT8_MAX)
+    return CUBEB_ERROR_INVALID_FORMAT;
+  ss.channels = (uint8_t) stream_params->channels;
 
   if (stream_params->layout == CUBEB_LAYOUT_UNDEFINED) {
     pa_channel_map cm;

--- a/tools/cubeb-test.cpp
+++ b/tools/cubeb-test.cpp
@@ -282,10 +282,13 @@ void print_help() {
   fprintf(stderr, "%s\n", msg);
 }
 
-bool choose_action(const cubeb_client& cl, operation_data * op, char c) {
+bool choose_action(const cubeb_client& cl, operation_data * op, int c) {
+  // Consume "enter" and "space"
   while (c == 10 || c == 32) {
-    // Consume "enter and "space"
     c = getchar();
+  }
+  if (c == EOF) {
+    c = 'q';
   }
 
   if (c == 'q') {
@@ -362,7 +365,7 @@ bool choose_action(const cubeb_client& cl, operation_data * op, char c) {
       fprintf(stderr, "unregister_device_collection_changed failed\n");
     }
   } else {
-    fprintf(stderr, "Error: %c is not a valid entry\n", c);
+    fprintf(stderr, "Error: '%c' is not a valid entry\n", c);
   }
 
   return true; // Loop up


### PR DESCRIPTION
A couple of simple fixes for -Wimplicit-int-conversion (available in Clang 8.0+).  ALSA, JACK, and AudioUnit backends were all clean.  Didn't test other build configurations.

cubeb_mixer.cpp has a bunch of warnings for this also, but it might be more involved to clean that up as it looks like it might be better to review the types used rather than just add checks and casts.