### PR TITLE
Add a `clang-format` file and format `src/cubeb_aaudio.cpp`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+IndentWidth: 2
+UseTab: Never
+ReflowComments: true
+PointerAlignment: Middle
+AlignAfterOpenBracket: Align
+AlwaysBreakAfterReturnType: TopLevel
+ColumnLimit: 80
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  AfterControlStatement: Never
+SpaceBeforeParens: ControlStatements
+BreakBeforeBinaryOperators: None


### PR DESCRIPTION
I kind of tried something based on what I think the style is, but it's probably not finished and @kinetiknz will know best.

This is based on #622 but doesn't contain functional changes, https://github.com/kinetiknz/cubeb/commit/77c4812f89117c01944490ebd3aece9137075da1 has all the formatting changes.