### PR TITLE
sun: Fix use-after-free of s->mutex in sun_stream_destroy.

### DIFF
--- a/src/cubeb_sun.c
+++ b/src/cubeb_sun.c
@@ -362,8 +362,8 @@ sun_stream_stop(cubeb_stream * s)
 static void
 sun_stream_destroy(cubeb_stream * s)
 {
-  pthread_mutex_destroy(&s->mutex);
   sun_stream_stop(s);
+  pthread_mutex_destroy(&s->mutex);
   if (s->play.fd != -1) {
     close(s->play.fd);
   }


### PR DESCRIPTION
cc @niacat for review.