### PR TITLE
Increase input channel count limit.

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -80,7 +80,7 @@ validate_stream_params(cubeb_stream_params * input_stream_params,
   }
   if (input_stream_params) {
     if (input_stream_params->rate < 1000 || input_stream_params->rate > 192000 ||
-        input_stream_params->channels < 1 || input_stream_params->channels > 8) {
+        input_stream_params->channels < 1 || input_stream_params->channels > UINT8_MAX) {
       return CUBEB_ERROR_INVALID_FORMAT;
     }
   }


### PR DESCRIPTION
The mixer supports 32 input channels, so this is safe. This is necessary
for professional audio gear and for testing with virtual devices (in particular the new virtual audio device called [Blackhole](https://github.com/ExistentialAudio/BlackHole/) on OSX).

This also fixes [BMO#1610550](https://bugzilla.mozilla.org/show_bug.cgi?id=1610550).