### PR TITLE
Some windows fixes

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -35,6 +35,7 @@ MOZ_END_STD_NAMESPACE
 #include "cubeb_utils.h"
 #include "cubeb-speex-resampler.h"
 #include "cubeb_resampler.h"
+#include "cubeb_log.h"
 #include <stdio.h>
 
 /* This header file contains the internal C++ API of the resamplers, for testing. */
@@ -528,6 +529,7 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
       (output_params && output_params->rate == target_rate)) ||
       (input_params && !output_params && (input_params->rate == target_rate)) ||
       (output_params && !input_params && (output_params->rate == target_rate))) {
+    LOG("Input and output sample-rate match, target rate of %dHz", target_rate);
     return new passthrough_resampler<T>(stream, callback,
                                         user_ptr,
                                         input_params ? input_params->channels : 0,
@@ -578,6 +580,7 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
   }
 
   if (input_resampler && output_resampler) {
+    LOG("Resampling input (%d) and output (%d) to target rate of %dHz", input_params->rate, output_params->rate, target_rate);
     return new cubeb_resampler_speex<T,
                                      cubeb_resampler_speex_one_way<T>,
                                      cubeb_resampler_speex_one_way<T>>
@@ -585,6 +588,7 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
                                         output_resampler.release(),
                                         stream, callback, user_ptr);
   } else if (input_resampler) {
+    LOG("Resampling input (%d) to target and output rate of %dHz", input_params->rate, target_rate);
     return new cubeb_resampler_speex<T,
                                      cubeb_resampler_speex_one_way<T>,
                                      delay_line<T>>
@@ -592,6 +596,7 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
                                        output_delay.release(),
                                        stream, callback, user_ptr);
   } else {
+    LOG("Resampling output (%dHz) to target and input rate of %dHz", output_params->rate, target_rate);
     return new cubeb_resampler_speex<T,
                                      delay_line<T>,
                                      cubeb_resampler_speex_one_way<T>>

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -193,15 +193,13 @@ public:
                                            target_rate, quality, &r);
     assert(r == RESAMPLER_ERR_SUCCESS && "resampler allocation failure");
 
-    uint32_t ratio_num, ratio_den;
-    speex_resampler_get_ratio(speex_resampler, &ratio_num, &ratio_den);
     uint32_t input_latency = speex_resampler_get_input_latency(speex_resampler);
