### PR TITLE
Add stream preference to request a persistent stream session and implement this in WASAPI.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -236,8 +236,12 @@ typedef enum {
                                        selected, as well as the quality of the stream,
                                        for example to accomodate bluetooth SCO modes on
                                        bluetooth devices. */
-  CUBEB_STREAM_PREF_RAW = 0x08  /**< Windows only. Bypass all signal processing
+  CUBEB_STREAM_PREF_RAW = 0x08, /**< Windows only. Bypass all signal processing
                                      except for always on APO, driver and hardware. */
+  CUBEB_STREAM_PREF_PERSIST = 0x10, /**< Request that the volume and mute settings
+                                         should persist across restarts of the stream
+                                         and/or application. May not be honored for
+                                         all backends and platforms. */
 } cubeb_stream_prefs;
 
 /** Stream format initialization parameters. */

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1857,7 +1857,7 @@ initialize_iaudioclient3(com_ptr<IAudioClient> & audio_client,
 
   // IAudioClient3 doesn't support AUDCLNT_STREAMFLAGS_NOPERSIST, and will return
   // AUDCLNT_E_INVALID_STREAM_FLAG. This is undocumented.
-  flags = flags ^ AUDCLNT_STREAMFLAGS_NOPERSIST;
+  flags = flags & ~AUDCLNT_STREAMFLAGS_NOPERSIST;
 
   // Some people have reported glitches with capture streams:
   // http://blog.nirbheek.in/2018/03/low-latency-audio-on-windows-with.html
@@ -2054,7 +2054,13 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
       mix_params->format, mix_params->rate, mix_params->channels,
       mix_params->layout);
 
-  DWORD flags = AUDCLNT_STREAMFLAGS_NOPERSIST;
+
+  DWORD flags = 0;
+
+  bool is_persist = stream_params->prefs & CUBEB_STREAM_PREF_PERSIST;
+  if (!is_persist) {
+    flags |= AUDCLNT_STREAMFLAGS_NOPERSIST;
+  }
 
   // Check if a loopback device should be requested. Note that event callbacks
   // do not work with loopback devices, so only request these if not looping.


### PR DESCRIPTION
Like #594 but as an optional thing.

This adds a stream preference flag to request a persistent audio session, so that volume and mute settings remain the same even after closing and reopening a program on Windows.

See https://docs.microsoft.com/en-us/windows/win32/coreaudio/audclnt-streamflags-xxx-constants for details.