### PR TITLE
Fix integer underflow/unsigned wrapping.

### DIFF
--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -290,9 +290,9 @@ cbjack_xrun_callback(void * arg)
   cubeb * ctx = (cubeb *)arg;
 
   float delay = api_jack_get_xrun_delayed_usecs(ctx->jack_client);
-  int fragments = (int)ceilf( ((delay / 1000000.0) * ctx->jack_sample_rate )
-                             / (float)(ctx->jack_buffer_size) );
-  ctx->jack_xruns += fragments;
+  float fragments = ceilf(((delay / 1000000.0) * ctx->jack_sample_rate) / ctx->jack_buffer_size);
+
+  ctx->jack_xruns += (unsigned int)fragments;
   return 0;
 }
 
@@ -332,8 +332,10 @@ static int
 cbjack_process(jack_nframes_t nframes, void * arg)
 {
   cubeb * ctx = (cubeb *)arg;
-  int t_jack_xruns = ctx->jack_xruns;
+  unsigned int t_jack_xruns = ctx->jack_xruns;
   int i;
+
+  ctx->jack_xruns = 0;
 
   for (int j = 0; j < MAX_STREAMS; j++) {
     cubeb_stream *stm = &ctx->streams[j];
@@ -344,10 +346,7 @@ cbjack_process(jack_nframes_t nframes, void * arg)
       continue;
 
     // handle xruns by skipping audio that should have been played
-    for (i = 0; i < t_jack_xruns; i++) {
-        stm->position += ctx->fragment_size * stm->ratio;
-    }
-    ctx->jack_xruns -= t_jack_xruns;
+    stm->position += t_jack_xruns * ctx->fragment_size * stm->ratio;
 
     if (!stm->ports_ready)
       continue;


### PR DESCRIPTION
Got pointed here from the Mozilla bug tracker to send in the patch upstream:

This is an attempt at a fix for [firefox bug 1614278](https://bugzilla.mozilla.org/show_bug.cgi?id=1614278) where firefox crashes on a regular on xruns. This has been a long standing issue for me (older than the linked bug report). With this patch applied firefox does run stable again with the jack backend.
Looking at the subtraction logic in the xrun handing I am somewhat surprised this does not crash more often. Might also be related to #154 

--

The number of xrun fragments to skip is added once to ctx->jack_xruns but
then subtracted multiple times (once for each stream) from the same variable.
This causes the unsigned int to "underflow" and wrap around.

- Use unsigned int in all calculations instead of mixing un/signed.
- Remove erroneous and useless subtraction logic
- Replace for loop by simple multiplication
- Remove unneeded casts to float