### PR TITLE
Fix typo in handsfree tag

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2087,7 +2087,9 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   if (rv == CUBEB_OK) {
     const char* HANDSFREE_TAG = "BTHHFENUM";
     size_t len = sizeof(HANDSFREE_TAG);
-    if (direction == eCapture && strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
+    if (direction == eCapture &&
+        strlen(device_info.group_id) >= len &&
+        strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
       // Rather high-latency to prevent constant under-runs in this particular
       // case of an input device using bluetooth handsfree.
       uint32_t default_period_frames = hns_to_frames(device_info.default_rate, default_period);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2085,7 +2085,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
   cubeb_device_info device_info;
   int rv = wasapi_create_device(stm->context, device_info, stm->device_enumerator.get(), device.get());
   if (rv == CUBEB_OK) {
-    const char* HANDSFREE_TAG = "BTHHFEENUM";
+    const char* HANDSFREE_TAG = "BTHHFENUM";
     size_t len = sizeof(HANDSFREE_TAG);
     if (direction == eCapture && strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
       // Rather high-latency to prevent constant under-runs in this particular


### PR DESCRIPTION
An embarassing mistake, causing [BMO#1674283](https://bugzilla.mozilla.org/show_bug.cgi?id=1674283). I'm putting in a length check as well. `device_info.group_id` is guaranteed to be present.