-    int64_t skip_frac_num = input_latency * ratio_den;
-    T input_buffer[8192] = {};
-    T output_buffer[8192] = {};
-    uint32_t input_frame_count, output_frame_count;
-    input_frame_count = input_latency;
-    output_frame_count = 8192;
+    const size_t LATENCY_SAMPLES = 8192;
+    T input_buffer[LATENCY_SAMPLES] = {};
+    T output_buffer[LATENCY_SAMPLES] = {};
+    uint32_t input_frame_count = input_latency;
+    uint32_t output_frame_count = LATENCY_SAMPLES;
+    assert(input_latency * channels <= LATENCY_SAMPLES);
     speex_resample(
       input_buffer,
       &input_frame_count,

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -270,7 +270,14 @@ public:
     speex_resample(resampling_in_buffer.data(), &in_len,
                    resampling_out_buffer.data(), &out_len);
 
-    assert(out_len == output_frame_count);
+    if (out_len < output_frame_count) {
+      LOGV("underrun during resampling: got %u frames, expected %u", out_len, output_frame_count);
+      // silence the rightmost part
+      T* data = resampling_out_buffer.data();
+      for (uint32_t i = frames_to_samples(out_len); i < frames_to_samples(output_frame_count); i++) {
+        data[i] = 0;
+      }
+    }
 
     /* This shifts back any unresampled samples to the beginning of the input
        buffer. */

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -192,6 +192,21 @@ public:
     speex_resampler = speex_resampler_init(channels, source_rate,
                                            target_rate, quality, &r);
     assert(r == RESAMPLER_ERR_SUCCESS && "resampler allocation failure");
+
+    uint32_t ratio_num, ratio_den;
+    speex_resampler_get_ratio(speex_resampler, &ratio_num, &ratio_den);
+    uint32_t input_latency = speex_resampler_get_input_latency(speex_resampler);
+    int64_t skip_frac_num = input_latency * ratio_den;
+    T input_buffer[8192] = {};
+    T output_buffer[8192] = {};
+    uint32_t input_frame_count, output_frame_count;
+    input_frame_count = input_latency;
+    output_frame_count = 8192;
+    speex_resample(
+      input_buffer,
+      &input_frame_count,
+      output_buffer,
+      &output_frame_count);
   }
 
   /** Destructor, deallocate the resampler */

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -309,11 +309,9 @@ public:
   uint32_t input_needed_for_output(int32_t output_frame_count) const
   {
     assert(output_frame_count >= 0); // Check overflow
-    int32_t unresampled_frames_left = samples_to_frames(resampling_in_buffer.length());
     int32_t resampled_frames_left = samples_to_frames(resampling_out_buffer.length());
-    float input_frames_needed =
-      (output_frame_count - unresampled_frames_left) * resampling_ratio
-        - resampled_frames_left;
+    float input_frames_needed = 
+      output_frame_count * resampling_ratio - resampled_frames_left;
     if (input_frames_needed < 0) {
       return 0;
     }

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2356,13 +2356,6 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   stm->state_callback = state_callback;
   stm->user_ptr = user_ptr;
 
-  if (stm->output_stream_params.prefs & CUBEB_STREAM_PREF_VOICE ||
-      stm->input_stream_params.prefs & CUBEB_STREAM_PREF_VOICE) {
-    stm->voice = true;
-  } else {
-    stm->voice = false;
-  }
-
   stm->role = eConsole;
 
   if (input_stream_params) {
@@ -2372,6 +2365,13 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   if (output_stream_params) {
     stm->output_stream_params = *output_stream_params;
     stm->output_device_id = utf8_to_wstr(reinterpret_cast<char const *>(output_device));
+  }
+
+  if (stm->output_stream_params.prefs & CUBEB_STREAM_PREF_VOICE ||
+      stm->input_stream_params.prefs & CUBEB_STREAM_PREF_VOICE) {
+    stm->voice = true;
+  } else {
+    stm->voice = false;
   }
 
   switch (output_stream_params ? output_stream_params->format : input_stream_params->format) {

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1038,9 +1038,6 @@ refill_callback_duplex(cubeb_stream * stm)
   }
 
   input_frames = stm->linear_input_buffer->length() / stm->input_stream_params.channels;
-  if (!input_frames) {
-    return true;
-  }
 
   rv = get_output_buffer(stm, output_buffer, output_frames);
   if (!rv) {

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -245,6 +245,7 @@ struct cubeb_stream {
   cubeb_stream_params output_stream_params = { CUBEB_SAMPLE_FLOAT32NE, 0, 0, CUBEB_LAYOUT_UNDEFINED, CUBEB_STREAM_PREF_NONE };
   /* A MMDevice role for this stream: either communication or console here. */
   ERole role;
+  bool voice;
   /* The input and output device, or NULL for default. */
   std::unique_ptr<const wchar_t[]> input_device;
   std::unique_ptr<const wchar_t[]> output_device;
@@ -2213,7 +2214,7 @@ int setup_wasapi_stream(cubeb_stream * stm)
                            target_sample_rate,
                            stm->data_callback,
                            stm->user_ptr,
-                           CUBEB_RESAMPLER_QUALITY_DESKTOP));
+                           stm->voice ? CUBEB_RESAMPLER_QUALITY_VOIP : CUBEB_RESAMPLER_QUALITY_DESKTOP));
   if (!stm->resampler) {
     LOG("Could not get a resampler");
     return CUBEB_ERROR;
@@ -2303,10 +2304,12 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   if (stm->output_stream_params.prefs & CUBEB_STREAM_PREF_VOICE ||
       stm->input_stream_params.prefs & CUBEB_STREAM_PREF_VOICE) {
-    stm->role = eCommunications;
+    stm->voice = true;
   } else {
-    stm->role = eConsole;
+    stm->voice = false;
   }
+
+  stm->role = eConsole;
 
   if (input_stream_params) {
     stm->input_stream_params = *input_stream_params;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -194,6 +194,7 @@ void close_wasapi_stream(cubeb_stream * stm);
 int setup_wasapi_stream(cubeb_stream * stm);
 ERole pref_to_role(cubeb_stream_prefs param);
 int wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * enumerator, IMMDevice * dev);
+void wasapi_destroy_device(cubeb_device_info * device_info);
 static int wasapi_enumerate_devices(cubeb * context, cubeb_device_type type, cubeb_device_collection * out);
 static int wasapi_device_collection_destroy(cubeb * ctx, cubeb_device_collection * collection);
 static char const * wstr_to_utf8(wchar_t const * str);
@@ -2063,6 +2064,8 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
     stm->input_bluetooth_handsfree = false;
   }
 
+  wasapi_destroy_device(&device_info);
+
 #if 0 // See https://bugzilla.mozilla.org/show_bug.cgi?id=1590902
   if (initialize_iaudioclient3(audio_client, stm, mix_format, flags, direction)) {
     LOG("Initialized with IAudioClient3");
@@ -2973,6 +2976,13 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
   return CUBEB_OK;
 }
 
+void
+wasapi_destroy_device(cubeb_device_info * device)
+{
+  delete [] device->friendly_name;
+  delete [] device->group_id;
+}
+
 static int
 wasapi_enumerate_devices(cubeb * context, cubeb_device_type type,
                          cubeb_device_collection * out)
@@ -3036,8 +3046,7 @@ wasapi_device_collection_destroy(cubeb * /*ctx*/, cubeb_device_collection * coll
 
   for (size_t n = 0; n < collection->count; n++) {
     cubeb_device_info& dev = collection->device[n];
-    delete [] dev.friendly_name;
-    delete [] dev.group_id;
+    wasapi_destroy_device(&dev);
   }
 
   delete [] collection->device;


### PR DESCRIPTION
A series of loosely related fixes that improve duplex audio stream, in particular for bluetooth devices that support both A2DP and handsfree, to stop picking the A2DP device when using the mic, to have lower latency and more importantly because it seems like it doesn't work to have the mic in handsfree and the headphones themselves in A2DP (that would be weird anyways).

I'll add commits, because there is a problem with the resampling code (apparently a bad rounding that leads to premature draining of the stream), and I'm not sure yet about the default device matching policy. I might make it opt-in except when we know it makes sense (we might be able to detect that it's a bluetooth device, etc.). I'll also look at what other communication software do.

The review can start now, though, the remaining commits will be small adjustments.