### PR TITLE
Fix CMake rust path and only use rust deps if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ if(USE_KAI)
   target_link_libraries(cubeb PRIVATE kai)
 endif()
 
-if(USE_PULSE_RUST)
+if(USE_PULSE AND USE_PULSE_RUST)
   include(ExternalProject)
   set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/rust)
   ExternalProject_Add(
@@ -240,17 +240,17 @@ if(USE_PULSE_RUST)
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cargo build COMMAND cargo build --release
     BUILD_ALWAYS ON
-    BINARY_DIR "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs"
+    BINARY_DIR "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs"
     INSTALL_COMMAND ""
     LOG_BUILD ON)
   add_dependencies(cubeb cubeb_pulse_rs)
   target_compile_definitions(cubeb PRIVATE USE_PULSE_RUST)
   target_link_libraries(cubeb PRIVATE
-    debug "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/debug/libcubeb_pulse.a"
-    optimized "${CMAKE_SOURCE_DIR}/src/cubeb-pulse-rs/target/release/libcubeb_pulse.a" pulse)
+    debug "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs/target/debug/libcubeb_pulse.a"
+    optimized "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs/target/release/libcubeb_pulse.a" pulse)
 endif()
 
-if(USE_AUDIOUNIT_RUST)
+if(USE_AUDIOUNIT AND USE_AUDIOUNIT_RUST)
   include(ExternalProject)
   set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/rust)
   ExternalProject_Add(
@@ -259,14 +259,14 @@ if(USE_AUDIOUNIT_RUST)
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cargo build COMMAND cargo build --release
     BUILD_ALWAYS ON
-    BINARY_DIR "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs"
+    BINARY_DIR "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs"
     INSTALL_COMMAND ""
     LOG_BUILD ON)
   add_dependencies(cubeb cubeb_coreaudio_rs)
   target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT_RUST)
   target_link_libraries(cubeb PRIVATE
-    debug "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/debug/libcubeb_coreaudio.a"
-    optimized "${CMAKE_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/release/libcubeb_coreaudio.a")
+    debug "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/debug/libcubeb_coreaudio.a"
+    optimized "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/release/libcubeb_coreaudio.a")
 endif()
 
 find_package(Doxygen)


### PR DESCRIPTION
This change fixes two things:
- Use `PROJECT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` to use the `cubeb` directory instead of the root directory when the cmake project is included by another cmake project.
- Only build the rust version of pulse and audiounit backend if the C version of the backend was also going to be built.