### PR TITLE
Add a test case for WASAPI reconfigure event

### DIFF
--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -639,6 +639,62 @@ TEST(cubeb, drain)
   do_drain = 0;
 }
 
+TEST(cubeb, device_reset)
+{
+  int r;
+  cubeb * ctx;
+  cubeb_stream * stream;
+  cubeb_stream_params params;
+  uint64_t position;
+
+  r = common_init(&ctx, "test_sanity");
+  ASSERT_EQ(r, CUBEB_OK);
+  ASSERT_NE(ctx, nullptr);
+
+  if (strcmp(cubeb_get_backend_id(ctx), "wasapi")) {
+    // cubeb_stream_reset_default_device is only useful and implemented in the
+    // WASAPI backend.
+    return;
+  }
+
+  params.format = STREAM_FORMAT;
+  params.rate = STREAM_RATE;
+  params.channels = STREAM_CHANNELS;
+  params.layout = STREAM_LAYOUT;
+  params.prefs = CUBEB_STREAM_PREF_NONE;
+
+  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
+                        test_data_callback, test_state_callback, &dummy);
+  ASSERT_EQ(r, CUBEB_OK);
+  ASSERT_NE(stream, nullptr);
+
+  r = cubeb_stream_start(stream);
+  ASSERT_EQ(r, CUBEB_OK);
+
+  uint32_t iterations = 5;
+  uint64_t previous_position = 0;
+  while (iterations--) {
+    r = cubeb_stream_get_position(stream, &position);
+    ASSERT_EQ(r, CUBEB_OK);
+    ASSERT_GE(position, previous_position);
+    delay(100);
+  }
+
+  r = cubeb_stream_reset_default_device(stream);
+  ASSERT_EQ(r, CUBEB_OK);
+
+  iterations = 5;
+  while (iterations--) {
+    r = cubeb_stream_get_position(stream, &position);
+    ASSERT_EQ(r, CUBEB_OK);
+    ASSERT_GE(position, previous_position);
+    delay(100);
+  }
+
+  cubeb_stream_destroy(stream);
+  cubeb_destroy(ctx);
+}
+
 TEST(cubeb, DISABLED_eos_during_prefill)
 {
   // This test needs to be implemented.

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -677,6 +677,7 @@ TEST(cubeb, device_reset)
     r = cubeb_stream_get_position(stream, &position);
     ASSERT_EQ(r, CUBEB_OK);
     ASSERT_GE(position, previous_position);
+    previous_position = position;
     delay(100);
   }
 
@@ -688,9 +689,11 @@ TEST(cubeb, device_reset)
     r = cubeb_stream_get_position(stream, &position);
     ASSERT_EQ(r, CUBEB_OK);
     ASSERT_GE(position, previous_position);
+    previous_position = position;
     delay(100);
   }
 
+  cubeb_stream_stop(stream);
   cubeb_stream_destroy(stream);
   cubeb_destroy(ctx);
 }


### PR DESCRIPTION
This would have caught the mistake fixed by https://github.com/kinetiknz/cubeb/commit/a45f6d072f6e17e82a34769ef527f3041dca0259.