### PR TITLE
jack: Output stereo audio if the input source is mono

### DIFF
--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -261,6 +261,14 @@ cbjack_connect_ports (cubeb_stream * stream)
 
     api_jack_connect (stream->context->jack_client, src_port, phys_in_ports[c]);
   }
+
+  // Special case playing mono source in stereo
+  if (stream->out_params.channels == 1 && phys_in_ports[1] != NULL) {
+    const char *src_port = api_jack_port_name (stream->output_ports[0]);
+
+    api_jack_connect (stream->context->jack_client, src_port, phys_in_ports[1]);
+  }
+
   r = CUBEB_OK;
 
 skipplayback:


### PR DESCRIPTION
This brings the JACK backend into parity with e.g. the Pulse backend, which [has this behavior already](https://github.com/kinetiknz/cubeb/blob/master/src/cubeb_pulse.c#L580). A typical Firefox user [expects this behavior](https://bugzilla.mozilla.org/show_bug.cgi?id=979705), and because Firefox creates a new unique stream at every audio playback init it's difficult to achieve this behavior currently as a JACK user even if you know what you're doing. Other application users (of e.g. music or video players) will overwhelmingly have the same expectation. There may be esoteric cases in which strict 1 input <-> 1 output is desirable even if the source is mono, but if that case should be supported I think it should enabled via some sort of config rather than the default behavior.

I've tested this patch against the `test_audio` test and confirmed that it results in the desired behavior, whereas the current code does not. If y'all agree that mono source -> stereo out should be the expected behavior for all backends, I could look into adding backend-agnostic testing for this.

Since the patch in the main commit resulted in some obvious code duplication, I included a second commit that cleans it up by adding two new functions. Depending on y'all's tastes and long-term plans, y'all may not want that refactoring, so if y'all would like only the first commit I'm happy to toss the second.