### PR TITLE
Don't depend on development package for ALSA and SNDIO

### DIFF
--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -811,9 +811,12 @@ alsa_init(cubeb ** context, char const * context_name)
   *context = NULL;
 
 #ifndef DISABLE_LIBASOUND_DLOPEN
-  libasound = dlopen("libasound.so", RTLD_LAZY);
+  libasound = dlopen("libasound.so.2", RTLD_LAZY);
   if (!libasound) {
-    return CUBEB_ERROR;
+    libasound = dlopen("libasound.so", RTLD_LAZY);
+    if (!libasound) {
+      return CUBEB_ERROR;
+    }
   }
 
 #define LOAD(x) {                               \

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -211,6 +211,9 @@ load_jack_lib(cubeb * context)
 # endif
 #else
   context->libjack = dlopen("libjack.so.0", RTLD_LAZY);
+  if (!context->libjack) {
+    context->libjack = dlopen("libjack.so", RTLD_LAZY);
+  }
 #endif
   if (!context->libjack) {
     return CUBEB_ERROR;

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -627,7 +627,10 @@ pulse_init(cubeb ** context, char const * context_name)
 #ifndef DISABLE_LIBPULSE_DLOPEN
   libpulse = dlopen("libpulse.so.0", RTLD_LAZY);
   if (!libpulse) {
-    return CUBEB_ERROR;
+    libpulse = dlopen("libpulse.so", RTLD_LAZY);
+    if (!libpulse) {
+      return CUBEB_ERROR;
+    }
   }
 
 #define LOAD(x) {                               \

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -283,10 +283,13 @@ sndio_init(cubeb **context, char const *context_name)
   void * libsndio = NULL;
 
 #ifndef DISABLE_LIBSNDIO_DLOPEN
-  libsndio = dlopen("libsndio.so", RTLD_LAZY);
+  libsndio = dlopen("libsndio.so.7.0", RTLD_LAZY);
   if (!libsndio) {
-    DPR("sndio_init(%s) failed dlopen(libsndio.so)\n", context_name);
-    return CUBEB_ERROR;
+    libsndio = dlopen("libsndio.so", RTLD_LAZY);
+    if (!libsndio) {
+      DPR("sndio_init(%s) failed dlopen(libsndio.so)\n", context_name);
+      return CUBEB_ERROR;
+    }
   }
 
 #define LOAD(x) {                               \


### PR DESCRIPTION
Regressed by #539

- On Debian `.so` symlink is part of separate [`libasound2-dev`](https://packages.debian.org/sid/amd64/libasound2-dev/filelist) and [`libsndio-dev`](https://packages.debian.org/sid/amd64/libsndio-dev/filelist) packages
- On OpenBSD `.so.X` symlink is not provided because OS updates often change ABI of all libraries
- On rolling distributions runtime and development bits are not separate
