### PR TITLE
Revert "Don't account for unresampled data when computing how much input is needed."

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -307,9 +307,11 @@ public:
   uint32_t input_needed_for_output(int32_t output_frame_count) const
   {
     assert(output_frame_count >= 0); // Check overflow
+    int32_t unresampled_frames_left = samples_to_frames(resampling_in_buffer.length());
     int32_t resampled_frames_left = samples_to_frames(resampling_out_buffer.length());
-    float input_frames_needed = 
-      output_frame_count * resampling_ratio - resampled_frames_left;
+    float input_frames_needed =
+      (output_frame_count - unresampled_frames_left) * resampling_ratio
+        - resampled_frames_left;
     if (input_frames_needed < 0) {
       return 0;
     }


### PR DESCRIPTION
This reverts commit d0127cdb668fe7908397ba4eaca2dc1e8600fc09.
From testing this caused the audio to get out of sync/delayed in Citra (testing based on citra-emu/citra#5577).
The 3ds' native sample rate is 32728 Hz, which is what Citra uses.

While the drift is small, it is very noticeable over anything but very short play sessions.
From some loose testing, in 10 minutes there's a couple seconds of added delay to e.g. a confirmation sound.

From testing, reverting this commit fixed the issue. I checked the original PR (#598), but I don't see an
explanation for this specific change.