### PR TITLE
Revert "Don't account for unresampled data when computing how much input is needed." and fix the real problem

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -138,17 +138,6 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   , user_ptr(ptr)
 {
   if (input_processor && output_processor) {
-    // Add some delay on the processor that has the lowest delay so that the
-    // streams are synchronized.
-    uint32_t in_latency = input_processor->latency();
-    uint32_t out_latency = output_processor->latency();
-    if (in_latency > out_latency) {
-      uint32_t latency_diff = in_latency - out_latency;
-      output_processor->add_latency(latency_diff);
-    } else if (in_latency < out_latency) {
-      uint32_t latency_diff = out_latency - in_latency;
-      input_processor->add_latency(latency_diff);
-    }
     fill_internal = &cubeb_resampler_speex::fill_internal_duplex;
   }  else if (input_processor) {
     fill_internal = &cubeb_resampler_speex::fill_internal_input;

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -307,9 +307,11 @@ public:
   uint32_t input_needed_for_output(int32_t output_frame_count) const
   {
     assert(output_frame_count >= 0); // Check overflow
+    int32_t unresampled_frames_left = samples_to_frames(resampling_in_buffer.length());
     int32_t resampled_frames_left = samples_to_frames(resampling_out_buffer.length());
-    float input_frames_needed = 
-      output_frame_count * resampling_ratio - resampled_frames_left;
+    float input_frames_needed =
+      (output_frame_count - unresampled_frames_left) * resampling_ratio
+        - resampled_frames_left;
     if (input_frames_needed < 0) {
       return 0;
     }

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -213,17 +213,6 @@ public:
     speex_resampler_destroy(speex_resampler);
   }
 
-  /** Sometimes, it is necessary to add latency on one way of a two-way
-   * resampler so that the stream are synchronized. This must be called only on
-   * a fresh resampler, otherwise, silent samples will be inserted in the
-   * stream.
-   * @param frames the number of frames of latency to add. */
-  void add_latency(size_t frames)
-  {
-    additional_latency += frames;
-    resampling_in_buffer.push_silence(frames_to_samples(frames));
-  }
-
   /* Fill the resampler with `input_frame_count` frames. */
   void input(T * input_buffer, size_t input_frame_count)
   {
@@ -413,13 +402,6 @@ public:
   {
     /* Fill the delay line with some silent frames to add latency. */
     delay_input_buffer.push_silence(frames * channels);
-  }
-  /* Add some latency to the delay line.
-   * @param frames the number of frames of latency to add. */
-  void add_latency(size_t frames)
-  {
-    length += frames;
-    delay_input_buffer.push_silence(frames_to_samples(frames));
   }
   /** Push some frames into the delay line.
    * @parameter buffer the frames to push.


### PR DESCRIPTION
cc @vitor-k

In #619, a patch is being rightfully reverted. I made this because it made cubeb stream with a user rate of 48000 and device rate of 44100 drain instantly, and it made sense at the time somehow, but I was fixing the symptoms and not the cause. This patch causes a drift, as reported in #619.

I'm adding another patch here on top of #619 to fix the initial problem while keeping the revert to unbreak the use-case discussed there. The issue in my particular use-case was that `input_needed_for_output` was asking the user callback for a number of audio frames that was too low, because it's subtracting the frames already buffered. But this is the beginning of the stream, so the number of already buffered frames should be zero, but is not, because we're adding latency frames at construction in the duplex case when rates are not identical, but this makes no sense because streams are in opposite directions.

With this removed, `input_needed_for_output` calls the user callback with a sensible number of frames requested, at the user rate, and resampling back to the device rate before handing the frames to the OS works.

I'm doing a separate PR because I believe I can't put a patch on top of #619, but this is based on the same branch.