### PR TITLE
Remove test for registering device changed callback twice

### DIFF
--- a/test/test_device_changed_callback.cpp
+++ b/test/test_device_changed_callback.cpp
@@ -66,22 +66,6 @@ void test_registering_and_unregistering_callback(cubeb_stream * stream)
   ASSERT_EQ(r, CUBEB_OK) << "Error unregistering device changed callback";
 }
 
-void test_registering_second_callbacks(cubeb_stream * stream)
-{
-  int r = cubeb_stream_register_device_changed_callback(stream, device_changed_callback);
-  if (r == CUBEB_ERROR_NOT_SUPPORTED) {
-    return;
-  }
-  ASSERT_EQ(r, CUBEB_OK) << "Error registering device changed callback";
-
-  // Get an assertion fails when registering a callback
-  // without unregistering the original one.
-  ASSERT_DEATH_IF_SUPPORTED(
-    cubeb_stream_register_device_changed_callback(stream, device_changed_callback),
-    ""
-  );
-}
-
 TEST(cubeb, device_changed_callbacks)
 {
   cubeb * ctx;
@@ -120,8 +104,6 @@ TEST(cubeb, device_changed_callbacks)
   test_registering_null_callback_twice(stream);
 
   test_registering_and_unregistering_callback(stream);
-
-  test_registering_second_callbacks(stream);
 
   cubeb_stream_destroy(stream);
 }


### PR DESCRIPTION
The *audiounit-rust* backend will return an error instead of hitting
an assertion when registering a second callback within
`cubeb_stream_register_device_changed_callback` without unregistering
the registered callback first. It's not possible to run a death test in *gtest*
for the Rust API[1], so the death test should not be used.

It's a regression of #481 . 

[1] https://users.rust-lang.org/t/how-to-write-a-death-test-in-gtest-for-rust-apis/23575