### PR TITLE
Add an option to not automatically connect ports on jack.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -242,6 +242,10 @@ typedef enum {
                                          should persist across restarts of the stream
                                          and/or application. May not be honored for
                                          all backends and platforms. */
+
+  CUBEB_STREAM_PREF_JACK_NO_AUTO_CONNECT = 0x20  /**< Don't automatically try to connect
+                                                      ports.  Only affects the jack
+                                                      backend. */
 } cubeb_stream_prefs;
 
 /** Stream format initialization parameters. */

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -907,10 +907,12 @@ cbjack_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_
     }
   }
 
-  if (cbjack_connect_ports(stm) != CUBEB_OK) {
-    pthread_mutex_unlock(&stm->mutex);
-    cbjack_stream_destroy(stm);
-    return CUBEB_ERROR;
+  if (!input_stream_params->prefs & CUBEB_STREAM_PREF_JACK_NO_AUTO_CONNECT) {
+    if (cbjack_connect_ports(stm) != CUBEB_OK) {
+      pthread_mutex_unlock(&stm->mutex);
+      cbjack_stream_destroy(stm);
+      return CUBEB_ERROR;
+    }
   }
 
   *stream = stm;


### PR DESCRIPTION
This patch adds a perf to disable auto jack port connection. This is useful if the user of the lib wants to coordinate connection management themselves, for example linking into a mixing app rather than straight to audio_out.