### PR TITLE
tests: Fix crash when device enumeration is not supported

### DIFF
--- a/test/test_devices.cpp
+++ b/test/test_devices.cpp
@@ -161,7 +161,7 @@ TEST(cubeb, enumerate_devices)
   if (r == CUBEB_ERROR_NOT_SUPPORTED) {
     fprintf(stderr, "Device enumeration not supported"
                     " for this backend, skipping this test.\n");
-    r = CUBEB_OK;
+    return;
   }
   ASSERT_EQ(r, CUBEB_OK) << "Error enumerating devices " << r;
 


### PR DESCRIPTION
This fixes the crash described in PR #440. The crash itself is a regression from commit 61aaac2, which causes the `CUBEB_ERROR_NOT_SUPPORTED` error code to be treated as if it was `CUBEB_OK`, resulting in a segfault when the test tries to access the collection structure.