### PR TITLE
Add support for float playback on android (OpenSLES)

### DIFF
--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1080,25 +1080,23 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params) {
   SLuint32* format_sample_rate = NULL;
 
 #if defined(__ANDROID__) && (__ANDROID_API__ >= ANDROID_VERSION_LOLLIPOP)
-  SLAndroidDataFormat_PCM_EX aformat;
+  SLAndroidDataFormat_PCM_EX pcm_ext_format;
   if (get_android_version() >= ANDROID_VERSION_LOLLIPOP) {
-    if (opensl_set_format_ext(&aformat, params) != CUBEB_OK) {
+    if (opensl_set_format_ext(&pcm_ext_format, params) != CUBEB_OK) {
       return CUBEB_ERROR_INVALID_FORMAT;
     }
-
-    format = &aformat;
-    format_sample_rate = &aformat.sampleRate;
+    format = &pcm_ext_format;
+    format_sample_rate = &pcm_ext_format.sampleRate;
   }
 #endif
 
-  SLDataFormat_PCM bformat;
+  SLDataFormat_PCM pcm_format;
   if(!format) {
-    if(opensl_set_format(&bformat, params) != CUBEB_OK) {
+    if(opensl_set_format(&pcm_format, params) != CUBEB_OK) {
       return CUBEB_ERROR_INVALID_FORMAT;
     }
-
-    format = &bformat;
-    format_sample_rate = &bformat.samplesPerSec;
+    format = &pcm_format;
+    format_sample_rate = &pcm_format.samplesPerSec;
   }
 
   SLDataLocator_BufferQueue loc_bufq;


### PR DESCRIPTION
Float output is only available (and the code only be used) if the targeted android version at compile time as well as the device version at runtime is high enough (>= lollipop).
This PR does not add support for float capturing since i don't really care about that. Tested it with a >= lollipop device. 
BTW, would there be any interest in an AAudio backend for cubeb? Some of the OpenSLES stuff seems kinda messy to me and AAudio might improve performance.