### PR TITLE
Always return valid strings for `friendly_name` and `group_id` (sometimes empty)

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2932,6 +2932,12 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
   hr = propstore->GetValue(PKEY_Device_FriendlyName, &namevar);
   if (SUCCEEDED(hr)) {
     ret.friendly_name = wstr_to_utf8(namevar.pwszVal);
+  } else {
+    // This is not fatal, but a valid string is expected in all cases.
+    char* empty = new char[1];
+    empty[0] = '\0';
+    ret.friendly_name = empty;
+  }
 
   devnode = wasapi_get_device_node(enumerator, dev);
   if (devnode) {
@@ -2944,6 +2950,13 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
     if (SUCCEEDED(hr)) {
       ret.group_id = wstr_to_utf8(instancevar.pwszVal);
     }
+  }
+
+  if (!ret.group_id) {
+    // This is not fatal, but a valid string is expected in all cases.
+    char* empty = new char[1];
+    empty[0] = '\0';
+    ret.group_id = empty;
   }
 
   ret.preferred = CUBEB_DEVICE_PREF_NONE;
@@ -3004,6 +3017,8 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
     ret.latency_lo = 0;
     ret.latency_hi = 0;
   }
+
+  XASSERT(ret.friendly_name && ret.group_id);
 
   return CUBEB_OK;
 }

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2895,14 +2895,20 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
   };
 
   hr = dev->QueryInterface(IID_PPV_ARGS(endpoint.receive()));
-  if (FAILED(hr)) return CUBEB_ERROR;
+  if (FAILED(hr)) {
+    return CUBEB_ERROR;
+  }
 
   hr = endpoint->GetDataFlow(&flow);
-  if (FAILED(hr)) return CUBEB_ERROR;
+  if (FAILED(hr)) {
+    return CUBEB_ERROR;
+  }
 
   wchar_t * tmp = nullptr;
   hr = dev->GetId(&tmp);
-  if (FAILED(hr)) return CUBEB_ERROR;
+  if (FAILED(hr)) {
+    return CUBEB_ERROR;
+  }
   com_heap_ptr<wchar_t> device_id(tmp);
 
   char const * device_id_intern = intern_device_id(ctx, device_id.get());
@@ -2911,16 +2917,20 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
   }
 
   hr = dev->OpenPropertyStore(STGM_READ, propstore.receive());
-  if (FAILED(hr)) return CUBEB_ERROR;
+  if (FAILED(hr)) {
+    return CUBEB_ERROR;
+  }
 
   hr = dev->GetState(&state);
-  if (FAILED(hr)) return CUBEB_ERROR;
+  if (FAILED(hr)) {
+    return CUBEB_ERROR;
+  }
 
   ret.device_id = device_id_intern;
   ret.devid = reinterpret_cast<cubeb_devid>(ret.device_id);
   prop_variant namevar;
   hr = propstore->GetValue(PKEY_Device_FriendlyName, &namevar);
-  if (SUCCEEDED(hr))
+  if (SUCCEEDED(hr)) {
     ret.friendly_name = wstr_to_utf8(namevar.pwszVal);
 
   devnode = wasapi_get_device_node(enumerator, dev);
@@ -2937,15 +2947,22 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info& ret, IMMDeviceEnumerator * 
   }
 
   ret.preferred = CUBEB_DEVICE_PREF_NONE;
-  if (wasapi_is_default_device(flow, eConsole, device_id.get(), enumerator))
+  if (wasapi_is_default_device(flow, eConsole, device_id.get(), enumerator)) {
     ret.preferred = (cubeb_device_pref)(ret.preferred | CUBEB_DEVICE_PREF_MULTIMEDIA);
-  if (wasapi_is_default_device(flow, eCommunications, device_id.get(), enumerator))
+  }
+  if (wasapi_is_default_device(flow, eCommunications, device_id.get(), enumerator)) {
     ret.preferred = (cubeb_device_pref)(ret.preferred | CUBEB_DEVICE_PREF_VOICE);
-  if (wasapi_is_default_device(flow, eConsole, device_id.get(), enumerator))
+  }
+  if (wasapi_is_default_device(flow, eConsole, device_id.get(), enumerator)) {
     ret.preferred = (cubeb_device_pref)(ret.preferred | CUBEB_DEVICE_PREF_NOTIFICATION);
+  }
 
