### PR TITLE
 Pass in AUDCLNT_STREAMOPTIONS_RAW when possible when initializing an AudioClient

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -230,12 +230,14 @@ typedef enum {
   CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING = 0x02, /**< Disable switching
                                                           default device on OS
                                                           changes. */
-  CUBEB_STREAM_PREF_VOICE = 0x04  /**< This stream is going to transport voice data.
+  CUBEB_STREAM_PREF_VOICE = 0x04, /**< This stream is going to transport voice data.
                                        Depending on the backend and platform, this can
                                        change the audio input or output devices
                                        selected, as well as the quality of the stream,
                                        for example to accomodate bluetooth SCO modes on
                                        bluetooth devices. */
+  CUBEB_STREAM_PREF_RAW = 0x08  /**< Windows only. Bypass all signal processing
+                                     except for always on APO, driver and hardware. */
 } cubeb_stream_prefs;
 
 /** Stream format initialization parameters. */

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2102,9 +2102,12 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
     LOG("Could not get cubeb_device_info.");
   }
 
-  if (initialize_iaudioclient2(audio_client) != CUBEB_OK) {
-    LOG("Can't create the reconfigure event, error: %lx", GetLastError());
-    // This is not fatal.
+  if (stm->output_stream_params.prefs & CUBEB_STREAM_PREF_RAW ||
+      stm->input_stream_params.prefs & CUBEB_STREAM_PREF_RAW) {
+    if (initialize_iaudioclient2(audio_client) != CUBEB_OK) {
+      LOG("Can't initialize an IAudioClient2, error: %lx", GetLastError());
+      // This is not fatal.
+    }
   }
 
 #if 0 // See https://bugzilla.mozilla.org/show_bug.cgi?id=1590902

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1828,7 +1828,7 @@ initialize_iaudioclient2(com_ptr<IAudioClient> & audio_client)
 #endif
   HRESULT hr = audio_client2->SetClientProperties(&properties);
   if (FAILED(hr)) {
-    LOG("Can't create the reconfigure event, error: %lx", GetLastError());
+    LOG("IAudioClient2::SetClientProperties error: %lx", GetLastError());
     return CUBEB_ERROR;
   }
   return CUBEB_OK;
@@ -2104,8 +2104,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
     LOG("Could not get cubeb_device_info.");
   }
 
-  if (stm->output_stream_params.prefs & CUBEB_STREAM_PREF_RAW ||
-      stm->input_stream_params.prefs & CUBEB_STREAM_PREF_RAW) {
+  if (stream_params->prefs & CUBEB_STREAM_PREF_RAW) {
     if (initialize_iaudioclient2(audio_client) != CUBEB_OK) {
       LOG("Can't initialize an IAudioClient2, error: %lx", GetLastError());
       // This is not fatal.

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -4,7 +4,7 @@
  * This program is made available under an ISC-style license.  See the
  * accompanying file LICENSE for details.
  */
-#define _WIN32_WINNT 0x0600
+#define _WIN32_WINNT 0x0603
 #define NOMINMAX
 
 #include <initguid.h>

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1823,7 +1823,9 @@ initialize_iaudioclient2(com_ptr<IAudioClient> & audio_client)
   }
   AudioClientProperties properties = { 0 };
   properties.cbSize = sizeof(AudioClientProperties);
+#ifndef __MINGW32__
   properties.Options |= AUDCLNT_STREAMOPTIONS_RAW;
+#endif
   HRESULT hr = audio_client2->SetClientProperties(&properties);
   if (FAILED(hr)) {
     LOG("Can't create the reconfigure event, error: %lx", GetLastError());


### PR DESCRIPTION
This is night and day in terms of quality on the XPS15 that I'm using, and I'm using the default setup, with the WAVES MaxxAudio app (required on this machine, otherwise, for example, plugging in a pair of analog headphones won't switch the audio output to those headphones). This app can be manually disabled, but otherwise inserts an APO that does noise reduction and echo cancellation, etc., but more importantly doubles ou triples the roundtrip latency.

Additionally, stacking echo cancellers and noise reduction is kind of wasteful.

I suppose we could make this a flag, to then make it controllable externally.

