### PR TITLE
sun: Fix arithmetic on void pointer.

### DIFF
--- a/src/cubeb_sun.c
+++ b/src/cubeb_sun.c
@@ -473,7 +473,7 @@ sun_io_routine(void * arg)
 
       if (to_write > 0) {
         bytes = to_write * s->play.frame_size;
-        if ((n = write(s->play.fd, s->play.buf + write_ofs, bytes)) < 0) {
+        if ((n = write(s->play.fd, (uint8_t *)s->play.buf + write_ofs, bytes)) < 0) {
           state = CUBEB_STATE_ERROR;
           break;
         }
@@ -482,17 +482,17 @@ sun_io_routine(void * arg)
         s->frames_written += frames;
         pthread_mutex_unlock(&s->mutex);
         to_write -= frames;
-        write_ofs += frames;
+        write_ofs += n;
       }
       if (to_read > 0) {
         bytes = to_read * s->record.frame_size;
-        if ((n = read(s->record.fd, s->record.buf + read_ofs, bytes)) < 0) {
+        if ((n = read(s->record.fd, (uint8_t *)s->record.buf + read_ofs, bytes)) < 0) {
           state = CUBEB_STATE_ERROR;
           break;
         }
         frames = n / s->record.frame_size;
         to_read -= frames;
-        read_ofs += frames;
+        read_ofs += n;
       }
     }
     if (drain && state != CUBEB_STATE_ERROR) {


### PR DESCRIPTION
Noticed when building with a newer clang version.