### PR TITLE
sndio: Always use SIO_DEVANY on FreeBSD/DragonFly

### DIFF
--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -128,7 +128,7 @@ s16_to_float(void *ptr, long nsamp)
 static const char *
 sndio_get_device()
 {
-#ifndef __OpenBSD__
+#ifdef __linux__
   /*
    * On other platforms default to sndio devices,
    * so cubebs other backends can be used instead.


### PR DESCRIPTION
Forcing cubeb to snd/0 is entirely inappropriate for FreeBSD where
using the sndio backend without a running sndiod is completely ok
and does not suffer from the same drawbacks (blocking the audio
device) as ALSA on Linux.

Using SIO_DEVANY (i.e., "default") will cause libsndio to open the
default device /dev/dsp on FreeBSD, so libsndio can be used without
running sndiod or extra configuration like setting the AUDIODEVICE
environment variable.

Regressed by a7b7cdbeeb79191fbf9c8dbe3934d9d1c5531067.