### PR TITLE
Remove AUDCLNT_STREAMFLAGS_NOPERSIST

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1827,7 +1827,6 @@ initialize_iaudioclient3(com_ptr<IAudioClient> & audio_client,
 
   // IAudioClient3 doesn't support AUDCLNT_STREAMFLAGS_NOPERSIST, and will return
   // AUDCLNT_E_INVALID_STREAM_FLAG. This is undocumented.
-  flags = flags ^ AUDCLNT_STREAMFLAGS_NOPERSIST;
 
   // Some people have reported glitches with capture streams:
   // http://blog.nirbheek.in/2018/03/low-latency-audio-on-windows-with.html
@@ -2024,7 +2023,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
       mix_params->format, mix_params->rate, mix_params->channels,
       mix_params->layout);
 
-  DWORD flags = AUDCLNT_STREAMFLAGS_NOPERSIST;
+  DWORD flags = 0;
 
   // Check if a loopback device should be requested. Note that event callbacks
   // do not work with loopback devices, so only request these if not looping.


### PR DESCRIPTION
Kind of subjective but I'm not sure why you'd want Windows to not remember the volume and mute setting after restarting the application.