### PR TITLE
Clear the buffer properly when draining.

### DIFF
--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -692,9 +692,13 @@ audiounit_output_callback(void * user_ptr,
 
   /* Post process output samples. */
   if (stm->draining) {
-    size_t outbpf = cubeb_sample_size(stm->output_stream_params.format);
     /* Clear missing frames (silence) */
-    memset((uint8_t*)output_buffer + outframes * outbpf, 0, (output_frames - outframes) * outbpf);
+    size_t missing_samples = (output_frames - outframes) * stm->output_desc.mChannelsPerFrame;
+    size_t size_sample = cubeb_sample_size(stm->output_stream_params.format);
+    /* number of bytes that have been filled with valid audio by the callback. */
+    size_t audio_byte_count = outframes * stm->output_desc.mChannelsPerFrame * size_sample;
+    PodZero((uint8_t*)output_buffer + audio_byte_count,
+            missing_samples * size_sample);
   }
 
   /* Mixing */


### PR DESCRIPTION
A multiplication by the size of the type was missing.

This was not a problem, because apparently macOS clears the buffers, but when remoting this is not necessarily the case, and a glitch happens when draining.