### PR TITLE
Fix output latency reporting on OSX, and add a round trip latency testing mode to the tool

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -241,6 +241,7 @@ struct cubeb_stream {
   /* Latency requested by the user. */
   uint32_t latency_frames = 0;
   atomic<uint32_t> current_latency_frames{ 0 };
+  atomic<uint32_t> total_output_latency_frames { 0 };
   atomic<float> panning{ 0 };
   unique_ptr<cubeb_resampler, decltype(&cubeb_resampler_destroy)> resampler;
   /* This is true if a device change callback is currently running.  */
@@ -368,8 +369,10 @@ typedef UInt32 AudioObjectID;
 
 #define AudioGetCurrentHostTime mach_absolute_time
 
+#endif
+
 uint64_t
-AudioConvertHostTimeToNanos(uint64_t host_time)
+ConvertHostTimeToNanos(uint64_t host_time)
 {
   static struct mach_timebase_info timebase_info;
   static bool initialized = false;
@@ -385,7 +388,6 @@ AudioConvertHostTimeToNanos(uint64_t host_time)
   }
   return (uint64_t)answer;
 }
-#endif
 
 static void
 audiounit_increment_active_streams(cubeb * ctx)
@@ -582,6 +584,15 @@ audiounit_output_callback(void * user_ptr,
   assert(outBufferList->mNumberBuffers == 1);
 
   cubeb_stream * stm = static_cast<cubeb_stream *>(user_ptr);
+
+  uint64_t now = ConvertHostTimeToNanos(mach_absolute_time());
+  uint64_t audio_output_time = ConvertHostTimeToNanos(tstamp->mHostTime);
+  uint64_t output_latency_ns = audio_output_time - now;
+
+  const int ns2s = 1e9;
+  // The total output latency is the timestamp difference + the stream latency +
+  // the hardware latency.
+  stm->total_output_latency_frames = output_latency_ns * stm->output_hw_rate / ns2s + stm->current_latency_frames;
 
   ALOGV("(%p) output: buffers %u, size %u, channels %u, frames %u, total input frames %lu.",
         stm,
@@ -2973,7 +2984,7 @@ audiounit_stream_get_latency(cubeb_stream * stm, uint32_t * latency)
   //TODO
   return CUBEB_ERROR_NOT_SUPPORTED;
 #else
-  *latency = stm->current_latency_frames;
+  *latency = stm->total_output_latency_frames;
   return CUBEB_OK;
 #endif
 }

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -61,7 +61,7 @@ const char * PRIVATE_AGGREGATE_DEVICE_NAME = "CubebAggregateDevice";
 /* Testing empirically, some headsets report a minimal latency that is very
  * low, but this does not work in practice. Lie and say the minimum is 256
  * frames. */
-const uint32_t SAFE_MIN_LATENCY_FRAMES = 256;
+const uint32_t SAFE_MIN_LATENCY_FRAMES = 128;
 const uint32_t SAFE_MAX_LATENCY_FRAMES = 512;
 
 const AudioObjectPropertyAddress DEFAULT_INPUT_DEVICE_PROPERTY_ADDRESS = {

--- a/tools/cubeb-test.cpp
+++ b/tools/cubeb-test.cpp
@@ -17,7 +17,8 @@
 
 // Default values if none specified
 #define DEFAULT_RATE 44100
-#define DEFAULT_CHANNELS 2
+#define DEFAULT_OUTPUT_CHANNELS 2
+#define DEFAULT_INPUT_CHANNELS 1
 
 static const char* state_to_string(cubeb_state state) {
   switch (state) {
@@ -53,7 +54,10 @@ public:
   bool destroy_stream() const;
   bool destroy();
   bool activate_log(cubeb_log_level log_level) const;
+  void set_latency_testing(bool on);
+  void set_latency_frames(uint32_t latency_frames);
   uint64_t get_stream_position() const;
+  uint32_t get_stream_latency() const;
 
   long user_data_cb(cubeb_stream* stm, void* user, const void* input_buffer,
                     void* output_buffer, long nframes);
@@ -79,6 +83,9 @@ private:
   /* Accessed only from client and audio thread. */
   std::atomic<uint32_t> _rate = {0};
   std::atomic<uint32_t> _channels = {0};
+  std::atomic<bool> _latency_testing = {false};
+  std::atomic<uint32_t> _latency_frames = {0}; // if !0, override. Else, use min.
+
 
   /* Accessed only from audio thread. */
   uint32_t _total_frames = 0;
@@ -124,11 +131,27 @@ bool cubeb_client::init_stream() {
   _rate = has_output() ? output_params.rate : input_params.rate;
   _channels = has_output() ? output_params.channels : input_params.channels;
 
-  int rv =
+  cubeb_stream_params params;
+  params.rate = _rate;
+  params.channels = 2;
+  params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  uint32_t latency = 0;
+  int rv = cubeb_get_min_latency(context, &params, &latency);
+  if (rv != CUBEB_OK) {
+    fprintf(stderr, "Could not get min latency.");
+    return false;
+  }
+
+  if (_latency_frames) {
+    latency = _latency_frames.load();
+    printf("Opening a stream with a forced latency of %d frames\n", latency);
+  }
+
+  rv =
       cubeb_stream_init(context, &stream, "Stream", input_device,
                         has_input() ? &input_params : nullptr, output_device,
-                        has_output() ? &output_params : nullptr, 512,
-                        user_data_cb_s, user_state_cb_s, this);
+                        has_output() ? &output_params : nullptr, latency, user_data_cb_s, user_state_cb_s, this);
   if (rv != CUBEB_OK) {
     fprintf(stderr, "Could not open the stream\n");
     return false;
@@ -158,10 +181,20 @@ uint64_t cubeb_client::get_stream_position() const {
   uint64_t pos = 0;
   int rv = cubeb_stream_get_position(stream, &pos);
   if (rv != CUBEB_OK) {
-    fprintf(stderr, "Could not get the position the stream\n");
+    fprintf(stderr, "Could not get the position of the stream\n");
     return 0;
   }
   return pos;
+}
+
+uint32_t cubeb_client::get_stream_latency() const {
+  uint32_t latency = 0;
+  int rv = cubeb_stream_get_latency(stream, &latency);
+  if (rv != CUBEB_OK) {
+    fprintf(stderr, "Could not get the latency of the stream\n");
+    return 0;
+  }
+  return latency;
 }
 
 bool cubeb_client::destroy_stream() const {
@@ -187,6 +220,14 @@ bool cubeb_client::activate_log(cubeb_log_level log_level) const {
   return true;
 }
 
+void cubeb_client::set_latency_testing(bool on) {
+  _latency_testing = on;
+}
+
+void cubeb_client::set_latency_frames(uint32_t latency_frames) {
+  _latency_frames = latency_frames;
+}
+
 static void fill_with_sine_tone(float* buf, uint32_t num_of_frames,
                                uint32_t num_of_channels, uint32_t frame_rate,
                                uint32_t position) {
@@ -206,7 +247,28 @@ long cubeb_client::user_data_cb(cubeb_stream* stm, void* user,
   if (input_buffer && output_buffer) {
     const float* in = static_cast<const float*>(input_buffer);
     float* out = static_cast<float*>(output_buffer);
-    memcpy(out, in, sizeof(float) * nframes * _channels);
+    if (_latency_testing) {
+      for (uint32_t i = 0; i < nframes; i++) {
+        // Impulses every second, mixed with the input signal fed back at half
+        // gain, to measure the input-to-output latency via feedback.
+        uint32_t clock = ((_total_frames + i) % _rate);
+        if (!clock) {
+          for (uint32_t j = 0; j < _channels; j++) {
+            out[i * _channels + j] = 1.0 + in[i] * 0.5;
+          }
+        } else {
+          for (uint32_t j = 0; j < _channels; j++) {
+            out[i * _channels + j] = 0.0 + in[i] * 0.5;
+          }
+        }
+      }
+    } else {
+      for (uint32_t i = 0; i < nframes; i++) {
+        for (uint32_t j = 0; j < _channels; j++) {
+          out[i * _channels + j] = in[i];
+        }
+      }
+    }
   } else if (output_buffer && !input_buffer) {
     fill_with_sine_tone(static_cast<float*>(output_buffer), nframes, _channels,
                        _rate, _total_frames);
@@ -254,6 +316,7 @@ enum play_mode {
   RECORD,
   PLAYBACK,
   DUPLEX,
+  LATENCY_TESTING,
   COLLECTION_CHANGE,
 };
 
@@ -292,7 +355,7 @@ bool choose_action(const cubeb_client& cl, operation_data * op, int c) {
   }
 
   if (c == 'q') {
-    if (op->pm == PLAYBACK || op->pm == RECORD || op->pm == DUPLEX) {
+    if (op->pm == PLAYBACK || op->pm == RECORD || op->pm == DUPLEX || op->pm == LATENCY_TESTING) {
       bool res = cl.stop_stream();
       if (!res) {
         fprintf(stderr, "stop_stream failed\n");
@@ -337,7 +400,8 @@ bool choose_action(const cubeb_client& cl, operation_data * op, int c) {
     }
   } else if (c == 'c') {
     uint64_t pos = cl.get_stream_position();
-    fprintf(stderr, "stream position %" PRIu64 "\n", pos);
+    uint64_t latency = cl.get_stream_latency();
+    fprintf(stderr, "stream position %" PRIu64 " (latency %" PRIu64 ")\n", pos, latency);
   } else if (c == 'i') {
     op->collection_device_type = CUBEB_DEVICE_TYPE_INPUT;
     fprintf(stderr, "collection device type changed to INPUT\n");
@@ -385,12 +449,18 @@ int main(int argc, char* argv[]) {
       op.pm = PLAYBACK;
     } else if ('d' == argv[1][0]) {
       op.pm = DUPLEX;
+    } else if ('l' == argv[1][0]) {
+      op.pm = LATENCY_TESTING;
     } else if ('c' == argv[1][0]) {
       op.pm = COLLECTION_CHANGE;
     }
   }
   op.rate = DEFAULT_RATE;
-  if (argc > 2) {
+  uint32_t latency_override = 0;
+  if (op.pm == LATENCY_TESTING && argc > 2) {
+    latency_override = strtoul(argv[2], NULL, 10);
+    printf("LATENCY_TESTING %d\n", latency_override);
+  } else if (argc > 2) {
     op.rate = strtoul(argv[2], NULL, 0);
   }
 
@@ -412,13 +482,18 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "register_device_collection_changed failed\n");
     }
   } else {
-    if (op.pm == PLAYBACK || op.pm == DUPLEX) {
-      cl.output_params = {CUBEB_SAMPLE_FLOAT32NE, op.rate, DEFAULT_CHANNELS,
-                          CUBEB_LAYOUT_UNDEFINED, CUBEB_STREAM_PREF_NONE};
+    if (op.pm == PLAYBACK || op.pm == DUPLEX || op.pm == LATENCY_TESTING) {
+      cl.output_params = {CUBEB_SAMPLE_FLOAT32NE, op.rate, DEFAULT_OUTPUT_CHANNELS,
+                          CUBEB_LAYOUT_STEREO, CUBEB_STREAM_PREF_NONE};
     }
-    if (op.pm == RECORD || op.pm == DUPLEX) {
-      cl.input_params = {CUBEB_SAMPLE_FLOAT32NE, op.rate, DEFAULT_CHANNELS,
-                         CUBEB_LAYOUT_UNDEFINED, CUBEB_STREAM_PREF_NONE};
+    if (op.pm == RECORD || op.pm == DUPLEX || op.pm == LATENCY_TESTING) {
+      cl.input_params = {CUBEB_SAMPLE_FLOAT32NE, op.rate, DEFAULT_INPUT_CHANNELS, CUBEB_LAYOUT_UNDEFINED, CUBEB_STREAM_PREF_NONE};
+    }
+    if (op.pm == LATENCY_TESTING) {
+      cl.set_latency_testing(true);
+      if (latency_override) {
+        cl.set_latency_frames(latency_override);
+      }
     }
     res = cl.init_stream();
     if (!res) {


### PR DESCRIPTION
Also lower the minimum latency, we'll see in gecko whether it can work.