### PR TITLE
Add method to change stream name

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -584,6 +584,14 @@ CUBEB_EXPORT int cubeb_stream_get_input_latency(cubeb_stream * stream, uint32_t 
     @retval CUBEB_ERROR_NOT_SUPPORTED */
 CUBEB_EXPORT int cubeb_stream_set_volume(cubeb_stream * stream, float volume);
 
+/** Change a stream's name.
+    @param stream the stream for which to set the name.
+    @param stream_name the new name for the stream
+    @retval CUBEB_OK
+    @retval CUBEB_ERROR_INVALID_PARAMETER if any pointer is invalid
+    @retval CUBEB_ERROR_NOT_SUPPORTED */
+CUBEB_EXPORT int cubeb_stream_set_name(cubeb_stream * stream, char const * stream_name);
+
 /** Get the current output device for this stream.
     @param stm the stream for which to query the current output device
     @param device a pointer in which the current output device will be stored.

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -65,6 +65,7 @@ struct cubeb_ops {
   int (* stream_get_latency)(cubeb_stream * stream, uint32_t * latency);
   int (* stream_get_input_latency)(cubeb_stream * stream, uint32_t * latency);
   int (* stream_set_volume)(cubeb_stream * stream, float volumes);
+  int (* stream_set_name)(cubeb_stream * stream, char const * stream_name);
   int (* stream_get_current_device)(cubeb_stream * stream,
                                     cubeb_device ** const device);
   int (* stream_device_destroy)(cubeb_stream * stream,

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -448,6 +448,20 @@ cubeb_stream_set_volume(cubeb_stream * stream, float volume)
   return stream->context->ops->stream_set_volume(stream, volume);
 }
 
+int
+cubeb_stream_set_name(cubeb_stream * stream, char const * stream_name)
+{
+  if (!stream || !stream_name) {
+    return CUBEB_ERROR_INVALID_PARAMETER;
+  }
+
+  if (!stream->context->ops->stream_set_name) {
+    return CUBEB_ERROR_NOT_SUPPORTED;
+  }
+
+  return stream->context->ops->stream_set_name(stream, stream_name);
+}
+
 int cubeb_stream_get_current_device(cubeb_stream * stream,
                                     cubeb_device ** const device)
 {

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -1446,6 +1446,7 @@ static struct cubeb_ops const alsa_ops = {
   .stream_get_latency = alsa_stream_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = alsa_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = NULL,
   .stream_device_destroy = NULL,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -435,6 +435,7 @@ static struct cubeb_ops const audiotrack_ops = {
   .stream_get_latency = audiotrack_stream_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = audiotrack_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = NULL,
   .stream_device_destroy = NULL,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3623,6 +3623,7 @@ cubeb_ops const audiounit_ops = {
   /*.stream_get_latency =*/ audiounit_stream_get_latency,
   /*.stream_get_input_latency =*/ NULL,
   /*.stream_set_volume =*/ audiounit_stream_set_volume,
+  /*.stream_set_name =*/ NULL,
   /*.stream_get_current_device =*/ audiounit_stream_get_current_device,
   /*.stream_device_destroy =*/ audiounit_stream_device_destroy,
   /*.stream_register_device_changed_callback =*/ audiounit_stream_register_device_changed_callback,

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -134,6 +134,7 @@ static struct cubeb_ops const cbjack_ops = {
   .stream_get_latency = cbjack_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = cbjack_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = cbjack_stream_get_current_device,
   .stream_device_destroy = cbjack_stream_device_destroy,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -363,6 +363,7 @@ static struct cubeb_ops const kai_ops = {
   /*.stream_get_latency = */ kai_stream_get_latency,
   /*.stream_get_input_latency = */ NULL,
   /*.stream_set_volume =*/ kai_stream_set_volume,
+  /*.stream_set_name =*/ NULL,
   /*.stream_get_current_device =*/ NULL,
   /*.stream_device_destroy =*/ NULL,
   /*.stream_register_device_changed_callback=*/ NULL,

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1756,6 +1756,7 @@ static struct cubeb_ops const opensl_ops = {
   .stream_get_latency = opensl_stream_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = opensl_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = NULL,
   .stream_device_destroy = NULL,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -86,6 +86,7 @@
   X(pa_mainloop_api_once)                       \
   X(pa_get_library_version)                     \
   X(pa_channel_map_init_auto)                   \
+  X(pa_stream_set_name)                         \
 
 #define MAKE_TYPEDEF(x) static typeof(x) * cubeb_##x;
 LIBPULSE_API_VISIT(MAKE_TYPEDEF);
@@ -1139,6 +1140,14 @@ volume_success(pa_context *c, int success, void *userdata)
   WRAP(pa_threaded_mainloop_signal)(stream->context->mainloop, 0);
 }
 
+static void
+rename_success(pa_stream *s, int success, void *userdata)
+{
+  cubeb_stream * stream = userdata;
+  assert(success);
+  WRAP(pa_threaded_mainloop_signal)(stream->context->mainloop, 0);
+}
+
 static int
 pulse_stream_set_volume(cubeb_stream * stm, float volume)
 {
@@ -1179,6 +1188,28 @@ pulse_stream_set_volume(cubeb_stream * stm, float volume)
   }
 
   WRAP(pa_threaded_mainloop_unlock)(ctx->mainloop);
+
+  return CUBEB_OK;
+}
+
+static int
+pulse_stream_set_name(cubeb_stream * stm, char const * stream_name)
+{
+  if (!stm || !stm->output_stream) {
+    return CUBEB_ERROR;
+  }
+
+  WRAP(pa_threaded_mainloop_lock)(stm->context->mainloop);
+
+  pa_operation * op =
+    WRAP(pa_stream_set_name)(stm->output_stream, stream_name, rename_success, stm);
+
+  if (op) {
+    operation_wait(stm->context, stm->output_stream, op);
+    WRAP(pa_operation_unref)(op);
+  }
+
+  WRAP(pa_threaded_mainloop_unlock)(stm->context->mainloop);
 
   return CUBEB_OK;
 }
@@ -1599,6 +1630,7 @@ static struct cubeb_ops const pulse_ops = {
   .stream_get_latency = pulse_stream_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = pulse_stream_set_volume,
+  .stream_set_name = pulse_stream_set_name,
   .stream_get_current_device = pulse_stream_get_current_device,
   .stream_device_destroy = pulse_stream_device_destroy,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -662,6 +662,7 @@ static struct cubeb_ops const sndio_ops = {
   .stream_get_position = sndio_stream_get_position,
   .stream_get_latency = sndio_stream_get_latency,
   .stream_set_volume = sndio_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = NULL,
   .stream_device_destroy = NULL,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_sun.c
+++ b/src/cubeb_sun.c
@@ -723,6 +723,7 @@ static struct cubeb_ops const sun_ops = {
   .stream_get_latency = sun_stream_get_latency,
   .stream_get_input_latency = NULL,
   .stream_set_volume = sun_stream_set_volume,
+  .stream_set_name = NULL,
   .stream_get_current_device = sun_get_current_device,
   .stream_device_destroy = sun_stream_device_destroy,
   .stream_register_device_changed_callback = NULL,

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -3211,6 +3211,7 @@ cubeb_ops const wasapi_ops = {
   /*.stream_get_latency =*/ wasapi_stream_get_latency,
   /*.stream_get_input_latency =*/ wasapi_stream_get_input_latency,
   /*.stream_set_volume =*/ wasapi_stream_set_volume,
+  /*.stream_set_name =*/ NULL,
   /*.stream_get_current_device =*/ NULL,
   /*.stream_device_destroy =*/ NULL,
   /*.stream_register_device_changed_callback =*/ NULL,

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -1061,6 +1061,7 @@ static struct cubeb_ops const winmm_ops = {
   /*.stream_get_latency = */ winmm_stream_get_latency,
   /*.stream_get_input_latency = */ NULL,
   /*.stream_set_volume =*/ winmm_stream_set_volume,
+  /*.stream_set_name =*/ NULL,
   /*.stream_get_current_device =*/ NULL,
   /*.stream_device_destroy =*/ NULL,
   /*.stream_register_device_changed_callback=*/ NULL,

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -227,6 +227,9 @@ TEST(cubeb, configure_stream)
   r = cubeb_stream_set_volume(stream, 1.0f);
   ASSERT_TRUE(r == 0 || r == CUBEB_ERROR_NOT_SUPPORTED);
 
+  r = cubeb_stream_set_name(stream, "test 2");
+  ASSERT_TRUE(r == 0 || r == CUBEB_ERROR_NOT_SUPPORTED);
+
   cubeb_stream_destroy(stream);
   cubeb_destroy(ctx);
 }


### PR DESCRIPTION
This PR adds a simple method called `cubeb_stream_set_name` to change a created stream's name so that bug 1120222 can be fixed. I'm new to C/CXX development, so there may be some mistakes.