### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/test/test_device_changed_callback.cpp
+++ b/test/test_device_changed_callback.cpp
@@ -76,7 +76,7 @@ void test_registering_second_callbacks(cubeb_stream * stream)
 
   // Get an assertion fails when registering a callback
   // without unregistering the original one.
-  ASSERT_DEATH(
+  ASSERT_DEATH_IF_SUPPORTED(
     cubeb_stream_register_device_changed_callback(stream, device_changed_callback),
     ""
   );


### PR DESCRIPTION
Bundled googeltest doesn't support death tests on any of BSDs.
https://github.com/google/googletest/blob/release-1.6.0/include/gtest/internal/gtest-port.h#L537-L546
