### PR TITLE
fix a few warnings

### DIFF
--- a/src/cubeb_utils.cpp
+++ b/src/cubeb_utils.cpp
@@ -19,5 +19,6 @@ size_t cubeb_sample_size(cubeb_sample_format format)
     default:
       // should never happen as all cases are handled above.
       assert(false);
+      return 0;
   }
 }

--- a/test/test_loopback.cpp
+++ b/test/test_loopback.cpp
@@ -26,7 +26,7 @@
 const uint32_t SAMPLE_FREQUENCY = 48000;
 const uint32_t TONE_FREQUENCY = 440;
 const double OUTPUT_AMPLITUDE = 0.25;
-const uint32_t NUM_FRAMES_TO_OUTPUT = SAMPLE_FREQUENCY / 20; /* play ~50ms of samples */
+const int32_t NUM_FRAMES_TO_OUTPUT = SAMPLE_FREQUENCY / 20; /* play ~50ms of samples */
 
 template<typename T> T ConvertSampleToOutput(double input);
 template<> float ConvertSampleToOutput(double input) { return float(input); }

--- a/tools/cubeb-test.cpp
+++ b/tools/cubeb-test.cpp
@@ -265,7 +265,7 @@ long cubeb_client::user_data_cb(cubeb_stream* stm, void* user,
     const float* in = static_cast<const float*>(input_buffer);
     float* out = static_cast<float*>(output_buffer);
     if (_latency_testing) {
-      for (uint32_t i = 0; i < nframes; i++) {
+      for (int32_t i = 0; i < nframes; i++) {
         // Impulses every second, mixed with the input signal fed back at half
         // gain, to measure the input-to-output latency via feedback.
         uint32_t clock = ((_total_frames + i) % _rate);
@@ -280,7 +280,7 @@ long cubeb_client::user_data_cb(cubeb_stream* stm, void* user,
         }
       }
     } else {
-      for (uint32_t i = 0; i < nframes; i++) {
+      for (int32_t i = 0; i < nframes; i++) {
         for (uint32_t j = 0; j < _channels; j++) {
           out[i * _channels + j] = in[i];
         }


### PR DESCRIPTION
Fixed a few warnings:
```
/home/travis/build/achronop/cubeb/src/cubeb_utils.cpp: In function ‘size_t cubeb_sample_size(cubeb_sample_format)’:
/home/travis/build/achronop/cubeb/src/cubeb_utils.cpp:23:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
```
```
/home/travis/build/achronop/cubeb/tools/cubeb-test.cpp: In member function ‘long int cubeb_client::user_data_cb(cubeb_stream*, void*, const void*, void*, long int)’:
/home/travis/build/achronop/cubeb/tools/cubeb-test.cpp:268:30: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (uint32_t i = 0; i < nframes; i++) {
                              ^
/home/travis/build/achronop/cubeb/tools/cubeb-test.cpp:283:30: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (uint32_t i = 0; i < nframes; i++) {
                              ^
```
```
/home/travis/build/achronop/cubeb/test/test_loopback.cpp: In instantiation of ‘long int data_cb_loop_duplex(cubeb_stream*, void*, const void*, void*, long int) [with T = float; cubeb_stream = cubeb_stream]’:
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:290:65:   required from here
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:168:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (u->position + i < NUM_FRAMES_TO_OUTPUT) {
                         ^
/home/travis/build/achronop/cubeb/test/test_loopback.cpp: In instantiation of ‘long int data_cb_loop_duplex(cubeb_stream*, void*, const void*, void*, long int) [with T = short int; cubeb_stream = cubeb_stream]’:
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:290:65:   required from here
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:168:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
/home/travis/build/achronop/cubeb/test/test_loopback.cpp: In instantiation of ‘long int data_cb_playback(cubeb_stream*, void*, const void*, void*, long int) [with T = float; cubeb_stream = cubeb_stream]’:
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:373:62:   required from here
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:222:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (u->position + i < NUM_FRAMES_TO_OUTPUT) {
                         ^
/home/travis/build/achronop/cubeb/test/test_loopback.cpp: In instantiation of ‘long int data_cb_playback(cubeb_stream*, void*, const void*, void*, long int) [with T = short int; cubeb_stream = cubeb_stream]’:
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:373:62:   required from here
/home/travis/build/achronop/cubeb/test/test_loopback.cpp:222:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```