### PR TITLE
Add passthrough resampler no-copy optimization

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -1,0 +1,4 @@
+-D__ANDROID__
+-D__ANDROID_API__=24
+-I./build/exports
+-I/opt/android-ndk/sysroot/usr/include

--- a/.clang_complete
+++ b/.clang_complete
@@ -1,4 +1,0 @@
--D__ANDROID__
--D__ANDROID_API__=24
--I./build/exports
--I/opt/android-ndk/sysroot/usr/include

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -66,43 +66,41 @@ long passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_cou
          (output_buffer && !input_buffer && (!input_frames_count || *input_frames_count == 0)) ||
          (input_buffer && !output_buffer && output_frames == 0));
 
-  // when we have no pending input data and exactly as much input
+  // When we have no pending input data and exactly as much input
   // as output data, we don't need to copy it into the internal buffer
   // and can directly forward it to the callback.
   void * in_buf = input_buffer;
   unsigned long pop_input_count = 0u;
-  if (input_buffer) {
-    if (!output_buffer) {
+  if (input_buffer && !output_buffer) {
       output_frames = *input_frames_count;
+  } else if(input_buffer) {
+    if (internal_input_buffer.length() != 0) {
+      // In this case we have pending input data left and have
+      // to first append the input so we can pass it as one pointer
+      // to the callback
+      internal_input_buffer.push(static_cast<T*>(input_buffer),
+                                 frames_to_samples(*input_frames_count));
+      in_buf = internal_input_buffer.data();
+      pop_input_count = frames_to_samples(output_frames);
+    } else if(*input_frames_count > output_frames) {
+      // In this case we have more input that we need output and
+      // fill the overflowing input into internal_input_buffer
+      // Since we have no other pending data, we can nonetheless
+      // pass the current input data directly to the callback
+      assert(pop_input_count == 0);
+      unsigned long samples_off = frames_to_samples(output_frames);
+      internal_input_buffer.push(static_cast<T*>(input_buffer) + samples_off,
+                                 frames_to_samples(*input_frames_count - output_frames));
     }
-
-	if (internal_input_buffer.length() != 0) {
-		// In this case we have pending input data left and have
-		// to first append the input so we can pass it as one pointer
-		// to the callback
-		internal_input_buffer.push(static_cast<T*>(input_buffer),
-								   frames_to_samples(*input_frames_count));
-		in_buf = internal_input_buffer.data();
-		pop_input_count = frames_to_samples(output_frames);
-	} else if(*input_frames_count > output_frames) {
-		// in this case we have more input that we need output and
-		// fill the overflowing input into our buffer.
-		// Since we have no other pending data, we can nonetheless
-		// pass the current input data directly to the callback
-		unsigned long in_over = *input_frames_count - output_frames;
-		unsigned long samples_off = frames_to_samples(output_frames);
-		internal_input_buffer.push(static_cast<T*>(input_buffer) + samples_off,
-								   frames_to_samples(in_over));
-	}
   }
 
   long rv = data_callback(stream, user_ptr, in_buf, output_buffer, output_frames);
 
-  if (pop_input_count) {
-    internal_input_buffer.pop(nullptr, pop_input_count);
-  }
-
   if (input_buffer) {
+    if (pop_input_count) {
+      internal_input_buffer.pop(nullptr, pop_input_count);
+    }
+
     *input_frames_count = output_frames;
     drop_audio_if_needed();
   }

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -66,19 +66,43 @@ long passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_cou
          (output_buffer && !input_buffer && (!input_frames_count || *input_frames_count == 0)) ||
          (input_buffer && !output_buffer && output_frames == 0));
 
+  // when we have no pending input data and exactly as much input
+  // as output data, we don't need to copy it into the internal buffer
+  // and can directly forward it to the callback.
+  void * in_buf = input_buffer;
+  unsigned long pop_input_count = 0u;
   if (input_buffer) {
     if (!output_buffer) {
       output_frames = *input_frames_count;
     }
-    internal_input_buffer.push(static_cast<T*>(input_buffer),
-                               frames_to_samples(*input_frames_count));
+
+	if (internal_input_buffer.length() != 0) {
+		// In this case we have pending input data left and have
+		// to first append the input so we can pass it as one pointer
+		// to the callback
+		internal_input_buffer.push(static_cast<T*>(input_buffer),
+								   frames_to_samples(*input_frames_count));
+		in_buf = internal_input_buffer.data();
+		pop_input_count = frames_to_samples(output_frames);
+	} else if(*input_frames_count > output_frames) {
+		// in this case we have more input that we need output and
+		// fill the overflowing input into our buffer.
+		// Since we have no other pending data, we can nonetheless
+		// pass the current input data directly to the callback
+		unsigned long in_over = *input_frames_count - output_frames;
+		unsigned long samples_off = frames_to_samples(output_frames);
+		internal_input_buffer.push(static_cast<T*>(input_buffer) + samples_off,
+								   frames_to_samples(in_over));
+	}
   }
 
-  long rv = data_callback(stream, user_ptr, internal_input_buffer.data(),
-                          output_buffer, output_frames);
+  long rv = data_callback(stream, user_ptr, in_buf, output_buffer, output_frames);
+
+  if (pop_input_count) {
+    internal_input_buffer.pop(nullptr, pop_input_count);
+  }
 
   if (input_buffer) {
-    internal_input_buffer.pop(nullptr, frames_to_samples(output_frames));
     *input_frames_count = output_frames;
     drop_audio_if_needed();
   }


### PR DESCRIPTION
For input-only streams or duplex streams on backends that always have as much input as output (this is the case for AAudio, i just split this change to a seperate PR), this eliminates a full data copy per callback.