-  if (flow == eRender) ret.type = CUBEB_DEVICE_TYPE_OUTPUT;
-  else if (flow == eCapture) ret.type = CUBEB_DEVICE_TYPE_INPUT;
+  if (flow == eRender) {
+    ret.type = CUBEB_DEVICE_TYPE_OUTPUT;
+  } else if (flow == eCapture) {
+    ret.type = CUBEB_DEVICE_TYPE_INPUT;
+  }
+
   switch (state) {
     case DEVICE_STATE_ACTIVE:
       ret.state = CUBEB_DEVICE_STATE_ENABLED;


### PR DESCRIPTION
Crash stack (from Gecko) is:

<details>
<pre>
 	mozglue.dll!arena_dalloc(void * aPtr, unsigned __int64 aOffset, arena_t * aArena) Line 3364	C++
 	[Inline Frame] mozglue.dll!BaseAllocator::free(void * aPtr) Line 4147	C++
 	[Inline Frame] mozglue.dll!Allocator<MozJemallocBase>::free(void * arg1) Line 54	C++
 	[Inline Frame] mozglue.dll!PageFree(const mozilla::Maybe<unsigned long long> & aArenaId, void * aPtr) Line 1280	C++
 	mozglue.dll!replace_free(void * aPtr) Line 1317	C++
 	[Inline Frame] xul.dll!operator delete[](void * ptr) Line 60	C++
 	[Inline Frame] xul.dll!`anonymous namespace'::wasapi_destroy_device(cubeb_device_info * device) Line 2998	C++
>	[Inline Frame] xul.dll!`anonymous namespace'::setup_wasapi_stream_one_side(cubeb_stream * stm, cubeb_stream_params * stream_params, const wchar_t * devid, __MIDL___MIDL_itf_mmdeviceapi_0000_0000_0001 direction, const _GUID & riid, `anonymous namespace'::com_ptr<IAudioClient> & audio_client, unsigned int * buffer_frame_count, void * & event, `anonymous namespace'::com_ptr<IAudioRenderClient> & render_or_capture_client, cubeb_stream_params * mix_params, `anonymous namespace'::com_ptr<IMMDevice> & device) Line 2079	C++
 	xul.dll!`anonymous namespace'::setup_wasapi_stream(cubeb_stream * stm) Line 2248	C++
 	xul.dll!`anonymous namespace'::wasapi_stream_init(cubeb * context, cubeb_stream * * stream, const char * stream_name, const void * input_device, cubeb_stream_params * input_stream_params, const void * output_device, cubeb_stream_params * output_stream_params, unsigned int latency_frames, long(*)(cubeb_stream *, void *, const void *, void *, long) data_callback, void(*)(cubeb_stream *, void *, <unnamed-tag>) state_callback, void * user_ptr) Line 2472	C++
 	xul.dll!cubeb_stream_init(cubeb * context, cubeb_stream * * stream, const char * stream_name, const void * input_device, cubeb_stream_params * input_stream_params, const void * output_device, cubeb_stream_params * output_stream_params, unsigned int latency, long(*)(cubeb_stream *, void *, const void *, void *, long) data_callback, void(*)(cubeb_stream *, void *, <unnamed-tag>) state_callback, void * user_ptr) Line 345	C
 	[Inline Frame] xul.dll!cubeb_core::context::ContextRef::stream_init(core::option::Option<std::ffi::c_str::CStr*> stream_name, core::ffi::c_void * input_device, core::option::Option<cubeb_core::stream::StreamParamsRef*> output_device, core::ffi::c_void * latency_frames, core::option::Option<cubeb_core::stream::StreamParamsRef*> data_callback, unsigned int state_callback, core::option::Option<unsafe extern "C" fn(mut cubeb_sys::stream::cubeb_stream*, mut core::ffi::c_void*, const core::ffi::c_void*, mut core::ffi::c_void*, i32) -> i32> user_ptr, core::option::Option<unsafe extern "C" fn(mut cubeb_sys::stream::cubeb_stream*, mut core::ffi::c_void*, i32)>) Line 98	Unknown
 	[Inline Frame] xul.dll!audioipc_server::server::CubebServer::process_stream_init(cubeb_core::context::Context * self, audioipc::messages::StreamInitParams * context) Line 772	Unknown
 	xul.dll!audioipc_server::server::CubebServer::process_msg(cubeb_core::context::Context * self, audioipc_server::server::CubebDeviceCollectionManager * context, audioipc::messages::ServerMessage * manager) Line 501	Unknown
 	[Inline Frame] xul.dll!audioipc::rpc::driver::Driver<audioipc::rpc::server::ServerHandler<audioipc_server::server::CubebServer>>::receive_incoming() Line 47	Unknown
 	[Inline Frame] xul.dll!audioipc::rpc::driver::{{impl}}::poll(audioipc::rpc::driver::Driver<audioipc::rpc::server::ServerHandler<audioipc_server::server::CubebServer>> * self) Line 134	Unknown
 	xul.dll!futures::future::map_err::{{impl}}::poll<(),audioipc::rpc::driver::Driver<audioipc::rpc::server::ServerHandler<audioipc_server::server::CubebServer>>,closure-0>(futures::future::map_err::MapErr<audioipc::rpc::driver::Driver<audioipc::rpc::server::ServerHandler<audioipc_server::server::CubebServer>>, closure-0> * self) Line 30	Unknown
 	[Inline Frame] xul.dll!std::thread::local::LocalKey<core::cell::RefCell<core::option::Option<tokio_reactor::HandlePriv>>>::try_with(tokio_reactor::with_default::closure-0) Line 262	Unknown
 	[Inline Frame] xul.dll!std::thread::local::LocalKey<core::cell::RefCell<core::option::Option<tokio_reactor::HandlePriv>>>::with(tokio_reactor::with_default::closure-0 f) Line 239	Unknown
 	[Inline Frame] xul.dll!tokio_reactor::with_default(tokio_reactor::Handle * handle, tokio_executor::enter::Enter * enter, tokio::runtime::current_thread::runtime::{{impl}}::enter::closure-0 f) Line 214	Unknown
 	[Inline Frame] xul.dll!tokio::runtime::current_thread::runtime::Runtime::enter(tokio::runtime::current_thread::runtime::{{impl}}::block_on::closure-0 self) Line 217	Unknown
 	xul.dll!tokio::runtime::current_thread::runtime::Runtime::block_on<futures::sync::oneshot::Receiver<()>>(futures::sync::oneshot::Receiver<()> self) Line 182	Unknown
 	[Inline Frame] xul.dll!audioipc::core::spawn_thread::{{closure}}(audioipc::core::spawn_thread::closure-0) Line 66	Unknown
 	xul.dll!std::sys_common::backtrace::__rust_begin_short_backtrace<closure-0,()>(audioipc::core::spawn_thread::closure-0 f) Line 130	Unknown
 	[Inline Frame] xul.dll!std::thread::{{impl}}::spawn_unchecked::{{closure}}::{{closure}}(std::thread::{{impl}}::spawn_unchecked::{{closure}}::closure-0) Line 475	Unknown
 	[Inline Frame] xul.dll!std::panic::{{impl}}::call_once(std::panic::AssertUnwindSafe<closure-0>) Line 318	Unknown
 	[Inline Frame] xul.dll!std::panicking::try::do_call(unsigned char * data) Line 303	Unknown
 	[Inline Frame] xul.dll!panic_abort::__rust_maybe_catch_panic() Line 30	Unknown
 	[Inline Frame] xul.dll!std::panicking::try(std::panic::AssertUnwindSafe<closure-0>) Line 281	Unknown
 	[Inline Frame] xul.dll!std::panic::catch_unwind(std::panic::AssertUnwindSafe<closure-0>) Line 394	Unknown
 	[Inline Frame] xul.dll!std::thread::{{impl}}::spawn_unchecked::{{closure}}(std::thread::{{impl}}::spawn_unchecked::closure-0) Line 474	Unknown
 	xul.dll!core::ops::function::FnOnce::call_once<closure-0,()>(std::thread::{{impl}}::spawn_unchecked::closure-0 *) Line 232	Unknown
 	xul.dll!alloc::boxed::{{impl}}::call_once<(),FnOnce<()>>() Line 1017	Unknown
 	[Inline Frame] xul.dll!alloc::boxed::{{impl}}::call_once() Line 1017	Unknown
 	[Inline Frame] xul.dll!std::sys_common::thread::start_thread() Line 13	Unknown
 	xul.dll!std::sys::windows::thread::{{impl}}::new::thread_start() Line 51	Unknown
 	[External Code]	

</pre>
</details>