### PR TITLE
sndio backend fixes

### DIFF
--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -282,6 +282,8 @@ sndio_init(cubeb **context, char const *context_name)
 {
   void * libsndio = NULL;
 
+  assert(context);
+
 #ifndef DISABLE_LIBSNDIO_DLOPEN
   libsndio = dlopen("libsndio.so.7.0", RTLD_LAZY);
   if (!libsndio) {
@@ -306,7 +308,9 @@ sndio_init(cubeb **context, char const *context_name)
 #endif
 
   DPR("sndio_init(%s)\n", context_name);
-  *context = malloc(sizeof(*context));
+  *context = malloc(sizeof(**context));
+  if (*context == NULL)
+	return CUBEB_ERROR;
   (*context)->libsndio = libsndio;
   (*context)->ops = &sndio_ops;
   (void)context_name;


### PR DESCRIPTION
The first two commits fix two important memory issues.
* First commit allocates the size of `struct cubeb` instead of `struct cubeb *`, which previously would write beyond the allocated memory when assigning `libsndio` and `ops`.
* Second commit fixes writing beyond `struct pollfd[10]`, on my system 16 was required. It now uses `sio_ndfs` to avoid this from happening again.

The third commit is optional but imho improves the choice of which cubeb backend is used if libsndio.so is installed.