### PR TITLE
resampler: avoid overflow on uint arithmetics

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -283,8 +283,9 @@ public:
    * exactly `output_frame_count` resampled frames. This can return a number
    * slightly bigger than what is strictly necessary, but it guaranteed that the
    * number of output frames will be exactly equal. */
-  uint32_t input_needed_for_output(uint32_t output_frame_count) const
+  uint32_t input_needed_for_output(int32_t output_frame_count) const
   {
+    assert(output_frame_count >= 0); // Check overflow
     int32_t unresampled_frames_left = samples_to_frames(resampling_in_buffer.length());
     int32_t resampled_frames_left = samples_to_frames(resampling_out_buffer.length());
     float input_frames_needed =
@@ -462,8 +463,9 @@ public:
    * @parameter frames_needed the number of frames one want to write into the
    * delay_line
    * @returns the number of frames one will get. */
-  size_t input_needed_for_output(uint32_t frames_needed) const
+  uint32_t input_needed_for_output(int32_t frames_needed) const
   {
+    assert(frames_needed >= 0); // Check overflow
     return frames_needed;
   }
   /** Returns the number of frames produces for `input_frames` frames in input */

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1061,3 +1061,21 @@ TEST(cubeb, passthrough_resampler_fill_input_left) {
   ASSERT_EQ(input_frame_count, output_frame_count - 8);
 }
 
+TEST(cubeb, individual_methods) {
+  const uint32_t channels = 2;
+  const uint32_t sample_rate = 44100;
+  const uint32_t frames = 256;
+
+  delay_line<float> dl(10, channels, sample_rate);
+  uint32_t frames_needed1 = dl.input_needed_for_output(0);
+  ASSERT_EQ(frames_needed1, 0u);
+
+  cubeb_resampler_speex_one_way<float> one_way(channels, sample_rate, sample_rate, CUBEB_RESAMPLER_QUALITY_DEFAULT);
+  float buffer[channels * frames] = {0.0};
+  // Add all frames in the resampler's internal buffer.
+  one_way.input(buffer, frames);
+  // Ask for less than the existing frames, this would create a uint overlflow without the fix.
+  uint32_t frames_needed2 = one_way.input_needed_for_output(0);
+  ASSERT_EQ(frames_needed2, 0u);
+}
+


### PR DESCRIPTION
Change the argument to int in order to prevent unsigned int overflow on the arithmetics bellow. An assert added to make sure that the argument has a valid value. Changed also the return type of `delay_line::input_needed_for_output` to be symmetric to the other one.