### PR TITLE
Only print the filename when logging

### DIFF
--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -16,7 +16,11 @@ extern "C" {
 
 #if defined(__GNUC__) || defined(__clang__)
 #define PRINTF_FORMAT(fmt, args) __attribute__((format(printf, fmt, args)))
+#if defined(__FILE_NAME__)
+#define __FILENAME__ __FILE_NAME__
+#else
 #define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
 #else
 #define PRINTF_FORMAT(fmt, args)
 #define __FILENAME__ __FILE__

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -34,10 +34,10 @@ void cubeb_async_log_reset_threads();
 #define LOGV(msg, ...) LOG_INTERNAL(CUBEB_LOG_VERBOSE, msg, ##__VA_ARGS__)
 #define LOG(msg, ...) LOG_INTERNAL(CUBEB_LOG_NORMAL, msg, ##__VA_ARGS__)
 
-#define LOG_INTERNAL(level, fmt, ...) do {                                   \
-    if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                            \
+#define LOG_INTERNAL(level, fmt, ...) do {                                              \
+    if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                           \
       g_cubeb_log_callback("%s:%d: " fmt "\n",  __FILENAME__, __LINE__, ##__VA_ARGS__); \
-    }                                                                        \
+    }                                                                                   \
   } while(0)
 
 /* Asynchronous verbose logging, to log in real-time callbacks. */

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -23,7 +23,8 @@ extern "C" {
 #endif
 #else
 #define PRINTF_FORMAT(fmt, args)
-#define __FILENAME__ __FILE__
+#include <string.h>
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #endif
 
 extern cubeb_log_level g_cubeb_log_level;

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -18,8 +18,8 @@ extern "C" {
 #define PRINTF_FORMAT(fmt, args) __attribute__((format(printf, fmt, args)))
 #define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
 #else
-#define __FILENAME__ __FILE__
 #define PRINTF_FORMAT(fmt, args)
+#define __FILENAME__ __FILE__
 #endif
 
 extern cubeb_log_level g_cubeb_log_level;

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -16,7 +16,9 @@ extern "C" {
 
 #if defined(__GNUC__) || defined(__clang__)
 #define PRINTF_FORMAT(fmt, args) __attribute__((format(printf, fmt, args)))
+#define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
 #else
+#define __FILENAME__ __FILE__
 #define PRINTF_FORMAT(fmt, args)
 #endif
 
@@ -34,7 +36,7 @@ void cubeb_async_log_reset_threads();
 
 #define LOG_INTERNAL(level, fmt, ...) do {                                   \
     if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                            \
-      g_cubeb_log_callback("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+      g_cubeb_log_callback("%s:%d: " fmt "\n",  __FILENAME__, __LINE__, ##__VA_ARGS__); \
     }                                                                        \
   } while(0)
 


### PR DESCRIPTION
This keeps the logging message consistent after djg/cubeb-rs#50 is merged, 
which fixes the [BMO 162132](https://bugzilla.mozilla.org/show_bug.cgi?id=1628132).

Instead of printing the full path to the file that is currently running,
we should print the filename only. As long as we have the filename and
the line, we know where the log comes from.