### PR TITLE
Bring the AAudio backend to parity with the OpenSL backend

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -679,11 +679,11 @@ realize_stream(AAudioStreamBuilder * sb, const cubeb_stream_params * params,
   switch (params->format) {
     case CUBEB_SAMPLE_S16NE:
       fmt = AAUDIO_FORMAT_PCM_I16;
-      *frame_size = 2 * params->channels;
+      *frame_size = sizeof(int16_t) * params->channels;
       break;
     case CUBEB_SAMPLE_FLOAT32NE:
       fmt = AAUDIO_FORMAT_PCM_FLOAT;
-      *frame_size = 4 * params->channels;
+      *frame_size = sizeof(float) * params->channels;
       break;
     default:
       return CUBEB_ERROR_INVALID_FORMAT;

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -1380,6 +1380,24 @@ aaudio_get_min_latency(cubeb * ctx, cubeb_stream_params params, uint32_t * laten
   return CUBEB_OK;
 }
 
+int
+aaudio_get_preferred_sample_rate(cubeb * ctx, uint32_t * rate)
+{
+  AAudioStream* stream = init_dummy_stream();
+
+  if (!stream) {
+    return CUBEB_ERROR;
+  }
+
+  *rate = WRAP(AAudioStream_getSampleRate)(stream);
+
+  LOG("aaudio_get_preferred_sample_rate %uHz", *rate);
+
+  destroy_dummy_stream(stream);
+
+  return CUBEB_OK;
+}
+
 extern "C" int aaudio_init(cubeb ** context, char const * context_name);
 
 const static struct cubeb_ops aaudio_ops = {
@@ -1387,7 +1405,7 @@ const static struct cubeb_ops aaudio_ops = {
   /*.get_backend_id =*/ aaudio_get_backend_id,
   /*.get_max_channel_count =*/ aaudio_get_max_channel_count,
   /* .get_min_latency =*/ aaudio_get_min_latency,
-  /*.get_preferred_sample_rate =*/ NULL,
+  /*.get_preferred_sample_rate =*/ aaudio_get_preferred_sample_rate,
   /*.enumerate_devices =*/ NULL,
   /*.device_collection_destroy =*/ NULL,
   /*.destroy =*/ aaudio_destroy,

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -772,7 +772,6 @@ aaudio_stream_destroy(cubeb_stream * stm)
 static int
 aaudio_stream_init_impl(
     cubeb_stream * stm,
-    char const * stream_name,
     cubeb_devid input_device,
     cubeb_stream_params * input_stream_params,
     cubeb_devid output_device,
@@ -921,7 +920,7 @@ aaudio_stream_init_impl(
 static int
 aaudio_stream_init(cubeb * ctx,
     cubeb_stream ** stream,
-    char const * stream_name,
+    char const * /* stream_name */,
     cubeb_devid input_device,
     cubeb_stream_params * input_stream_params,
     cubeb_devid output_device,
@@ -933,8 +932,6 @@ aaudio_stream_init(cubeb * ctx,
 {
   assert(!input_device);
   assert(!output_device);
-
-  (void) stream_name;
 
   // atomically find a free stream.
   cubeb_stream * stm = NULL;
@@ -972,8 +969,7 @@ aaudio_stream_init(cubeb * ctx,
   stm->data_callback = data_callback;
   stm->state_callback = state_callback;
 
-  int err = aaudio_stream_init_impl(stm, stream_name, input_device,
-    input_stream_params, output_device, output_stream_params, latency_frames);
+  int err = aaudio_stream_init_impl(stm, input_device, input_stream_params, output_device, output_stream_params, latency_frames);
   if(err != CUBEB_OK) {
     // This is needed since aaudio_stream_destroy will lock the mutex again.
     // It's no problem that there is a gap in between as the stream isn't
@@ -1308,9 +1304,7 @@ const static struct cubeb_ops aaudio_ops = {
 
 
 extern "C" /*static*/ int
-aaudio_init(cubeb ** context, char const * context_name) {
-  (void) context_name;
-
+aaudio_init(cubeb ** context, char const * /* context_name */) {
   // load api
   void * libaaudio = NULL;
 #ifndef DISABLE_LIBAAUDIO_DLOPEN

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -420,9 +420,8 @@ static void state_thread(cubeb* ctx)
 }
 
 static char const *
-aaudio_get_backend_id(cubeb * ctx)
+aaudio_get_backend_id(cubeb * /* ctx */)
 {
-  (void)ctx;
   return "aaudio";
 }
 

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -20,6 +20,7 @@
 #include "cubeb-internal.h"
 #include "cubeb_resampler.h"
 #include "cubeb_log.h"
+#include "cubeb_android.h"
 
 #ifdef DISABLE_LIBAAUDIO_DLOPEN
 #define WRAP(x) x
@@ -821,13 +822,13 @@ aaudio_stream_init_impl(
   WRAP(AAudioStreamBuilder_setSharingMode)(sb, AAUDIO_SHARING_MODE_EXCLUSIVE);
 #endif
 
-#ifdef CUBEB_AAUDIO_LOW_LATENCY
-  LOG("AAudio setting low latency mode for stream");
-  WRAP(AAudioStreamBuilder_setPerformanceMode)(sb, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
-#elif defined(CUBEB_AAUDIO_POWER_SAVING)
-  LOG("AAudio setting power saving mode for stream");
-  WRAP(AAudioStreamBuilder_setPerformanceMode)(sb, AAUDIO_PERFORMANCE_MODE_POWER_SAVING);
-#endif
+  if (latency_frames <= POWERSAVE_LATENCY_FRAMES_THRESHOLD) {
+    LOG("AAudio setting low latency mode for stream");
+    WRAP(AAudioStreamBuilder_setPerformanceMode)(sb, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+  } else {
+    LOG("AAudio setting power saving mode for stream");
+    WRAP(AAudioStreamBuilder_setPerformanceMode)(sb, AAUDIO_PERFORMANCE_MODE_POWER_SAVING);
+  }
 
   unsigned frame_size;
 

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -86,7 +86,7 @@ LIBAAUDIO_API_VISIT(MAKE_TYPEDEF)
 #undef MAKE_TYPEDEF
 #endif
 
-#define MAX_STREAMS 16
+const uint8_t MAX_STREAMS = 16;
 
 using unique_lock = std::unique_lock<std::mutex>;
 using lock_guard = std::lock_guard<std::mutex>;

--- a/src/cubeb_android.h
+++ b/src/cubeb_android.h
@@ -1,0 +1,17 @@
+#ifndef CUBEB_ANDROID_H
+#define CUBEB_ANDROID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// If the latency requested is above this threshold, this stream is considered
+// intended for playback (vs. real-time). Tell Android it should favor saving
+// power over performance or latency.
+// This is around 100ms at 44100 or 48000
+const uint16_t POWERSAVE_LATENCY_FRAMES_THRESHOLD = 4000;
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif // CUBEB_ANDROID_H

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -27,6 +27,7 @@
 #include "cubeb-sles.h"
 #include "cubeb_array_queue.h"
 #include "android/cubeb-output-latency.h"
+#include "cubeb_android.h"
 
 #if defined(__ANDROID__)
 #ifdef LOG
@@ -65,11 +66,6 @@
 
 #define DEFAULT_SAMPLE_RATE 48000
 #define DEFAULT_NUM_OF_FRAMES 480
-// If the latency requested is above this threshold, this stream is considered
-// intended for playback (vs. real-time). Tell Android it should favor saving
-// power over performance or latency.
-// This is around 100ms at 44100 or 48000
-#define POWERSAVE_LATENCY_FRAMES_THRESHOLD 4000
 
 static struct cubeb_ops const opensl_ops;
 

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1698,7 +1698,7 @@ opensl_stream_get_latency(cubeb_stream * stm, uint32_t * latency)
   assert(latency);
 
   uint32_t stream_latency_frames =
-    stm->user_output_rate * (stm->output_latency_ms / 1000);
+    stm->user_output_rate * stm->output_latency_ms / 1000;
 
   return stream_latency_frames + cubeb_resampler_latency(stm->resampler);
 }


### PR DESCRIPTION
This is lots of little commits, implementing missing features that we have in the other Android backend, and other fixes.

With this patch set, the AAudio backend is at parity in terms of round-trip latency and resilience (if not better, depending on the device) compared to the OpenSL backend, on the same device. In a second phase, we'll be able to take advantage of AAudio-specific features or other recent Android audio things (such as unprocessed input streams, or using the hardware AEC).

In particular, it's interesting to note that we can trigger the `FAST_MIXER` fast paths in native code **without** having to do JNI madness or `dlopen`ing `libmedia.so`, but this requires opening a dummy stream.

The latency figures are fairly accurate, and I believe it's possible to make them very accurate.

This is green when pushing to try on the Firefox CI but I'll spend some more time with it before making it the default, after testing on mode devices.

cc @nyorain, if you want to have a look.