### PR TITLE
QueryPerformanceCounter returns non-zero in case of success

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1549,10 +1549,10 @@ int wasapi_init(cubeb ** context, char const * context_name)
 
   LARGE_INTEGER frequency;
   if (QueryPerformanceFrequency(&frequency)) {
+    ctx->performance_counter_frequency = frequency.QuadPart;
+  } else {
     LOG("Failed getting performance counter frequency, latency reporting will be inacurate");
     ctx->performance_counter_frequency = 0;
-  } else {
-    ctx->performance_counter_frequency = frequency.QuadPart;
   }
 
   *context = ctx;


### PR DESCRIPTION
I forgot to `git add` this bit...

Doc is here: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency (return value section).