### PR TITLE
Add -ldl for USE_SNDIO as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if(USE_SNDIO)
   target_sources(cubeb PRIVATE
     src/cubeb_sndio.c)
   target_compile_definitions(cubeb PRIVATE USE_SNDIO)
-  target_link_libraries(cubeb PRIVATE pthread)
+  target_link_libraries(cubeb PRIVATE pthread ${CMAKE_DL_LIBS})
 endif()
 
 check_include_files(sys/audioio.h USE_SUN)


### PR DESCRIPTION
Regressed by #539, see [dlopen(3)](http://man7.org/linux/man-pages/man3/dlopen.3.html). May require `-DUSE_SNDIO=ON -DUSE_ALSA=OFF -DUSE_JACK=OFF -DUSE_PULSE=OFF` to reproduce.

