### PR TITLE
Bump the priority of audiounit-rust in `default_init`

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -200,11 +200,11 @@ cubeb_init(cubeb ** context, char const * context_name, char const * backend_nam
 #if defined(USE_ALSA)
     alsa_init,
 #endif
-#if defined(USE_AUDIOUNIT)
-    audiounit_init,
-#endif
 #if defined(USE_AUDIOUNIT_RUST)
     audiounit_rust_init,
+#endif
+#if defined(USE_AUDIOUNIT)
+    audiounit_init,
 #endif
 #if defined(USE_WASAPI)
     wasapi_init,


### PR DESCRIPTION
The change prefers using `audiounit-rust` backend. The rust backend is set as the default cubeb backend in *Firefox 74* and some new features have been implemented in the *Rust* backend only. Currently, the *Rust* backend is set by the `backend_name` via a preference in *gecko* when `cubeb_init` is called. With this change, the *Rust* backend will be set as the default cubeb backend if it exists, without passing the `"audiounit-rust"` to `cubeb_init`. 

Its related changes will be done in the [BMO 1598148](https://bugzilla.mozilla.org/show_bug.cgi?id=1598148).